### PR TITLE
Comment on rfc1 from @J12934

### DIFF
--- a/rfcs/rfc1.md
+++ b/rfcs/rfc1.md
@@ -259,9 +259,8 @@ metadata:
     office: berlin
     vlan: wifi
 spec:
-  scanSpec:
-    name: "nmap"
-    parameters: ["-sV", "10.42.0.0/16"]
+  name: "nmap"
+  parameters: ["-sV", "10.42.0.0/16"]
 ```
 
 To enable cascading rules you need to specify a label selector to select the cascading rules you'd like
@@ -280,9 +279,8 @@ spec:
       # Uses all CascadingRules in the namespace which are labelled as "non-invasive" and a intensiveness level of "light"
       securecodebox.io/invasive: non-invasive
       securecodebox.io/intensive: light
-  scanSpec:
-    name: "nmap"
-    parameters: ["-sV", "10.42.0.0/16"]
+  name: "nmap"
+  parameters: ["-sV", "10.42.0.0/16"]
 ```
 
 To implicitly enable all cascading rules (not-recommended) a empty label selector can be used
@@ -299,9 +297,8 @@ spec:
   cascades:
     # Uses all `CascadingRules` in the namespace
     matchLabels: {}
-  scanSpec:
-    name: "nmap"
-    parameters: ["-sV", "10.42.0.0/16"]
+  name: "nmap"
+  parameters: ["-sV", "10.42.0.0/16"]
 ```
 
 [bcp-14]: https://tools.ietf.org/html/bcp14

--- a/rfcs/rfc1.md
+++ b/rfcs/rfc1.md
@@ -12,15 +12,15 @@ Authors:
 
 ## Status of this Memo
 
-This document is a draft for the syntax and grammar definition used to declare combined scans in the next generation *secureCodeBox*. This is not a stable reference. It is necessary to discuss this topic in the community. Distribution of this memo is unlimited.
+This document is a draft for the syntax and grammar definition used to declare combined scans in the next generation _secureCodeBox_. This is not a stable reference. It is necessary to discuss this topic in the community. Distribution of this memo is unlimited.
 
 ## Motivation
 
-We are using *secureCodeBox* (further referenced as *SCB*) not only to scan a single web application for potential vulnerabilities. We also use *SCB* to scan whole networks to find potential vulnerable hosts. This approach relies on a concept of so called *combined scans*: We do one scan and feed the result into a subsequent scan. For example we scan for all hosts in a network with the *nmap scanner*, afterwords we scan all found IP addresses with the *nmap scanner* for open ports, and finally we scan these open ports with dedicated scanners like *SSLye*, *Nikto* etc.
+We are using _secureCodeBox_ (further referenced as _SCB_) not only to scan a single web application for potential vulnerabilities. We also use _SCB_ to scan whole networks to find potential vulnerable hosts. This approach relies on a concept of so called _combined scans_: We do one scan and feed the result into a subsequent scan. For example we scan for all hosts in a network with the _nmap scanner_, afterwords we scan all found IP addresses with the _nmap scanner_ for open ports, and finally we scan these open ports with dedicated scanners like _SSLye_, _Nikto_ etc.
 
-We are now moving to a new architectural approach of the *secureCodeBox* based on [Kubernetes][k8s] and its [custom resources][k8s-custom-resources]. This aproach gives us the posibility to orchestrate scans as simple YAML files in Kubernetes. The whole descrition of this new architecture is out of scope of this document. It is described in the master thesis "Automatic Assessment of Applications Security Aspects running in Cloud Environments". This new architecture is further referenced as *SCBv2*.
+We are now moving to a new architectural approach of the _secureCodeBox_ based on [Kubernetes][k8s] and its [custom resources][k8s-custom-resources]. This aproach gives us the posibility to orchestrate scans as simple YAML files in Kubernetes. The whole descrition of this new architecture is out of scope of this document. It is described in the master thesis "Automatic Assessment of Applications Security Aspects running in Cloud Environments". This new architecture is further referenced as _SCBv2_.
 
-This ground breaking architectural change requires also a new approach to define *combined scans*. They were implemented as plain Java code so far. This was quite inflexible: We needed to implement *combined scanners* for all possible combination of scanner (*nmap-nikto*, *nmap-sslyze*, *nmap-ssl* etc.). Also it is not very intuitive because you need a deep understanding of the underlying BPMN engine.
+This ground breaking architectural change requires also a new approach to define _combined scans_. They were implemented as plain Java code so far. This was quite inflexible: We needed to implement _combined scanners_ for all possible combination of scanner (_nmap-nikto_, _nmap-sslyze_, _nmap-ssl_ etc.). Also it is not very intuitive because you need a deep understanding of the underlying BPMN engine.
 
 ## Requirements Notation
 
@@ -28,7 +28,7 @@ The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD", "S
 
 ## Introduction
 
-Since the archietcure of *SCBv2* is based on Kubernetes the main artifact to describe the SCB orchestration is [YAML][yaml-spec]. So it seems natural to find an approach to define the *combined scans* also in YAML.
+Since the archietcure of _SCBv2_ is based on Kubernetes the main artifact to describe the SCB orchestration is [YAML][yaml-spec]. So it seems natural to find an approach to define the _combined scans_ also in YAML.
 
 ## Problem Description
 
@@ -58,9 +58,15 @@ A cocnrete example:
                                                              +-------------+
 ```
 
+## Changelog
+
+- Switched attribute `on` in `CascadingRule` to `matches`. On is a reserved keyword in yaml which gets implicitly converted to `"false"` when used without quationmarks as a key in yaml.
+- Introduced a new layer under the `matches` attribute, to mark how these rules should be applied. Currently only supporting `anyOf`. This enabled to introduces other operators to add new behavior later, without introducing breaking changes.
+- Switches selection mechanism for `CascadingRules` on `Scan` Objects to use kubernetes label selectors([documentation](https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/#api),[api reference](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.18/#labelselector-v1-meta)). The previous version matched on the names, which especially when using denylists can lead to problems when new `CascadingRules` were introduced but not included in the Blacklist. In the worst cases this can lead to invasive scanners being used against services where this is not permitted. The new label selector lets you block out classes of scanners (like all invasive scanner).
+
 ### List of Interesting Services for Scans
 
-The [nmap service detection][nmap-detection] examines every foundopen port to detect what kind of service it is. For us interesting is this list:
+The [nmap service detection][nmap-detection] examines every found open port to detect what kind of service it is. For us interesting is this list:
 
 - ssh
 - ldap
@@ -83,21 +89,33 @@ apiVersion: "cascading.experimental.securecodebox.io/v1"
 kind: CascadingRule
 metadata:
   name: "tls-scans"
+  labels:
+    # Described how "invasive" the scan is.
+    # Possible values: "invasive" or "non-invasive"
+    # CascadingRules are considered "invasive" when the Scan they start actively sends out packages with attack payloads.
+    securecodebox.io/invasive: non-invasive
+    # Described the intensiveness level on a scanning and computational resource level.
+    # Possible values: "ligh", "medium", "intense"
+    # CascadingRules are considered more "intensive" when the Scan they start consumes lots of computational resources like RAM, CPU, or Network
+    securecodebox.io/intensive: light
 spec:
-  on:
-    # AND logic
-    # define an explicit "port" as finding and a given port number
-    - category: "Open Port"
-      attributes:
-        port: 443
-        service: "https"
-    # define an "port service" finding (any port)
-    - category: "Open Port"
-      attributes:
-        service: "https"
+  matches:
+    # CascadingRule triggers if a finding matches at least one of the anyOf matchers
+    # With the first version of this implementation only anyOf would be supported.
+    # If this turns out to be lacking and other operators (like `allOf` can be introduced without breaking changes)
+    anyOf:
+      # define an explicit "port" as finding and a given port number
+      - category: "Open Port"
+        attributes:
+          port: 443
+          service: "https"
+      # define an "port service" finding (any port)
+      - category: "Open Port"
+        attributes:
+          service: "https"
   scanSpec:
     name: "sslyze"
-    parameters: ["--regular", "${attributes.hostname}"]
+    parameters: ["--regular", "{{attributes.hostname}}"]
 ```
 
 ### ZAP Scan Rule
@@ -107,17 +125,21 @@ apiVersion: "cascading.experimental.securecodebox.io/v1"
 kind: CascadingRule
 metadata:
   name: "zap-scans"
+  labels:
+    securecodebox.io/invasive: non-invasive
+    securecodebox.io/intensive: medium
 spec:
-  on:
-    - category: "Open Port"
-      attributes:
-        service: "http"
-    - category: "Open Port"
-      attributes:
-        service: "https"
+  matches:
+    anyOf:
+      - category: "Open Port"
+        attributes:
+          service: "http"
+      - category: "Open Port"
+        attributes:
+          service: "https"
   scanSpec:
     name: "zap-baseline"
-    parameters: ["-t", "${location}"]
+    parameters: ["-t", "{{location}}"]
 ```
 
 ### Ncrack (for Postgres)
@@ -127,15 +149,19 @@ apiVersion: "cascading.experimental.securecodebox.io/v1"
 kind: CascadingRule
 metadata:
   name: "postgres-credential-check"
+  labels:
+    securecodebox.io/invasive: invasive
+    securecodebox.io/intensive: high
 spec:
-  on:
-    # define an "port service" finding (any port)
-    - category: "Open Port"
-      attributes:
-        service: "postgresql"
+  matches:
+    anyOf:
+      # define an "port service" finding (any port)
+      - category: "Open Port"
+        attributes:
+          service: "postgresql"
   scanSpec:
     name: "ncrack"
-    parameters: ["postgresql://${attributes.hostname}:${attributes.port}"]
+    parameters: ["postgresql://{{attributes.hostname}}:{{attributes.port}}"]
 ```
 
 ### Nikto
@@ -149,18 +175,22 @@ apiVersion: "cascading.experimental.securecodebox.io/v1"
 kind: CascadingRule
 metadata:
   name: "host-scan-http"
+  labels:
+    securecodebox.io/invasive: invasive
+    securecodebox.io/intensive: medium
 spec:
-  on:
-    # define an "port service" finding (any port)
-    - category: "Open Port"
-      attributes:
-        service: "http"
-    - category: "Open Port"
-      attributes:
-        service: "https"
+  matches:
+    anyOf:
+      # define an "port service" finding (any port)
+      - category: "Open Port"
+        attributes:
+          service: "http"
+      - category: "Open Port"
+        attributes:
+          service: "https"
   scanSpec:
     name: "nikto"
-    parameters: ["-h", "${attributes.service:-http}://${attributes.hostname}"]
+    parameters: ["-h", "{{attributes.service:}}://{{attributes.hostname}}"]
 ```
 
 #### Alternative 2
@@ -172,70 +202,112 @@ apiVersion: "cascading.experimental.securecodebox.io/v1"
 kind: CascadingRule
 metadata:
   name: "host-scans-http"
+  labels:
+    securecodebox.io/invasive: invasive
+    securecodebox.io/intensive: medium
 spec:
-  on:
-    - category: "Open Port"
-      attributes:
-        service: "http"
+  matches:
+    anyOf:
+      - category: "Open Port"
+        attributes:
+          service: "http"
   scanSpec:
     name: "nitko"
-    parameters: ["-h", "http://${attributes.hostname}"]
+    parameters: ["-h", "http://{{attributes.hostname}}"]
 ---
 apiVersion: "cascading.experimental.securecodebox.io/v1"
 kind: CascadingRule
 metadata:
   name: "host-scans-https"
+  labels:
+    securecodebox.io/invasive: invasive
+    securecodebox.io/intensive: medium
 spec:
-  on:
-    - category: "Open Port"
-      attributes:
-        service:
-          equals: "host-scan-https"
-    - category: "Open Port"
-      attributes:
-        service:
-          regex: "^host-.*-https"
-    - category: "Open Port"
-      attributes: # Alternative RegEx
-        service: "/^host-.*-https/"
-    - category: "Open Port"
-      attributes:
-        service:
-          contains: "scan"
+  matches:
+    anyOf:
+      - category: "Open Port"
+        attributes:
+          service:
+            equals: "host-scan-https"
+      - category: "Open Port"
+        attributes:
+          service:
+            regex: "^host-.*-https"
+      - category: "Open Port"
+        attributes: # Alternative RegEx
+          service: "/^host-.*-https/"
+      - category: "Open Port"
+        attributes:
+          service:
+            contains: "scan"
   scanSpec:
     name: "nitko"
     parameters: ["-h", "https://${attributes.hostname}"]
 ```
 
-## a complete IP Range Scan Example
+## Using Cascading Rules
+
+By default no cascading Rules will be used.
+
+```yaml
+# Nmap Scan without cascading rules
+apiVersion: "execution.experimental.securecodebox.io/v1"
+kind: Scan
+metadata:
+  name: "portscan-berlin-wifi"
+  label:
+    office: berlin
+    vlan: wifi
+spec:
+  scanSpec:
+    name: "nmap"
+    parameters: ["-sV", "10.42.0.0/16"]
+```
+
+To enable cascading rules you need to specify a label selector to select the cascading rules you'd like
 
 ```yaml
 apiVersion: "execution.experimental.securecodebox.io/v1"
 kind: Scan
 metadata:
-  name: "portscan-hamburg-full"
+  name: "portscan-berlin-wifi"
   label:
-    office: hamburg
-    vlan: complete
+    office: berlin
+    vlan: wifi
 spec:
   cascades:
-    enabled: true
-    allowedCascades:
-      - tls-scans # SSL Tests
-      - host-scans # Nikto alternative 1
-      - host-scans-https # Nikto alternative 2.1
-      - host-scans-http # Nikto alternative 2.2
-    disallowedCascades:
-      - zap-scans # ZAP HTTP WebApp
+    matchLabels:
+      # Uses all CascadingRules in the namespace which are labelled as "non-invasive" and a intensiveness level of "light"
+      securecodebox.io/invasive: non-invasive
+      securecodebox.io/intensive: light
   scanSpec:
     name: "nmap"
-    parameters: ["-sV", "192.168.188.0/24"]
+    parameters: ["-sV", "10.42.0.0/16"]
 ```
 
-[bcp-14]:               https://tools.ietf.org/html/bcp14
-[k8s]:                  https://kubernetes.io/
+To implicitly enable all cascading rules (not-recommended) a empty label selector can be used
+
+```yaml
+apiVersion: "execution.experimental.securecodebox.io/v1"
+kind: Scan
+metadata:
+  name: "portscan-berlin-wifi"
+  label:
+    office: berlin
+    vlan: wifi
+spec:
+  cascades:
+    # Uses all `CascadingRules` in the namespace
+    matchLabels: {}
+  scanSpec:
+    name: "nmap"
+    parameters: ["-sV", "10.42.0.0/16"]
+```
+
+[bcp-14]: https://tools.ietf.org/html/bcp14
+[k8s]: https://kubernetes.io/
 [k8s-custom-resources]: https://kubernetes.io/docs/concepts/extend-kubernetes/api-extension/custom-resources/
-[nmap-detection]:       https://nmap.org/book/man-version-detection.html
-[rfc-2119]:             https://tools.ietf.org/html/rfc2119
-[rfc-8174]:             https://tools.ietf.org/html/rfc8174
-[yaml-spec]:            https://github.com/yaml/yaml-spec
+[nmap-detection]: https://nmap.org/book/man-version-detection.html
+[rfc-2119]: https://tools.ietf.org/html/rfc2119
+[rfc-8174]: https://tools.ietf.org/html/rfc8174
+[yaml-spec]: https://github.com/yaml/yaml-spec


### PR DESCRIPTION
- Switched attribute `on` in `CascadingRule` to `matches`. On is a reserved keyword in yaml which gets implicitly converted to `"false"` when used without quationmarks as a key in yaml.
- Introduced a new layer under the `matches` attribute, to mark how these rules should be applied. Currently only supporting `anyOf`. This enabled to introduces other operators to add new behavior later, without introducing breaking changes.
- Switches selection mechanism for `CascadingRules` on `Scan` Objects to use kubernetes label selectors([documentation](https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/#api),[api reference](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.18/#labelselector-v1-meta)). The previous version matched on the names, which especially when using denylists can lead to problems when new `CascadingRules` were introduced but not included in the Blacklist. In the worst cases this can lead to invasive scanners being used against services where this is not permitted. The new label selector lets you block out classes of scanners (like all invasive scanner).