### PR TITLE
Integrate Amass subdomain scanner

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,6 +118,7 @@ The following scanners are currently available out of the box:
 - [SQLMap][sqlmap] for SQL Injection scans
 - [Arachni][arachni] web vulnerability scans
 - [WPScan][wpscan] black box [WordPress][wordpress] vulnerability scans
+- [Amass][amass] for subdomain scans
 
 Enabled by the architecture you can also add your own non-free or commercial tools, like
 - [Burp Suite][burp] web vulnerability scanner.
@@ -176,6 +177,7 @@ Contributions are welcome and extremely helpful 🙌
 [burp]:                 https://portswigger.net/burp
 [arachni]:              http://www.arachni-scanner.com/
 [wpscan]:               https://wpscan.org/
+[amass]:                https://github.com/owasp/amass
 [wordpress]:            https://wordpress.com/
 [consul]:               https://www.consul.io/
 [resty]:                https://openresty.org/en/

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -97,7 +97,7 @@ services:
       environment:
       - ENGINE_ADDRESS=http://engine:8080
 
-  scanner-infinfrastructurera-amass:
+  scanner-infrastructure-amass:
       image: securecodebox/amass:oss
       depends_on:
         - engine

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -107,6 +107,7 @@ services:
         container_group: scanner
       environment:
       - ENGINE_ADDRESS=http://engine:8080
+      - DEBUG=true
 
   persistence-elasticsearch:
     image: docker.elastic.co/elasticsearch/elasticsearch:6.2.3

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -97,6 +97,17 @@ services:
       environment:
       - ENGINE_ADDRESS=http://engine:8080
 
+  scanner-infinfrastructurera-amass:
+      image: securecodebox/amass:oss
+      depends_on:
+        - engine
+      networks:
+        - frontend
+      labels:
+        container_group: scanner
+      environment:
+      - ENGINE_ADDRESS=http://engine:8080
+
   persistence-elasticsearch:
     image: docker.elastic.co/elasticsearch/elasticsearch:6.2.3
     ports:


### PR DESCRIPTION
Integrates the Amass container to the docker-compose stack.

(Currently with very verbose debug level logging turned on, until all quirks are fixed)