### PR TITLE
Update outdated link to the old website

### DIFF
--- a/demo-apps/dummy-ssh/Chart.yaml
+++ b/demo-apps/dummy-ssh/Chart.yaml
@@ -4,8 +4,8 @@ type: application
 appVersion: "v1.0.0"
 name: dummy-ssh
 description: "SSH Server for scan testing."
-home: https://wordpress.org
-icon: https://www.securecodebox.io/integrationIcons/SSH.svg
+home: https://docs.securecodebox.io
+icon: https://docs.securecodebox.io/img/integrationIcons/SSH.svg
 keywords:
   - vulnerable
   - ssh

--- a/demo-apps/dummy-ssh/README.md
+++ b/demo-apps/dummy-ssh/README.md
@@ -4,7 +4,7 @@
 
 SSH Server for scan testing.
 
-**Homepage:** <https://wordpress.org>
+**Homepage:** <https://docs.securecodebox.io>
 
 ## Maintainers
 

--- a/demo-apps/dummy-ssh/helm2.Chart.yaml
+++ b/demo-apps/dummy-ssh/helm2.Chart.yaml
@@ -4,8 +4,8 @@ type: application
 appVersion: "v1.0.0"
 name: dummy-ssh
 description: "SSH Server for scan testing."
-home: https://wordpress.org
-icon: https://www.securecodebox.io/integrationIcons/SSH.svg
+home: https://docs.securecodebox.io
+icon: https://docs.securecodebox.io/img/integrationIcons/SSH.svg
 keywords:
   - vulnerable
   - ssh

--- a/operator/README.md
+++ b/operator/README.md
@@ -43,5 +43,5 @@ helm install securecodebox-operator secureCodeBox/operator
 | securityContext.privileged | bool | `false` | Ensures that the operator container is not run in privileged mode |
 | securityContext.readOnlyRootFilesystem | bool | `true` | Prevents write access to the containers file system |
 | securityContext.runAsNonRoot | bool | `true` | Enforces that the Operator image is run as a non root user |
-| telemetryEnabled | bool | `true` | The Operator sends anonymous telemetry data, to give the team an overview how much the secureCodeBox is used. Find out more at https://www.securecodebox.io/telemetry |
+| telemetryEnabled | bool | `true` | The Operator sends anonymous telemetry data, to give the team an overview how much the secureCodeBox is used. Find out more at https://docs.securecodebox.io/docs/telemetry |
 

--- a/operator/README.md
+++ b/operator/README.md
@@ -43,5 +43,5 @@ helm install securecodebox-operator secureCodeBox/operator
 | securityContext.privileged | bool | `false` | Ensures that the operator container is not run in privileged mode |
 | securityContext.readOnlyRootFilesystem | bool | `true` | Prevents write access to the containers file system |
 | securityContext.runAsNonRoot | bool | `true` | Enforces that the Operator image is run as a non root user |
-| telemetryEnabled | bool | `true` | The Operator sends anonymous telemetry data, to give the team an overview how much the secureCodeBox is used. Find out more at https://docs.securecodebox.io/docs/telemetry |
+| telemetryEnabled | bool | `true` | The Operator sends anonymous telemetry data, to give the team an overview how much the secureCodeBox is used. Find out more at https://www.securecodebox.io/telemetry |
 

--- a/operator/internal/telemetry/telemetry.go
+++ b/operator/internal/telemetry/telemetry.go
@@ -44,7 +44,7 @@ type telemetryData struct {
 
 // Loop Submits Telemetry Data in a regular interval
 func Loop(apiClient client.Client, log logr.Logger) {
-	log.Info("The Operator sends anonymous telemetry data, to give the team an overview how much the secureCodeBox is used. Find out more at https://www.securecodebox.io/telemetry")
+	log.Info("The Operator sends anonymous telemetry data, to give the team an overview how much the secureCodeBox is used. Find out more at https://docs.securecodebox.io/docs/telemetry")
 
 	// Wait 1hour to give users time to uninstall / disable telemetry
 	time.Sleep(1 * time.Hour)

--- a/operator/templates/NOTES.txt
+++ b/operator/templates/NOTES.txt
@@ -1,14 +1,14 @@
 secureCodeBox Operator Deployed 🚀
 
 The operator can orchestrate the execution of various security scanning tools inside of your cluster.
-You can find a list of all officially supported scanners here: https://www.securecodebox.io/integrations/
+You can find a list of all officially supported scanners here: https://docs.securecodebox.io/
 The website also lists other integrations, like persisting scan results to DefectDojo or Elasticsearch.
 
 {{ if .Values.telemetryEnabled -}}
 The operator send out regular telemetry pings to a central service.
 This lets us, the secureCodeBox team, get a grasp on how much the secureCodeBox is used.
 The submitted data is chosen to be as anonymous as possible.
-You can find a complete report of the data submitted and links to the source-code at: https://www.securecodebox.io/telemetry
+You can find a complete report of the data submitted and links to the source-code at: https://docs.securecodebox.io/docs/telemetry
 The first ping is send one hour after the install, you can prevent this by upgrading the chart and setting `telemetryEnabled` to `false`.
 {{ else -}}
 Telemetry data collection has been disabled.


### PR DESCRIPTION
Update outdated links to point to the new page.

I'll add a short info page to the www.securecodebox.io site for the links included in the v2.0.0 release so that they don't 404 anymore and point to the correct page.