### PR TITLE
Enabled integration test for the latest stable releases

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ node_js:
 services:
   - docker
 env:
-  #  - DEFAULT_TAG=latest
+  - DEFAULT_TAG=latest
   - DEFAULT_TAG=develop
 script:
   - cp test/.env.test .env


### PR DESCRIPTION
Integration tests will now test both:
 - **develop tag:** the current development state
 - **latest tag:** the latest versioned stable release

Before it was only able to test the current develop stat,e as the docker healthchecks were missing from the container in the tagged versions.