### PR TITLE
Splitted screenshooter cascading rule into two different rules

### DIFF
--- a/scanners/screenshooter/cascading-rules/screenshooter-http.yaml
+++ b/scanners/screenshooter/cascading-rules/screenshooter-http.yaml
@@ -1,7 +1,7 @@
 apiVersion: "cascading.securecodebox.io/v1"
 kind: CascadingRule
 metadata:
-  name: "screenshooter-http"
+  name: "screenshooter-http-scan"
   labels:
     securecodebox.io/invasive: non-invasive
     securecodebox.io/intensive: light
@@ -14,8 +14,8 @@ spec:
           state: open
       - category: "Open Port"
         attributes:
-          service: https
+          port: 80
           state: open
   scanSpec:
     scanType: "screenshooter"
-    parameters: ["{{attributes.service}}://{{$.hostOrIP}}:{{attributes.port}}"]
+    parameters: ["http://{{$.hostOrIP}}:{{attributes.port}}"]

--- a/scanners/screenshooter/cascading-rules/screenshooter-https.yaml
+++ b/scanners/screenshooter/cascading-rules/screenshooter-https.yaml
@@ -1,0 +1,21 @@
+apiVersion: "cascading.securecodebox.io/v1"
+kind: CascadingRule
+metadata:
+  name: "screenshooter-https-scan"
+  labels:
+    securecodebox.io/invasive: non-invasive
+    securecodebox.io/intensive: light
+spec:
+  matches:
+    anyOf:
+      - category: "Open Port"
+        attributes:
+          service: https
+          state: open
+      - category: "Open Port"
+        attributes:
+          port: 443
+          state: open
+  scanSpec:
+    scanType: "screenshooter"
+    parameters: ["https://{{$.hostOrIP}}:{{attributes.port}}"]


### PR DESCRIPTION
<!-- 
Thank you for your contribution to our Project 🙌 

Before submitting your Pull Request, please take the time to check the points below and provide some descriptive information.
* [ ] If this PR comes from a fork, please [Allow edits from maintainers](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork)
* [ ] Set a meaningful title. Format: {task_name} (closes #{issue_number}). For example: Use logger (closes #41)
* [ ] [Link your Pull Request to an issue](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) (if applicable)
* [ ] Create Draft pull requests if you need clarification or an explicit review before you can continue your work item.
* [ ] Make sure that your PR is not introducing _unncessary_ reformatting (e.g., introduced by on-save hooks in your IDE)
* [ ] Make sure each new source file you add has a correct license header.
-->
## Checklist

* [x] Test your changes as thoroughly as possible before you commit them. Preferably, automate your test by unit/integration tests.
* [x] Make sure `npm test` runs for the whole project.

## Description

<!-- Please be brief in describing which issue is solved by your PR or which enhancement it brings -->

Splitted screenshooter cascading rule into two different rule because NMAP sometimes identifies the HTTP services on port 443 instead of HTTPS and this leads to errors.
