### PR TITLE
Fix Helm2 Chart Containing the Packaged Helm3 Chart

### DIFF
--- a/.github/workflows/helm-charts.yaml
+++ b/.github/workflows/helm-charts.yaml
@@ -53,6 +53,8 @@ jobs:
             echo "Restoring Helm2 Chart and replace Helm3 Chart temporary"
             [ ! -f helm2.requirements.lock ] || mv helm2.requirements.lock requirements.lock
             [ ! -f helm2.requirements.yaml ] || mv helm2.requirements.yaml requirements.yaml
+            # Removing packaged Helm3 chart version build in the previous step
+            rm *.tgz
             echo "Processing Helm2 Chart in $dir"
             helm package --version $RELEASE_VERSION .
             NAME=$(yq read - name < Chart.yaml)

--- a/operator/.helmignore
+++ b/operator/.helmignore
@@ -27,3 +27,12 @@ config/
 bin/
 controllers/
 apis/
+internal/
+utils/
+Dockerfile
+go.mod
+go.sum
+main.go
+Makefile
+PROJECT
+README.md.gotmpl


### PR DESCRIPTION
This fixes a problem where the packaged helm3 chart .tgz is included in the packaged helm2 chart .tgz.

This could potentially lead to sizing problems.

This pr also exclude various other "code" files from the operator chart, which aren't really required there.