### PR TITLE
Allow to configure ZAP via envFrom property

### DIFF
--- a/scanners/zap/README.md
+++ b/scanners/zap/README.md
@@ -67,6 +67,7 @@ Options:
 | parserImage.repository | string | `"docker.io/securecodebox/parser-zap"` | Parser image repository |
 | parserImage.tag | string | defaults to the charts version | Parser image tag |
 | scannerJob.env | list | `[]` | Optional environment variables mapped into each scanJob (see: https://kubernetes.io/docs/tasks/inject-data-application/define-environment-variable-container/) |
+| scannerJob.envFrom | list | `[]` | Optional mount environment variables from configMaps or secrets (see: https://kubernetes.io/docs/tasks/inject-data-application/distribute-credentials-secure/#configure-all-key-value-pairs-in-a-secret-as-container-environment-variables) |
 | scannerJob.extraContainers | list | `[]` | Optional additional Containers started with each scanJob (see: https://kubernetes.io/docs/concepts/workloads/pods/init-containers/) |
 | scannerJob.extraVolumeMounts | list | `[{"mountPath":"/zap/wrk","name":"zap-workdir"}]` | Optional VolumeMounts mapped into each scanJob (see: https://kubernetes.io/docs/concepts/storage/volumes/) |
 | scannerJob.extraVolumes | list | `[{"emptyDir":{},"name":"zap-workdir"}]` | Optional Volumes mapped into each scanJob (see: https://kubernetes.io/docs/concepts/storage/volumes/) |

--- a/scanners/zap/templates/zap-scan-type.yaml
+++ b/scanners/zap/templates/zap-scan-type.yaml
@@ -31,6 +31,8 @@ spec:
                 {{- toYaml .Values.scannerJob.securityContext | nindent 16 }}
               env:
                 {{- toYaml .Values.scannerJob.env | nindent 16 }}
+              envFrom:
+                {{- toYaml .Values.scannerJob.envFrom | nindent 16 }}
               volumeMounts:
                 {{- toYaml .Values.scannerJob.extraVolumeMounts | nindent 16 }}
             {{- if .Values.scannerJob.extraContainers }}
@@ -72,6 +74,8 @@ spec:
                 {{- toYaml .Values.scannerJob.securityContext | nindent 16 }}
               env:
                 {{- toYaml .Values.scannerJob.env | nindent 16 }}
+              envFrom:
+                {{- toYaml .Values.scannerJob.envFrom | nindent 16 }}
               volumeMounts:
                 {{- toYaml .Values.scannerJob.extraVolumeMounts | nindent 16 }}
             {{- if .Values.scannerJob.extraContainers }}
@@ -113,6 +117,8 @@ spec:
                 {{- toYaml .Values.scannerJob.securityContext | nindent 16 }}
               env:
                 {{- toYaml .Values.scannerJob.env | nindent 16 }}
+              envFrom:
+                {{- toYaml .Values.scannerJob.envFrom | nindent 16 }}
               volumeMounts:
                 {{- toYaml .Values.scannerJob.extraVolumeMounts | nindent 16 }}
             {{- if .Values.scannerJob.extraContainers }}

--- a/scanners/zap/values.yaml
+++ b/scanners/zap/values.yaml
@@ -28,6 +28,9 @@ scannerJob:
   # scannerJob.env -- Optional environment variables mapped into each scanJob (see: https://kubernetes.io/docs/tasks/inject-data-application/define-environment-variable-container/)
   env: []
 
+  # scannerJob.envFrom -- Optional mount environment variables from configMaps or secrets (see: https://kubernetes.io/docs/tasks/inject-data-application/distribute-credentials-secure/#configure-all-key-value-pairs-in-a-secret-as-container-environment-variables)
+  envFrom: []
+
   # scannerJob.extraVolumes -- Optional Volumes mapped into each scanJob (see: https://kubernetes.io/docs/concepts/storage/volumes/)
   extraVolumes:
     - name: zap-workdir


### PR DESCRIPTION
This allow to mount all key/value pairs from a configMap/secret into the zap container.
This makes it easier to mount a long list of env vars.