### PR TITLE
Add history limit for failed Scans in ScheduledScans

### DIFF
--- a/operator/apis/execution/v1/scheduledscan_types.go
+++ b/operator/apis/execution/v1/scheduledscan_types.go
@@ -37,6 +37,8 @@ type ScheduledScanSpec struct {
 
 	// SuccessfulJobsHistoryLimit determines how many past Scans will be kept until the oldest one will be deleted, defaults to 3. When set to 0, Scans will be deleted directly after completion
 	SuccessfulJobsHistoryLimit *int32 `json:"successfulJobsHistoryLimit,omitempty"`
+	// FailedJobsHistoryLimit determines how many failed past Scans will be kept until the oldest one will be deleted, defaults to 3. When set to 0, Scans will be deleted directly after failure
+	FailedJobsHistoryLimit *int32 `json:"failedJobsHistoryLimit,omitempty"`
 
 	// ScanSpec describes the scan which should be started regularly
 	ScanSpec *ScanSpec `json:"scanSpec"`

--- a/operator/apis/execution/v1/zz_generated.deepcopy.go
+++ b/operator/apis/execution/v1/zz_generated.deepcopy.go
@@ -614,6 +614,11 @@ func (in *ScheduledScanSpec) DeepCopyInto(out *ScheduledScanSpec) {
 		*out = new(int32)
 		**out = **in
 	}
+	if in.FailedJobsHistoryLimit != nil {
+		in, out := &in.FailedJobsHistoryLimit, &out.FailedJobsHistoryLimit
+		*out = new(int32)
+		**out = **in
+	}
 	if in.ScanSpec != nil {
 		in, out := &in.ScanSpec, &out.ScanSpec
 		*out = new(ScanSpec)

--- a/operator/config/crd/bases/execution.securecodebox.io_scheduledscans.yaml
+++ b/operator/config/crd/bases/execution.securecodebox.io_scheduledscans.yaml
@@ -59,6 +59,12 @@ spec:
         spec:
           description: ScheduledScanSpec defines the desired state of ScheduledScan
           properties:
+            failedJobsHistoryLimit:
+              description: FailedJobsHistoryLimit determines how many failed past
+                Scans will be kept until the oldest one will be deleted, defaults
+                to 3. When set to 0, Scans will be deleted directly after failure
+              format: int32
+              type: integer
             interval:
               description: 'Interval describes how often the scan should be repeated
                 Examples: ''12h'', ''30m'''

--- a/operator/controllers/execution/scheduledscan_controller.go
+++ b/operator/controllers/execution/scheduledscan_controller.go
@@ -100,7 +100,7 @@ func (r *ScheduledScanReconciler) Reconcile(req ctrl.Request) (ctrl.Result, erro
 
 	// Delete Old Failed Scans when exceeding the history limit
 	failedScans := getScansWithState(childScans.Items, "Errored")
-	var failedHistoryLimit int32 = 3
+	var failedHistoryLimit int32 = 1
 	if scheduledScan.Spec.FailedJobsHistoryLimit != nil {
 		failedHistoryLimit = *scheduledScan.Spec.FailedJobsHistoryLimit
 	}

--- a/operator/crds/execution.securecodebox.io_scheduledscans.yaml
+++ b/operator/crds/execution.securecodebox.io_scheduledscans.yaml
@@ -59,6 +59,12 @@ spec:
         spec:
           description: ScheduledScanSpec defines the desired state of ScheduledScan
           properties:
+            failedJobsHistoryLimit:
+              description: FailedJobsHistoryLimit determines how many failed past
+                Scans will be kept until the oldest one will be deleted, defaults
+                to 3. When set to 0, Scans will be deleted directly after failure
+              format: int32
+              type: integer
             interval:
               description: 'Interval describes how often the scan should be repeated
                 Examples: ''12h'', ''30m'''


### PR DESCRIPTION
Adds a new `failedJobsHistoryLimit` property to the ScheduledScan CRD which can be used to automatically clean up failed scans.

Example:

```yaml
apiVersion: "execution.securecodebox.io/v1"
kind: ScheduledScan
metadata:
  name: "nmap-localhost"
spec:
  interval: 10s
  failedJobsHistoryLimit: 3
  successfulJobsHistoryLimit: 3
  scanSpec:
    scanType: "nmap"
    parameters:
      - localhost
```


This will keep 3 successful and 3 failed scans. All other will be deleted. Older scans will be deleted first.