### PR TITLE
Make Scanner Images Changeable via Helm Values

### DIFF
--- a/scanners/amass/Chart.yaml
+++ b/scanners/amass/Chart.yaml
@@ -5,7 +5,7 @@ description: A Helm chart for the Amass security scanner that integrates with th
 type: application
 # version - gets automatically set to the secureCodeBox release version when the helm charts gets published
 version: latest
-appVersion: 3.10.4
+appVersion: "v3.10.4"
 kubeVersion: ">=v1.11.0"
 
 keywords:

--- a/scanners/amass/README.md
+++ b/scanners/amass/README.md
@@ -40,6 +40,8 @@ Special command line options:
 
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
+| image.repository | string | `"caffix/amass"` | Container Image to run the scan |
+| image.tag | string | `nil` | defaults to the charts appVersion |
 | parserImage.repository | string | `"docker.io/securecodebox/parser-amass"` | Parser image repository |
 | parserImage.tag | string | defaults to the charts version | Parser image tag |
 | scannerJob.env | list | `[]` | Optional environment variables mapped into each scanJob (see: https://kubernetes.io/docs/tasks/inject-data-application/define-environment-variable-container/) |

--- a/scanners/amass/helm2.Chart.yaml
+++ b/scanners/amass/helm2.Chart.yaml
@@ -5,7 +5,7 @@ description: A Helm chart for the Amass security scanner that integrates with th
 type: application
 # version - gets automatically set to the secureCodeBox release version when the helm charts gets published
 version: latest
-appVersion: 3.10.4
+appVersion: "v3.10.4"
 kubeVersion: ">=v1.11.0"
 
 keywords:

--- a/scanners/amass/templates/amass-scan-type.yaml
+++ b/scanners/amass/templates/amass-scan-type.yaml
@@ -18,7 +18,7 @@ spec:
           restartPolicy: OnFailure
           containers:
             - name: amass
-              image: "caffix/amass:v{{ .Chart.AppVersion }}"
+              image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
               command:
                 - "amass"
                 - "enum"

--- a/scanners/amass/values.yaml
+++ b/scanners/amass/values.yaml
@@ -1,11 +1,11 @@
 image:
   # image.repository -- Container Image to run the scan
   repository: caffix/amass
-  # image.tag - defaults to the charts appVersion
+  # image.tag -- defaults to the charts appVersion
   tag: null
 
 parserImage:
-  # parserImage.tag - defaults to the charts version
+  # parserImage.tag -- defaults to the charts version
   # parserImage.repository -- Parser image repository
   repository: docker.io/securecodebox/parser-amass
   # parserImage.tag -- Parser image tag

--- a/scanners/amass/values.yaml
+++ b/scanners/amass/values.yaml
@@ -5,7 +5,6 @@ image:
   tag: null
 
 parserImage:
-  # parserImage.tag -- defaults to the charts version
   # parserImage.repository -- Parser image repository
   repository: docker.io/securecodebox/parser-amass
   # parserImage.tag -- Parser image tag

--- a/scanners/amass/values.yaml
+++ b/scanners/amass/values.yaml
@@ -1,3 +1,9 @@
+image:
+  # image.repository -- Container Image to run the scan
+  repository: caffix/amass
+  # image.tag - defaults to the charts appVersion
+  tag: null
+
 parserImage:
   # parserImage.tag - defaults to the charts version
   # parserImage.repository -- Parser image repository

--- a/scanners/kube-hunter/Chart.yaml
+++ b/scanners/kube-hunter/Chart.yaml
@@ -5,7 +5,7 @@ description: A Helm chart for the kube-hunter security scanner that integrates w
 type: application
 # version - gets automatically set to the secureCodeBox release version when the helm charts gets published
 version: latest
-appVersion: v0.3.0
+appVersion: "0.3.0"
 kubeVersion: ">=v1.11.0"
 
 keywords:

--- a/scanners/kube-hunter/README.md
+++ b/scanners/kube-hunter/README.md
@@ -34,8 +34,8 @@ The following security scan configuration example are based on the [kube-hunter 
 
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
-| image.repository | string | `"docker.io/securecodebox/scanner-kube-hunter"` |  |
-| image.tag | string | `nil` |  |
+| image.repository | string | `"docker.io/securecodebox/scanner-kube-hunter"` | Container Image to run the scan |
+| image.tag | string | `nil` | defaults to the charts version |
 | parserImage.repository | string | `"docker.io/securecodebox/parser-kube-hunter"` | Parser image repository |
 | parserImage.tag | string | defaults to the charts version | Parser image tag |
 | scannerJob.env | list | `[]` | Optional environment variables mapped into each scanJob (see: https://kubernetes.io/docs/tasks/inject-data-application/define-environment-variable-container/) |

--- a/scanners/kube-hunter/helm2.Chart.yaml
+++ b/scanners/kube-hunter/helm2.Chart.yaml
@@ -5,7 +5,7 @@ description: A Helm chart for the kube-hunter security scanner that integrates w
 type: application
 # version - gets automatically set to the secureCodeBox release version when the helm charts gets published
 version: latest
-appVersion: v0.3.0
+appVersion: "0.3.0"
 kubeVersion: ">=v1.11.0"
 
 keywords:

--- a/scanners/kube-hunter/values.yaml
+++ b/scanners/kube-hunter/values.yaml
@@ -1,14 +1,15 @@
+image:
+  # image.repository -- Container Image to run the scan
+  repository: docker.io/securecodebox/scanner-kube-hunter
+  # image.tag -- defaults to the charts version
+  tag: null
+
 parserImage:
   # parserImage.tag - defaults to the charts version
   # parserImage.repository -- Parser image repository
   repository: docker.io/securecodebox/parser-kube-hunter
   # parserImage.tag -- Parser image tag
   # @default -- defaults to the charts version
-  tag: null
-
-image:
-  repository: docker.io/securecodebox/scanner-kube-hunter
-  # image.tag - defaults to the charts version
   tag: null
 
 scannerJob:

--- a/scanners/kube-hunter/values.yaml
+++ b/scanners/kube-hunter/values.yaml
@@ -5,7 +5,7 @@ image:
   tag: null
 
 parserImage:
-  # parserImage.tag - defaults to the charts version
+  # parserImage.tag -- defaults to the charts version
   # parserImage.repository -- Parser image repository
   repository: docker.io/securecodebox/parser-kube-hunter
   # parserImage.tag -- Parser image tag

--- a/scanners/kube-hunter/values.yaml
+++ b/scanners/kube-hunter/values.yaml
@@ -5,7 +5,6 @@ image:
   tag: null
 
 parserImage:
-  # parserImage.tag -- defaults to the charts version
   # parserImage.repository -- Parser image repository
   repository: docker.io/securecodebox/parser-kube-hunter
   # parserImage.tag -- Parser image tag

--- a/scanners/ncrack/README.md
+++ b/scanners/ncrack/README.md
@@ -142,8 +142,8 @@ SEE THE MAN PAGE (http://nmap.org/ncrack/man.html) FOR MORE OPTIONS AND EXAMPLES
 
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
-| image.repository | string | `"docker.io/securecodebox/scanner-ncrack"` |  |
-| image.tag | string | `nil` |  |
+| image.repository | string | `"docker.io/securecodebox/scanner-ncrack"` | Container Image to run the scan |
+| image.tag | string | `nil` | defaults to the charts appVersion |
 | parserImage.repository | string | `"docker.io/securecodebox/parser-ncrack"` | Parser image repository |
 | parserImage.tag | string | defaults to the charts version | Parser image tag |
 | scannerJob.env | list | `[]` | Optional environment variables mapped into each scanJob (see: https://kubernetes.io/docs/tasks/inject-data-application/define-environment-variable-container/) |

--- a/scanners/ncrack/values.yaml
+++ b/scanners/ncrack/values.yaml
@@ -5,7 +5,6 @@ image:
   tag: null
 
 parserImage:
-  # parserImage.tag -- defaults to the charts version
   # parserImage.repository -- Parser image repository
   repository: docker.io/securecodebox/parser-ncrack
   # parserImage.tag -- Parser image tag

--- a/scanners/ncrack/values.yaml
+++ b/scanners/ncrack/values.yaml
@@ -1,14 +1,15 @@
+image:
+  # image.repository -- Container Image to run the scan
+  repository: docker.io/securecodebox/scanner-ncrack
+  # image.tag - defaults to the charts appVersion
+  tag: null
+
 parserImage:
   # parserImage.tag - defaults to the charts version
   # parserImage.repository -- Parser image repository
   repository: docker.io/securecodebox/parser-ncrack
   # parserImage.tag -- Parser image tag
   # @default -- defaults to the charts version
-  tag: null
-
-image:
-  repository: docker.io/securecodebox/scanner-ncrack
-  # image.tag - defaults to the charts version
   tag: null
 
 scannerJob:

--- a/scanners/ncrack/values.yaml
+++ b/scanners/ncrack/values.yaml
@@ -1,11 +1,11 @@
 image:
   # image.repository -- Container Image to run the scan
   repository: docker.io/securecodebox/scanner-ncrack
-  # image.tag - defaults to the charts appVersion
+  # image.tag -- defaults to the charts appVersion
   tag: null
 
 parserImage:
-  # parserImage.tag - defaults to the charts version
+  # parserImage.tag -- defaults to the charts version
   # parserImage.repository -- Parser image repository
   repository: docker.io/securecodebox/parser-ncrack
   # parserImage.tag -- Parser image tag

--- a/scanners/nikto/README.md
+++ b/scanners/nikto/README.md
@@ -53,6 +53,8 @@ Nikto also has a comprehensive list of [command line options documented](https:/
 
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
+| image.repository | string | `"securecodebox/scannner-nikto"` | Container Image to run the scan |
+| image.tag | string | `nil` | defaults to the charts appVersion |
 | parserImage.repository | string | `"docker.io/securecodebox/parser-nikto"` | Parser image repository |
 | parserImage.tag | string | defaults to the charts version | Parser image tag |
 | scannerJob.env | list | `[]` | Optional environment variables mapped into each scanJob (see: https://kubernetes.io/docs/tasks/inject-data-application/define-environment-variable-container/) |

--- a/scanners/nikto/templates/nikto-scan-type.yaml
+++ b/scanners/nikto/templates/nikto-scan-type.yaml
@@ -16,7 +16,7 @@ spec:
           restartPolicy: Never
           containers:
             - name: nikto
-              image: securecodebox/scannner-nikto:latest
+              image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
               command:
                 # Nikto Entrypoint Script to avoid problems nikto exiting with a non zero exit code
                 # This would cause the kubernetes job to fail no matter what

--- a/scanners/nikto/values.yaml
+++ b/scanners/nikto/values.yaml
@@ -1,11 +1,11 @@
 image:
   # image.repository -- Container Image to run the scan
   repository: securecodebox/scannner-nikto
-  # image.tag - defaults to the charts appVersion
+  # image.tag -- defaults to the charts appVersion
   tag: null
 
 parserImage:
-  # parserImage.tag - defaults to the charts version
+  # parserImage.tag -- defaults to the charts version
   # parserImage.repository -- Parser image repository
   repository: docker.io/securecodebox/parser-nikto
   # parserImage.tag -- Parser image tag

--- a/scanners/nikto/values.yaml
+++ b/scanners/nikto/values.yaml
@@ -1,3 +1,9 @@
+image:
+  # image.repository -- Container Image to run the scan
+  repository: securecodebox/scannner-nikto
+  # image.tag - defaults to the charts appVersion
+  tag: null
+
 parserImage:
   # parserImage.tag - defaults to the charts version
   # parserImage.repository -- Parser image repository

--- a/scanners/nikto/values.yaml
+++ b/scanners/nikto/values.yaml
@@ -5,7 +5,6 @@ image:
   tag: null
 
 parserImage:
-  # parserImage.tag -- defaults to the charts version
   # parserImage.repository -- Parser image repository
   repository: docker.io/securecodebox/parser-nikto
   # parserImage.tag -- Parser image tag

--- a/scanners/nmap/README.md
+++ b/scanners/nmap/README.md
@@ -88,10 +88,10 @@ spec:
 
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
-| image.repository | string | `"docker.io/securecodebox/scanner-nmap"` |  |
-| image.tag | string | `nil` |  |
+| image.repository | string | `"docker.io/securecodebox/scanner-nmap"` | Container Image to run the scan |
+| image.tag | string | `nil` | defaults to the charts version |
 | parserImage.repository | string | `"docker.io/securecodebox/parser-nmap"` | Parser image repository |
-| parserImage.tag | string | defaults to the charts version | Parser image tag |
+| parserImage.tag | string | defaults to the charts appVersion | Parser image tag |
 | scannerJob.env | list | `[]` | Optional environment variables mapped into each scanJob (see: https://kubernetes.io/docs/tasks/inject-data-application/define-environment-variable-container/) |
 | scannerJob.extraContainers | list | `[]` | Optional additional Containers started with each scanJob (see: https://kubernetes.io/docs/concepts/workloads/pods/init-containers/) |
 | scannerJob.extraVolumeMounts | list | `[]` | Optional VolumeMounts mapped into each scanJob (see: https://kubernetes.io/docs/concepts/storage/volumes/) |

--- a/scanners/nmap/values.yaml
+++ b/scanners/nmap/values.yaml
@@ -5,7 +5,7 @@ image:
   tag: null
 
 parserImage:
-  # parserImage.tag - defaults to the charts version
+  # parserImage.tag -- defaults to the charts version
   # parserImage.repository -- Parser image repository
   repository: docker.io/securecodebox/parser-nmap
   # parserImage.tag -- Parser image tag

--- a/scanners/nmap/values.yaml
+++ b/scanners/nmap/values.yaml
@@ -5,7 +5,6 @@ image:
   tag: null
 
 parserImage:
-  # parserImage.tag -- defaults to the charts version
   # parserImage.repository -- Parser image repository
   repository: docker.io/securecodebox/parser-nmap
   # parserImage.tag -- Parser image tag

--- a/scanners/nmap/values.yaml
+++ b/scanners/nmap/values.yaml
@@ -1,14 +1,14 @@
 image:
   # image.repository -- Container Image to run the scan
   repository: docker.io/securecodebox/scanner-nmap
-  # image.tag - defaults to the charts version
+  # image.tag -- defaults to the charts version
   tag: null
 
 parserImage:
   # parserImage.repository -- Parser image repository
   repository: docker.io/securecodebox/parser-nmap
   # parserImage.tag -- Parser image tag
-  # @default -- defaults to the charts version
+  # @default -- defaults to the charts appVersion
   tag: null
 
 scannerJob:

--- a/scanners/nmap/values.yaml
+++ b/scanners/nmap/values.yaml
@@ -1,3 +1,9 @@
+image:
+  # image.repository -- Container Image to run the scan
+  repository: docker.io/securecodebox/scanner-nmap
+  # image.tag - defaults to the charts version
+  tag: null
+
 parserImage:
   # parserImage.tag - defaults to the charts version
   # parserImage.repository -- Parser image repository
@@ -6,10 +12,6 @@ parserImage:
   # @default -- defaults to the charts version
   tag: null
 
-image:
-  repository: docker.io/securecodebox/scanner-nmap
-  # image.tag - defaults to the charts version
-  tag: null
 scannerJob:
   # scannerJob.ttlSecondsAfterFinished -- Defines how long the scanner job after finishing will be available (see: https://kubernetes.io/docs/concepts/workloads/controllers/ttlafterfinished/)
   ttlSecondsAfterFinished: null

--- a/scanners/ssh_scan/README.md
+++ b/scanners/ssh_scan/README.md
@@ -66,6 +66,8 @@ Examples:
 
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
+| image.repository | string | `"mozilla/ssh_scan"` | Container Image to run the scan |
+| image.tag | string | `"latest@sha256:ebd76f798159844c0baca6b78cc324ba1966b11eb4f45118397a59d01f764c97"` | defaults to the charts appVersion |
 | parserImage.repository | string | `"docker.io/securecodebox/parser-ssh-scan"` | Parser image repository |
 | parserImage.tag | string | defaults to the charts version | Parser image tag |
 | scannerJob.env | list | `[]` | Optional environment variables mapped into each scanJob (see: https://kubernetes.io/docs/tasks/inject-data-application/define-environment-variable-container/) |

--- a/scanners/ssh_scan/templates/ssh-scan-scan-type.yaml
+++ b/scanners/ssh_scan/templates/ssh-scan-scan-type.yaml
@@ -17,7 +17,7 @@ spec:
           restartPolicy: OnFailure
           containers:
             - name: ssh-scan
-              image: mozilla/ssh_scan@sha256:ebd76f798159844c0baca6b78cc324ba1966b11eb4f45118397a59d01f764c97
+              image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
               command:
                 - "/app/bin/ssh_scan"
                 - "--output"

--- a/scanners/ssh_scan/values.yaml
+++ b/scanners/ssh_scan/values.yaml
@@ -1,3 +1,9 @@
+image:
+  # image.repository -- Container Image to run the scan
+  repository: mozilla/ssh_scan
+  # image.tag - defaults to the charts appVersion
+  tag: "latest@sha256:ebd76f798159844c0baca6b78cc324ba1966b11eb4f45118397a59d01f764c97"
+
 parserImage:
   # parserImage.tag - defaults to the charts version
   # parserImage.repository -- Parser image repository

--- a/scanners/ssh_scan/values.yaml
+++ b/scanners/ssh_scan/values.yaml
@@ -1,11 +1,11 @@
 image:
   # image.repository -- Container Image to run the scan
   repository: mozilla/ssh_scan
-  # image.tag - defaults to the charts appVersion
+  # image.tag -- defaults to the charts appVersion
   tag: "latest@sha256:ebd76f798159844c0baca6b78cc324ba1966b11eb4f45118397a59d01f764c97"
 
 parserImage:
-  # parserImage.tag - defaults to the charts version
+  # parserImage.tag -- defaults to the charts version
   # parserImage.repository -- Parser image repository
   repository: docker.io/securecodebox/parser-ssh-scan
   # parserImage.tag -- Parser image tag

--- a/scanners/ssh_scan/values.yaml
+++ b/scanners/ssh_scan/values.yaml
@@ -5,7 +5,6 @@ image:
   tag: "latest@sha256:ebd76f798159844c0baca6b78cc324ba1966b11eb4f45118397a59d01f764c97"
 
 parserImage:
-  # parserImage.tag -- defaults to the charts version
   # parserImage.repository -- Parser image repository
   repository: docker.io/securecodebox/parser-ssh-scan
   # parserImage.tag -- Parser image tag

--- a/scanners/sslyze/README.md
+++ b/scanners/sslyze/README.md
@@ -133,6 +133,8 @@ Options:
 
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
+| image.repository | string | `"nablac0d3/sslyze"` | Container Image to run the scan |
+| image.tag | string | `"latest@sha256:ff2c5c626401b1961736a5b2ae6e35a41d213e8b2712102100abf5ee46dcca71"` | defaults to the charts appVersion |
 | parserImage.repository | string | `"docker.io/securecodebox/parser-sslyze"` | Parser image repository |
 | parserImage.tag | string | defaults to the charts version | Parser image tag |
 | scannerJob.env | list | `[]` | Optional environment variables mapped into each scanJob (see: https://kubernetes.io/docs/tasks/inject-data-application/define-environment-variable-container/) |

--- a/scanners/sslyze/templates/sslyze-scan-type.yaml
+++ b/scanners/sslyze/templates/sslyze-scan-type.yaml
@@ -16,7 +16,7 @@ spec:
           restartPolicy: OnFailure
           containers:
             - name: sslyze
-              image: nablac0d3/sslyze@sha256:ff2c5c626401b1961736a5b2ae6e35a41d213e8b2712102100abf5ee46dcca71
+              image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
               command:
                 - 'sslyze'
                 - '--json_out'

--- a/scanners/sslyze/values.yaml
+++ b/scanners/sslyze/values.yaml
@@ -1,11 +1,11 @@
 image:
   # image.repository -- Container Image to run the scan
   repository: nablac0d3/sslyze
-  # image.tag - defaults to the charts appVersion
+  # image.tag -- defaults to the charts appVersion
   tag: "latest@sha256:ff2c5c626401b1961736a5b2ae6e35a41d213e8b2712102100abf5ee46dcca71"
 
 parserImage:
-  # parserImage.tag - defaults to the charts version
+  # parserImage.tag -- defaults to the charts version
   # parserImage.repository -- Parser image repository
   repository: docker.io/securecodebox/parser-sslyze
   # parserImage.tag -- Parser image tag

--- a/scanners/sslyze/values.yaml
+++ b/scanners/sslyze/values.yaml
@@ -5,7 +5,6 @@ image:
   tag: "latest@sha256:ff2c5c626401b1961736a5b2ae6e35a41d213e8b2712102100abf5ee46dcca71"
 
 parserImage:
-  # parserImage.tag -- defaults to the charts version
   # parserImage.repository -- Parser image repository
   repository: docker.io/securecodebox/parser-sslyze
   # parserImage.tag -- Parser image tag

--- a/scanners/sslyze/values.yaml
+++ b/scanners/sslyze/values.yaml
@@ -1,3 +1,9 @@
+image:
+  # image.repository -- Container Image to run the scan
+  repository: nablac0d3/sslyze
+  # image.tag - defaults to the charts appVersion
+  tag: "latest@sha256:ff2c5c626401b1961736a5b2ae6e35a41d213e8b2712102100abf5ee46dcca71"
+
 parserImage:
   # parserImage.tag - defaults to the charts version
   # parserImage.repository -- Parser image repository

--- a/scanners/test-scan/values.yaml
+++ b/scanners/test-scan/values.yaml
@@ -1,5 +1,5 @@
 parserImage:
-  # parserImage.tag - defaults to the charts version
+  # parserImage.tag -- defaults to the charts version
   # parserImage.repository -- Parser image repository
   repository: docker.io/securecodebox/parser-test-scan
   # parserImage.tag -- Parser image tag

--- a/scanners/test-scan/values.yaml
+++ b/scanners/test-scan/values.yaml
@@ -1,5 +1,4 @@
 parserImage:
-  # parserImage.tag -- defaults to the charts version
   # parserImage.repository -- Parser image repository
   repository: docker.io/securecodebox/parser-test-scan
   # parserImage.tag -- Parser image tag

--- a/scanners/trivy/Chart.yaml
+++ b/scanners/trivy/Chart.yaml
@@ -5,7 +5,7 @@ description: A Helm chart for the trivy security scanner that integrates with th
 type: application
 # version - gets automatically set to the secureCodeBox release version when the helm charts gets published
 version: latest
-appVersion: v0.6.0
+appVersion: "0.6.0"
 kubeVersion: ">=v1.11.0"
 
 keywords:

--- a/scanners/trivy/README.md
+++ b/scanners/trivy/README.md
@@ -38,6 +38,8 @@ The following security scan configuration example are based on the [Trivy Docume
 
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
+| image.repository | string | `"aquasec/trivy"` | Container Image to run the scan |
+| image.tag | string | `"0.6.0@sha256:61d42dbc030001463048f2f59fa034310fc114c7dee90b9dd9a9e3765dea7f5e"` | defaults to the charts appVersion |
 | parserImage.repository | string | `"docker.io/securecodebox/parser-trivy"` | Parser image repository |
 | parserImage.tag | string | defaults to the charts version | Parser image tag |
 | scannerJob.env | list | `[]` | Optional environment variables mapped into each scanJob (see: https://kubernetes.io/docs/tasks/inject-data-application/define-environment-variable-container/) |

--- a/scanners/trivy/helm2.Chart.yaml
+++ b/scanners/trivy/helm2.Chart.yaml
@@ -5,7 +5,7 @@ description: A Helm chart for the trivy security scanner that integrates with th
 type: application
 # version - gets automatically set to the secureCodeBox release version when the helm charts gets published
 version: latest
-appVersion: v0.6.0
+appVersion: "0.6.0"
 kubeVersion: ">=v1.11.0"
 
 keywords:

--- a/scanners/trivy/templates/trivy-scan-type.yaml
+++ b/scanners/trivy/templates/trivy-scan-type.yaml
@@ -17,7 +17,7 @@ spec:
           restartPolicy: OnFailure
           containers:
             - name: trivy
-              image: aquasec/trivy:0.6.0@sha256:61d42dbc030001463048f2f59fa034310fc114c7dee90b9dd9a9e3765dea7f5e
+              image: aquasec/trivy
               command:
                 - "trivy"
                 # Suppress progress bar, as it pollutes non interactive terminal logs

--- a/scanners/trivy/values.yaml
+++ b/scanners/trivy/values.yaml
@@ -1,3 +1,9 @@
+image:
+  # image.repository -- Container Image to run the scan
+  repository: aquasec/trivy
+  # image.tag - defaults to the charts appVersion
+  tag: "0.6.0@sha256:61d42dbc030001463048f2f59fa034310fc114c7dee90b9dd9a9e3765dea7f5e"
+
 parserImage:
   # parserImage.tag - defaults to the charts version
   # parserImage.repository -- Parser image repository

--- a/scanners/trivy/values.yaml
+++ b/scanners/trivy/values.yaml
@@ -1,11 +1,11 @@
 image:
   # image.repository -- Container Image to run the scan
   repository: aquasec/trivy
-  # image.tag - defaults to the charts appVersion
+  # image.tag -- defaults to the charts appVersion
   tag: "0.6.0@sha256:61d42dbc030001463048f2f59fa034310fc114c7dee90b9dd9a9e3765dea7f5e"
 
 parserImage:
-  # parserImage.tag - defaults to the charts version
+  # parserImage.tag -- defaults to the charts version
   # parserImage.repository -- Parser image repository
   repository: docker.io/securecodebox/parser-trivy
   # parserImage.tag -- Parser image tag

--- a/scanners/trivy/values.yaml
+++ b/scanners/trivy/values.yaml
@@ -5,7 +5,6 @@ image:
   tag: "0.6.0@sha256:61d42dbc030001463048f2f59fa034310fc114c7dee90b9dd9a9e3765dea7f5e"
 
 parserImage:
-  # parserImage.tag -- defaults to the charts version
   # parserImage.repository -- Parser image repository
   repository: docker.io/securecodebox/parser-trivy
   # parserImage.tag -- Parser image tag

--- a/scanners/wpscan/README.md
+++ b/scanners/wpscan/README.md
@@ -72,6 +72,8 @@ Incompatible choices (only one of each group/s can be used):
 
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
+| image.repository | string | `"wpscanteam/wpscan"` | Container Image to run the scan |
+| image.tag | string | `nil` | defaults to the charts appVersion |
 | parserImage.repository | string | `"docker.io/securecodebox/parser-wpscan"` | Parser image repository |
 | parserImage.tag | string | defaults to the charts version | Parser image tag |
 | scannerJob.env | list | `[]` | Optional environment variables mapped into each scanJob (see: https://kubernetes.io/docs/tasks/inject-data-application/define-environment-variable-container/) |

--- a/scanners/wpscan/templates/wpscan-scan-type.yaml
+++ b/scanners/wpscan/templates/wpscan-scan-type.yaml
@@ -17,7 +17,7 @@ spec:
           restartPolicy: OnFailure
           containers:
             - name: wpscan
-              image: wpscanteam/wpscan:latest
+              image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
               command:
                 - "wpscan"
                 - "-o"

--- a/scanners/wpscan/values.yaml
+++ b/scanners/wpscan/values.yaml
@@ -5,7 +5,6 @@ image:
   tag: null
 
 parserImage:
-  # parserImage.tag -- defaults to the charts version
   # parserImage.repository -- Parser image repository
   repository: docker.io/securecodebox/parser-wpscan
   # parserImage.tag -- Parser image tag

--- a/scanners/wpscan/values.yaml
+++ b/scanners/wpscan/values.yaml
@@ -1,11 +1,11 @@
 image:
   # image.repository -- Container Image to run the scan
   repository: wpscanteam/wpscan
-  # image.tag - defaults to the charts appVersion
+  # image.tag -- defaults to the charts appVersion
   tag: null
 
 parserImage:
-  # parserImage.tag - defaults to the charts version
+  # parserImage.tag -- defaults to the charts version
   # parserImage.repository -- Parser image repository
   repository: docker.io/securecodebox/parser-wpscan
   # parserImage.tag -- Parser image tag

--- a/scanners/wpscan/values.yaml
+++ b/scanners/wpscan/values.yaml
@@ -1,3 +1,9 @@
+image:
+  # image.repository -- Container Image to run the scan
+  repository: wpscanteam/wpscan
+  # image.tag - defaults to the charts appVersion
+  tag: null
+
 parserImage:
   # parserImage.tag - defaults to the charts version
   # parserImage.repository -- Parser image repository

--- a/scanners/zap/Chart.yaml
+++ b/scanners/zap/Chart.yaml
@@ -5,7 +5,7 @@ description: A Helm chart for the OWASP ZAP security scanner that integrates wit
 type: application
 # version - gets automatically set to the secureCodeBox release version when the helm charts gets published
 version: latest
-appVersion: v2.9.0
+appVersion: "w2020-10-13"
 kubeVersion: ">=v1.11.0"
 
 keywords:

--- a/scanners/zap/README.md
+++ b/scanners/zap/README.md
@@ -63,6 +63,8 @@ Options:
 
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
+| image.repository | string | `"owasp/zap2docker-weekly"` | Container Image to run the scan |
+| image.tag | string | `nil` | defaults to the charts appVersion |
 | parserImage.repository | string | `"docker.io/securecodebox/parser-zap"` | Parser image repository |
 | parserImage.tag | string | defaults to the charts version | Parser image tag |
 | scannerJob.env | list | `[]` | Optional environment variables mapped into each scanJob (see: https://kubernetes.io/docs/tasks/inject-data-application/define-environment-variable-container/) |

--- a/scanners/zap/templates/zap-scan-type.yaml
+++ b/scanners/zap/templates/zap-scan-type.yaml
@@ -16,7 +16,7 @@ spec:
           restartPolicy: Never
           containers:
             - name: zap-baseline
-              image: owasp/zap2docker-weekly:w2020-09-29
+              image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
               command:
                 - "zap-baseline.py"
                 # Force Zap to always return a zero exit code. k8s would otherwise try to restart zap.
@@ -57,7 +57,7 @@ spec:
           restartPolicy: Never
           containers:
             - name: zap-api-scan
-              image: owasp/zap2docker-weekly:w2020-09-29
+              image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
               command:
                 - "zap-api-scan.py"
                 # Force Zap to always return a zero exit code. k8s would otherwise try to restart zap.
@@ -98,7 +98,7 @@ spec:
           restartPolicy: Never
           containers:
             - name: zap-full-scan
-              image: owasp/zap2docker-weekly:w2020-09-29
+              image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
               command:
                 - "zap-full-scan.py"
                 # Force Zap to always return a zero exit code. k8s would otherwise try to restart zap.

--- a/scanners/zap/values.yaml
+++ b/scanners/zap/values.yaml
@@ -5,7 +5,6 @@ image:
   tag: null
 
 parserImage:
-  # parserImage.tag -- defaults to the charts version
   # parserImage.repository -- Parser image repository
   repository: docker.io/securecodebox/parser-zap
   # parserImage.tag -- Parser image tag

--- a/scanners/zap/values.yaml
+++ b/scanners/zap/values.yaml
@@ -1,11 +1,11 @@
 image:
   # image.repository -- Container Image to run the scan
   repository: owasp/zap2docker-weekly
-  # image.tag - defaults to the charts appVersion
+  # image.tag -- defaults to the charts appVersion
   tag: null
 
 parserImage:
-  # parserImage.tag - defaults to the charts version
+  # parserImage.tag -- defaults to the charts version
   # parserImage.repository -- Parser image repository
   repository: docker.io/securecodebox/parser-zap
   # parserImage.tag -- Parser image tag

--- a/scanners/zap/values.yaml
+++ b/scanners/zap/values.yaml
@@ -1,3 +1,9 @@
+image:
+  # image.repository -- Container Image to run the scan
+  repository: owasp/zap2docker-weekly
+  # image.tag - defaults to the charts appVersion
+  tag: null
+
 parserImage:
   # parserImage.tag - defaults to the charts version
   # parserImage.repository -- Parser image repository


### PR DESCRIPTION
- Exposed all scanner images via the `image.repository` and `image.tag` helm value
- Reordered the image config values to be at the top of the values file and the top of the README's, as these should generally be more important to the user as the `parserImage` configs.
- Updated the appVersion style (with a `v` prefix to match the actual versions of the 3rd party images used. This lets us keep the ScanType helm templates consistent
- For scanner images which are pinned using the digest / hash, these have been moved to the helm values to also be changeable by the user. I didnt want to put these into the appVersion as the digests are so long.

Recreated from https://github.com/secureCodeBox/secureCodeBox-v2/pull/143