### PR TITLE
Adjust ssh target

### DIFF
--- a/test/.eslintrc
+++ b/test/.eslintrc
@@ -1,0 +1,5 @@
+{
+  "rules": {
+    "quotes": ["warn", "single"]
+  }
+}

--- a/test/ssh.test.js
+++ b/test/ssh.test.js
@@ -28,7 +28,6 @@ test(
 
     expect(findings).toContainEqual({
       category: 'SSH Service',
-      description: undefined,
       name: 'SSH Service Information',
       osi_layer: 'NETWORK',
       severity: 'INFORMATIONAL',

--- a/test/ssh.test.js
+++ b/test/ssh.test.js
@@ -1,15 +1,15 @@
 const { startSecurityTest, Time } = require('./sdk');
 
 test(
-  'finds a few low severity findigns for securecodebox.io',
+  'finds a few low severity findings for securecodebox.io',
   async () => {
     const securityTest = await startSecurityTest({
-      context: 'securecodebox.io tls',
+      context: 'www.iteratec.de ssh',
       metaData: {},
       name: 'ssh',
       target: {
-        name: 'securecodebox.io tls',
-        location: 'securecodebox.io',
+        name: 'www.iteratec.de ssh',
+        location: 'www.iteratec.de',
         attributes: {},
       },
     });
@@ -36,16 +36,8 @@ test(
 
     expect(findings).toContainEqual({
       category: 'SSH Policy Violation',
-      description: 'Deprecated / discouraged SSH key algorithms are used',
-      name: 'Insecure SSH Key Algorithms',
-      osi_layer: 'NETWORK',
-      severity: 'MEDIUM',
-    });
-
-    expect(findings).toContainEqual({
-      category: 'SSH Policy Violation',
-      description: 'Deprecated / discouraged SSH MAC algorithms are used',
-      name: 'Insecure SSH MAC Algorithms',
+      description: 'Discouraged SSH authentication methods are used',
+      name: 'Discouraged SSH authentication methods',
       osi_layer: 'NETWORK',
       severity: 'MEDIUM',
     });
@@ -53,8 +45,7 @@ test(
     expect(
       findings
         .filter(({ name }) => name !== 'SSH Service Information')
-        .filter(({ name }) => name !== 'Insecure SSH Key Algorithms')
-        .filter(({ name }) => name !== 'Insecure SSH MAC Algorithms')
+        .filter(({ name }) => name !== 'Discouraged SSH authentication methods')
     ).toEqual([]);
   },
   2 * Time.Minute

--- a/test/sslyze.test.js
+++ b/test/sslyze.test.js
@@ -53,16 +53,6 @@ test(
       severity: 'INFORMATIONAL',
     });
     expect(findings).toContainEqual({
-      name: 'TLSv1 supported',
-      category: 'TLSv1',
-      severity: 'LOW',
-    });
-    expect(findings).toContainEqual({
-      name: 'TLSv1.1 supported',
-      category: 'TLSv1.1',
-      severity: 'INFORMATIONAL',
-    });
-    expect(findings).toContainEqual({
       name: 'TLSv1.2 supported',
       category: 'TLSv1.2',
       severity: 'INFORMATIONAL',


### PR DESCRIPTION
Due to the changes we made to the securecodebox.io website we need to adjust the changes.

I've moved the ssh scans over to use www.iteratec.de instead of securecodebox.io as github pages doesn't have a ssh service open.