### PR TITLE
Remove path from frontmatter and example README

### DIFF
--- a/hooks/declarative-subsequent-scans/README.md
+++ b/hooks/declarative-subsequent-scans/README.md
@@ -1,6 +1,5 @@
 ---
 title: "Cascading Scans"
-path: "hooks/declarative-subsequent-scans"
 category: "hook"
 type: "processing"
 state: "released"

--- a/hooks/declarative-subsequent-scans/README.md.gotmpl
+++ b/hooks/declarative-subsequent-scans/README.md.gotmpl
@@ -1,6 +1,5 @@
 ---
 title: "Cascading Scans"
-path: "hooks/declarative-subsequent-scans"
 category: "hook"
 type: "processing"
 state: "released"

--- a/hooks/generic-webhook/README.md
+++ b/hooks/generic-webhook/README.md
@@ -1,6 +1,5 @@
 ---
 title: "Generic WebHook"
-path: "hooks/generic-webhook"
 category: "hook"
 type: "integration"
 state: "released"

--- a/hooks/generic-webhook/README.md.gotmpl
+++ b/hooks/generic-webhook/README.md.gotmpl
@@ -1,6 +1,5 @@
 ---
 title: "Generic WebHook"
-path: "hooks/generic-webhook"
 category: "hook"
 type: "integration"
 state: "released"

--- a/hooks/persistence-defectdojo/README.md
+++ b/hooks/persistence-defectdojo/README.md
@@ -1,6 +1,5 @@
 ---
 title: "DefectDojo"
-path: "hooks/persistence-defectdojo"
 category: "hook"
 type: "persistenceProvider"
 state: "developing"

--- a/hooks/persistence-elastic/README.md
+++ b/hooks/persistence-elastic/README.md
@@ -1,6 +1,5 @@
 ---
 title: "Elasticsearch"
-path: "hooks/persistence-elastic"
 category: "hook"
 type: "persistenceProvider"
 state: "released"

--- a/hooks/persistence-elastic/README.md.gotmpl
+++ b/hooks/persistence-elastic/README.md.gotmpl
@@ -1,6 +1,5 @@
 ---
 title: "Elasticsearch"
-path: "hooks/persistence-elastic"
 category: "hook"
 type: "persistenceProvider"
 state: "released"

--- a/hooks/persistence-static-report/README.md
+++ b/hooks/persistence-static-report/README.md
@@ -1,6 +1,5 @@
 ---
 title: "Static Report"
-path: "hooks/persistence-staticreport"
 category: "hook"
 type: "persistenceProvider"
 state: "developing"

--- a/hooks/slack-webhook/README.md
+++ b/hooks/slack-webhook/README.md
@@ -1,6 +1,5 @@
 ---
 title: "Slack WebHook"
-path: "hooks/slack-webhook"
 category: "hook"
 type: "integration"
 state: "roadmap"

--- a/hooks/teams-webhook/README.md
+++ b/hooks/teams-webhook/README.md
@@ -1,6 +1,5 @@
 ---
 title: "MS Teams WebHook"
-path: "hooks/teams-webhook"
 category: "hook"
 type: "integration"
 state: "roadmap"

--- a/hooks/update-field/README.md
+++ b/hooks/update-field/README.md
@@ -1,6 +1,5 @@
 ---
 title: "Update Field"
-path: "hooks/update-field"
 category: "hook"
 type: "dataProcessing"
 state: "released"

--- a/hooks/update-field/README.md.gotmpl
+++ b/hooks/update-field/README.md.gotmpl
@@ -1,6 +1,5 @@
 ---
 title: "Update Field"
-path: "hooks/update-field"
 category: "hook"
 type: "dataProcessing"
 state: "released"

--- a/scanners/amass/README.md
+++ b/scanners/amass/README.md
@@ -1,6 +1,5 @@
 ---
 title: "Amass"
-path: "scanners/amass"
 category: "scanner"
 type: "Network"
 state: "released"

--- a/scanners/amass/README.md.gotmpl
+++ b/scanners/amass/README.md.gotmpl
@@ -1,6 +1,5 @@
 ---
 title: "Amass"
-path: "scanners/amass"
 category: "scanner"
 type: "Network"
 state: "released"

--- a/scanners/amass/examples/example.com/README.md
+++ b/scanners/amass/examples/example.com/README.md
@@ -1,7 +1,0 @@
----
-title: "example.com"
----
-
-> ✍ **Page under construction.**
- 
-the frontmatter requires the name of the scantarget as 'title'

--- a/scanners/gitleaks/README.md
+++ b/scanners/gitleaks/README.md
@@ -1,6 +1,5 @@
 ---
 title: "Gitleaks"
-path: "scanners/gitleaks"
 category: "scanner"
 type: "Repository"
 state: "in progress"

--- a/scanners/gitleaks/README.md.gotmpl
+++ b/scanners/gitleaks/README.md.gotmpl
@@ -1,6 +1,5 @@
 ---
 title: "Gitleaks"
-path: "scanners/gitleaks"
 category: "scanner"
 type: "Repository"
 state: "in progress"

--- a/scanners/kube-hunter/README.md
+++ b/scanners/kube-hunter/README.md
@@ -1,6 +1,5 @@
 ---
 title: "kube-hunter"
-path: "scanners/kube-hunter"
 category: "scanner"
 type: "Kubernetes"
 state: "released"

--- a/scanners/kube-hunter/README.md.gotmpl
+++ b/scanners/kube-hunter/README.md.gotmpl
@@ -1,6 +1,5 @@
 ---
 title: "kube-hunter"
-path: "scanners/kube-hunter"
 category: "scanner"
 type: "Kubernetes"
 state: "released"

--- a/scanners/kubeaudit/README.md
+++ b/scanners/kubeaudit/README.md
@@ -1,6 +1,5 @@
 ---
 title: "kubeaudit"
-path: "scanners/kubeaudit"
 category: "scanner"
 type: "Kubernetes"
 state: "roadmap"

--- a/scanners/ncrack/README.md
+++ b/scanners/ncrack/README.md
@@ -1,6 +1,5 @@
 ---
 title: "Ncrack"
-path: "scanners/Ncrack"
 category: "scanner"
 type: "Authentication"
 state: "developing"

--- a/scanners/ncrack/README.md.gotmpl
+++ b/scanners/ncrack/README.md.gotmpl
@@ -1,6 +1,5 @@
 ---
 title: "Ncrack"
-path: "scanners/Ncrack"
 category: "scanner"
 type: "Authentication"
 state: "developing"

--- a/scanners/nikto/README.md
+++ b/scanners/nikto/README.md
@@ -1,6 +1,5 @@
 ---
 title: "Nikto"
-path: "scanners/nikto"
 category: "scanner"
 type: "Webserver"
 state: "released"

--- a/scanners/nikto/README.md.gotmpl
+++ b/scanners/nikto/README.md.gotmpl
@@ -1,6 +1,5 @@
 ---
 title: "Nikto"
-path: "scanners/nikto"
 category: "scanner"
 type: "Webserver"
 state: "released"

--- a/scanners/nmap/README.md
+++ b/scanners/nmap/README.md
@@ -1,6 +1,5 @@
 ---
 title: "Nmap"
-path: "scanners/nmap"
 category: "scanner"
 type: "Network"
 state: "released"

--- a/scanners/nmap/README.md.gotmpl
+++ b/scanners/nmap/README.md.gotmpl
@@ -1,6 +1,5 @@
 ---
 title: "Nmap"
-path: "scanners/nmap"
 category: "scanner"
 type: "Network"
 state: "released"

--- a/scanners/ssh_scan/README.md
+++ b/scanners/ssh_scan/README.md
@@ -1,6 +1,5 @@
 ---
 title: "SSH"
-path: "scanners/ssh_scan"
 category: "scanner"
 type: "SSH"
 state: "released"

--- a/scanners/ssh_scan/README.md.gotmpl
+++ b/scanners/ssh_scan/README.md.gotmpl
@@ -1,6 +1,5 @@
 ---
 title: "SSH"
-path: "scanners/ssh_scan"
 category: "scanner"
 type: "SSH"
 state: "released"

--- a/scanners/sslyze/README.md
+++ b/scanners/sslyze/README.md
@@ -1,6 +1,5 @@
 ---
 title: "SSLyze"
-path: "scanners/sslyze"
 category: "scanner"
 type: "SSL"
 state: "released"

--- a/scanners/sslyze/README.md.gotmpl
+++ b/scanners/sslyze/README.md.gotmpl
@@ -1,6 +1,5 @@
 ---
 title: "SSLyze"
-path: "scanners/sslyze"
 category: "scanner"
 type: "SSL"
 state: "released"

--- a/scanners/trivy/README.md
+++ b/scanners/trivy/README.md
@@ -1,6 +1,5 @@
 ---
 title: "Trivy"
-path: "scanners/trivy"
 category: "scanner"
 type: "Container"
 state: "released"

--- a/scanners/trivy/README.md.gotmpl
+++ b/scanners/trivy/README.md.gotmpl
@@ -1,6 +1,5 @@
 ---
 title: "Trivy"
-path: "scanners/trivy"
 category: "scanner"
 type: "Container"
 state: "released"

--- a/scanners/zap/README.md
+++ b/scanners/zap/README.md
@@ -1,6 +1,5 @@
 ---
 title: "ZAP"
-path: "scanners/zap"
 category: "scanner"
 type: "WebApplication"
 state: "released"

--- a/scanners/zap/README.md.gotmpl
+++ b/scanners/zap/README.md.gotmpl
@@ -1,6 +1,5 @@
 ---
 title: "ZAP"
-path: "scanners/zap"
 category: "scanner"
 type: "WebApplication"
 state: "released"


### PR DESCRIPTION
The path property in the frontmatter becomes obsolete with the switch
to our new documentation framework. Furthermore, it could be confusing
leaving such a fragment.

Removing the example readme since it was only used for testing purposes.

**Only merge when the old securecodebox.io (GatsbyJS based) website is shut down!** 

Recreation of https://github.com/secureCodeBox/secureCodeBox-v2/pull/120