### PR TITLE
Fixing docs for demo-apps

### DIFF
--- a/demo-apps/bodgeit/README.md
+++ b/demo-apps/bodgeit/README.md
@@ -16,12 +16,6 @@ BodgeIt Store is a serverside rendering based html website without any heavy jav
 
 **Homepage:** <https://github.com/psiinon/bodgeit>
 
-## Maintainers
-
-| Name | Email | Url |
-| ---- | ------ | --- |
-| iteratec GmbH | securecodebox@iteratec.com |  |
-
 ## Source Code
 
 * <https://github.com/secureCodeBox/secureCodeBox/tree/master/demo-apps/bodgeit>

--- a/demo-apps/bodgeit/README.md
+++ b/demo-apps/bodgeit/README.md
@@ -12,13 +12,19 @@ usecase: "Vulnerable WebApp based on html serverside rendering"
 ![Version: latest](https://img.shields.io/badge/Version-latest-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v1.4.0](https://img.shields.io/badge/AppVersion-v1.4.0-informational?style=flat-square)
 
 The BodgeIt Store is a vulnerable web app which is aimed at people who are new to pen testing.
-BodgeIt Store is a serverside renering based html website without any heavy javascript.
+BodgeIt Store is a serverside rendering based html website without any heavy javascript.
 
 **Homepage:** <https://github.com/psiinon/bodgeit>
 
+## Maintainers
+
+| Name | Email | Url |
+| ---- | ------ | --- |
+| iteratec GmbH | securecodebox@iteratec.com |  |
+
 ## Source Code
 
-* <https://github.com/secureCodeBox/helm>
+* <https://github.com/secureCodeBox/secureCodeBox/tree/master/demo-apps/bodgeit>
 * <https://github.com/psiinon/bodgeit>
 
 ## Chart Configuration

--- a/demo-apps/bodgeit/README.md.gotmpl
+++ b/demo-apps/bodgeit/README.md.gotmpl
@@ -11,14 +11,14 @@ usecase: "Vulnerable WebApp based on html serverside rendering"
 
 ![Version: latest](https://img.shields.io/badge/Version-latest-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v1.4.0](https://img.shields.io/badge/AppVersion-v1.4.0-informational?style=flat-square)
 
-The BodgeIt Store is a vulnerable web app which is aimed at people who are new to pen testing. 
-BodgeIt Store is a serverside renering based html website without any heavy javascript.
+The BodgeIt Store is a vulnerable web app which is aimed at people who are new to pen testing.
+BodgeIt Store is a serverside rendering based html website without any heavy javascript.
 
 **Homepage:** <https://github.com/psiinon/bodgeit>
 
 ## Source Code
 
-* <https://github.com/secureCodeBox/helm>
+* <https://github.com/secureCodeBox/secureCodeBox/tree/master/demo-apps/bodgeit>
 * <https://github.com/psiinon/bodgeit>
 
 ## Chart Configuration

--- a/demo-apps/dummy-ssh/Chart.yaml
+++ b/demo-apps/dummy-ssh/Chart.yaml
@@ -10,7 +10,7 @@ keywords:
   - vulnerable
   - ssh
 sources:
-  - https://github.com/secureCodeBox/secureCodeBox/tree/master/demo/dummy-ssh
+  - https://github.com/secureCodeBox/secureCodeBox/tree/master/demo-apps/dummy-ssh
 maintainers:
   - name: iteratec GmbH
     email: securecodebox@iteratec.com

--- a/demo-apps/dummy-ssh/README.md
+++ b/demo-apps/dummy-ssh/README.md
@@ -2,7 +2,8 @@
 
 ![Version: latest](https://img.shields.io/badge/Version-latest-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v1.0.0](https://img.shields.io/badge/AppVersion-v1.0.0-informational?style=flat-square)
 
-SSH Server for scan testing.
+Vulnerable SSH Server for scan testing.
+Port 22: Username root, Password: THEPASSWORDYOUCREATED
 
 **Homepage:** <https://docs.securecodebox.io>
 
@@ -14,7 +15,7 @@ SSH Server for scan testing.
 
 ## Source Code
 
-* <https://github.com/secureCodeBox/secureCodeBox/tree/master/demo/dummy-ssh>
+* <https://github.com/secureCodeBox/secureCodeBox/tree/master/demo-apps/dummy-ssh>
 
 ## Chart Configuration
 

--- a/demo-apps/dummy-ssh/README.md.gotmpl
+++ b/demo-apps/dummy-ssh/README.md.gotmpl
@@ -2,7 +2,8 @@
 
 ![Version: latest](https://img.shields.io/badge/Version-latest-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v1.0.0](https://img.shields.io/badge/AppVersion-v1.0.0-informational?style=flat-square)
 
-SSH Server for scan testing.
+Vulnerable SSH Server for scan testing.
+Port 22: Username root, Password: THEPASSWORDYOUCREATED
 
 **Homepage:** <https://docs.securecodebox.io>
 
@@ -14,7 +15,7 @@ SSH Server for scan testing.
 
 ## Source Code
 
-* <https://github.com/secureCodeBox/secureCodeBox/tree/master/demo/dummy-ssh>
+* <https://github.com/secureCodeBox/secureCodeBox/tree/master/demo-apps/dummy-ssh>
 
 ## Chart Configuration
 

--- a/demo-apps/dummy-ssh/helm2.Chart.yaml
+++ b/demo-apps/dummy-ssh/helm2.Chart.yaml
@@ -10,7 +10,7 @@ keywords:
   - vulnerable
   - ssh
 sources:
-  - https://github.com/secureCodeBox/secureCodeBox/tree/master/demo/dummy-ssh
+  - https://github.com/secureCodeBox/secureCodeBox/tree/master/demo-apps/dummy-ssh
 maintainers:
   - name: iteratec GmbH
     email: securecodebox@iteratec.com

--- a/demo-apps/http-webhook/README.md
+++ b/demo-apps/http-webhook/README.md
@@ -4,6 +4,19 @@
 
 A Dummy webserver to echo HTTP requests in log
 
+**Homepage:** <https://docs.securecodebox.io>
+
+## Maintainers
+
+| Name | Email | Url |
+| ---- | ------ | --- |
+| iteratec GmbH | securecodebox@iteratec.com |  |
+
+## Source Code
+
+* <https://github.com/mendhak/docker-http-https-echo>
+* <https://github.com/secureCodeBox/secureCodeBox/tree/master/demo-apps/http-webhook>
+
 ## Chart Configuration
 
 | Key | Type | Default | Description |

--- a/demo-apps/http-webhook/README.md.gotmpl
+++ b/demo-apps/http-webhook/README.md.gotmpl
@@ -4,6 +4,19 @@
 
 A Dummy webserver to echo HTTP requests in log
 
+**Homepage:** <https://docs.securecodebox.io>
+
+## Maintainers
+
+| Name | Email | Url |
+| ---- | ------ | --- |
+| iteratec GmbH | securecodebox@iteratec.com |  |
+
+## Source Code
+
+* <https://github.com/mendhak/docker-http-https-echo>
+* <https://github.com/secureCodeBox/secureCodeBox/tree/master/demo-apps/http-webhook>
+
 ## Chart Configuration
 
 {{ template "chart.valuesTable" . }}

--- a/demo-apps/juice-shop/Chart.yaml
+++ b/demo-apps/juice-shop/Chart.yaml
@@ -19,7 +19,7 @@ keywords:
   - appsec
   - ctf
 sources:
-  - https://github.com/secureCodeBox/helm
+  - https://github.com/secureCodeBox/secureCodeBox/tree/master/demo-apps/juice-shop
   - https://github.com/bkimminich/juice-shop
 maintainers:
   - name: iteratec GmbH

--- a/demo-apps/juice-shop/README.md
+++ b/demo-apps/juice-shop/README.md
@@ -14,7 +14,7 @@ OWASP Juice Shop: Probably the most modern and sophisticated insecure web applic
 
 ## Source Code
 
-* <https://github.com/secureCodeBox/helm>
+* <https://github.com/secureCodeBox/secureCodeBox/tree/master/demo-apps/juice-shop>
 * <https://github.com/bkimminich/juice-shop>
 
 ## Chart Configuration

--- a/demo-apps/juice-shop/README.md.gotmpl
+++ b/demo-apps/juice-shop/README.md.gotmpl
@@ -14,7 +14,7 @@ OWASP Juice Shop: Probably the most modern and sophisticated insecure web applic
 
 ## Source Code
 
-* <https://github.com/secureCodeBox/helm>
+* <https://github.com/secureCodeBox/secureCodeBox/tree/master/demo-apps/juice-shop>
 * <https://github.com/bkimminich/juice-shop>
 
 ## Chart Configuration

--- a/demo-apps/juice-shop/helm2.Chart.yaml
+++ b/demo-apps/juice-shop/helm2.Chart.yaml
@@ -19,7 +19,7 @@ keywords:
   - appsec
   - ctf
 sources:
-  - https://github.com/secureCodeBox/helm
+  - https://github.com/secureCodeBox/secureCodeBox/tree/master/demo-apps/juice-shop
   - https://github.com/bkimminich/juice-shop
 maintainers:
   - name: iteratec GmbH

--- a/demo-apps/old-wordpress/Chart.yaml
+++ b/demo-apps/old-wordpress/Chart.yaml
@@ -10,8 +10,7 @@ keywords:
   - vulnerable
   - wordpress
 sources:
-  - https://github.com/secureCodeBox/helm
-  - https://github.com/secureCodeBox/secureCodeBox/tree/master/demo/old-wordpress
+  - https://github.com/secureCodeBox/secureCodeBox/tree/master/demo-apps/old-wordpress
 maintainers:
   - name: iteratec GmbH
     email: securecodebox@iteratec.com

--- a/demo-apps/old-wordpress/README.md
+++ b/demo-apps/old-wordpress/README.md
@@ -14,8 +14,7 @@ Insecure & Outdated Wordpress Instance: Never expose it to the internet!
 
 ## Source Code
 
-* <https://github.com/secureCodeBox/helm>
-* <https://github.com/secureCodeBox/secureCodeBox/tree/master/demo/old-wordpress>
+* <https://github.com/secureCodeBox/secureCodeBox/tree/master/demo-apps/old-wordpress>
 
 ## Chart Configuration
 

--- a/demo-apps/old-wordpress/README.md.gotmpl
+++ b/demo-apps/old-wordpress/README.md.gotmpl
@@ -14,8 +14,7 @@ Insecure & Outdated Wordpress Instance: Never expose it to the internet!
 
 ## Source Code
 
-* <https://github.com/secureCodeBox/helm>
-* <https://github.com/secureCodeBox/secureCodeBox/tree/master/demo/old-wordpress>
+* <https://github.com/secureCodeBox/secureCodeBox/tree/master/demo-apps/old-wordpress>
 
 ## Chart Configuration
 

--- a/demo-apps/old-wordpress/helm2.Chart.yaml
+++ b/demo-apps/old-wordpress/helm2.Chart.yaml
@@ -10,8 +10,7 @@ keywords:
   - vulnerable
   - wordpress
 sources:
-  - https://github.com/secureCodeBox/helm
-  - https://github.com/secureCodeBox/secureCodeBox/tree/master/demo/old-wordpress
+  - https://github.com/secureCodeBox/secureCodeBox/tree/master/demo-apps/old-wordpress
 maintainers:
   - name: iteratec GmbH
     email: securecodebox@iteratec.com

--- a/demo-apps/swagger-petstore/Chart.yaml
+++ b/demo-apps/swagger-petstore/Chart.yaml
@@ -10,7 +10,7 @@ keywords:
   - swagger
   - openapi
 sources:
-  - https://github.com/secureCodeBox/helm
+  - https://github.com/secureCodeBox/secureCodeBox/tree/master/demo-apps/swagger-petstore
   - https://github.com/swagger-api/swagger-petstore
 maintainers:
   - name: iteratec GmbH

--- a/demo-apps/swagger-petstore/README.md
+++ b/demo-apps/swagger-petstore/README.md
@@ -14,7 +14,7 @@ This is the sample petstore application with a restful API.
 
 ## Source Code
 
-* <https://github.com/secureCodeBox/helm>
+* <https://github.com/secureCodeBox/secureCodeBox/tree/master/demo-apps/swagger-petstore>
 * <https://github.com/swagger-api/swagger-petstore>
 
 ## Chart Configuration

--- a/demo-apps/swagger-petstore/README.md.gotmpl
+++ b/demo-apps/swagger-petstore/README.md.gotmpl
@@ -14,7 +14,7 @@ This is the sample petstore application with a restful API.
 
 ## Source Code
 
-* <https://github.com/secureCodeBox/helm>
+* <https://github.com/secureCodeBox/secureCodeBox/tree/master/demo-apps/swagger-petstore>
 * <https://github.com/swagger-api/swagger-petstore>
 
 ## Chart Configuration

--- a/demo-apps/swagger-petstore/helm2.Chart.yaml
+++ b/demo-apps/swagger-petstore/helm2.Chart.yaml
@@ -10,7 +10,7 @@ keywords:
   - swagger
   - openapi
 sources:
-  - https://github.com/secureCodeBox/helm
+  - https://github.com/secureCodeBox/secureCodeBox/tree/master/demo-apps/swagger-petstore
   - https://github.com/swagger-api/swagger-petstore
 maintainers:
   - name: iteratec GmbH

--- a/scanners/ncrack/examples/dummy-ssh/README.md
+++ b/scanners/ncrack/examples/dummy-ssh/README.md
@@ -16,7 +16,7 @@ kubectl create secret generic --from-file users.txt --from-file passwords.txt nc
 helm install dummy-ssh ./demo-apps/dummy-ssh/ --wait
 
 # Install the ncrack scanType and set mount the files from the ncrack-lists Kubernetes secret
-cat <<EOF | helm install ncrack ./scanners/ncrack --values -
+cat <<EOF | helm upgrade --install ncrack ./scanners/ncrack --values -
 scannerJob:
   extraVolumes:
     - name: ncrack-lists
@@ -27,6 +27,13 @@ scannerJob:
       mountPath: "/ncrack/"
 EOF
 ```
+
+After that you can execute the scan in this directory:
+```bash
+kubectl apply -f scan.yaml
+```
+
+The scan should find credentials for username 'root' with password 'THEPASSWORDYOUCREATED'. 
 
 #### Troubleshooting:
 * <b> Make sure to leave a blank line at the end of each file used in the secret!</b>


### PR DESCRIPTION
This pull request will fix a lot of deprecated links and descriptions in the Chart.yaml and Readme.md files of the demo-apps.
It also exposes the credentials of the dummy-ssh server and adds them to its ncrack example scan.