### PR TITLE
Increase Lease Duration and Renew Deadline

### DIFF
--- a/operator/main.go
+++ b/operator/main.go
@@ -19,6 +19,7 @@ package main
 import (
 	"flag"
 	"os"
+	"time"
 
 	"k8s.io/apimachinery/pkg/runtime"
 	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
@@ -58,12 +59,17 @@ func main() {
 
 	ctrl.SetLogger(zap.New(zap.UseDevMode(true)))
 
+	leaseDuration := 30 * time.Second
+	renewDeadline := 20 * time.Second
+
 	mgr, err := ctrl.NewManager(ctrl.GetConfigOrDie(), ctrl.Options{
 		Scheme:             scheme,
 		MetricsBindAddress: metricsAddr,
 		Port:               9443,
 		LeaderElection:     enableLeaderElection,
 		LeaderElectionID:   "e341d981.securecodebox.io",
+		LeaseDuration:      &leaseDuration,
+		RenewDeadline:      &renewDeadline,
 	})
 	if err != nil {
 		setupLog.Error(err, "unable to start manager")


### PR DESCRIPTION
We've noticed that the leader election the operator runs can timeout under certain conditions. (E.g. high load on the cluster / api-server) This causes the operator to run into a crash loop where the leader election times out and crashes the operator.

This PR should decrease the likelihood of that happening by increasing the retry period and lease duration for the leader election as suggested in: https://github.com/operator-framework/operator-sdk/issues/1813#issuecomment-733513350