### PR TITLE
Fixing scan name for sslyze example

### DIFF
--- a/scanners/sslyze/examples/example.com/scan.yaml
+++ b/scanners/sslyze/examples/example.com/scan.yaml
@@ -1,7 +1,7 @@
 apiVersion: "execution.securecodebox.io/v1"
 kind: Scan
 metadata:
-  name: "sslyze-securecodebox.io"
+  name: "sslyze-example"
 spec:
   scanType: "sslyze"
   parameters:


### PR DESCRIPTION
Renaming from sslyze-securecodebox.io to sslyze-example