### PR TITLE
Add Kubernetes 1.20 to supported versions

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -451,7 +451,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        k8sVersion: ["1.19.0", "1.18.8", "1.17.5", "1.16.9"]
+        k8sVersion: ["v1.20.0","1.19.4", "1.18.8", "1.17.11"]
     steps:
       - uses: actions/checkout@master
       - name: "Start kind cluster"

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -451,7 +451,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        k8sVersion: ["v1.20.0","1.19.4", "1.18.8", "1.17.11"]
+         k8sVersion: ["1.20.0", "1.19.4", "1.18.8", "1.17.11"]
     steps:
       - uses: actions/checkout@master
       - name: "Start kind cluster"


### PR DESCRIPTION
This PR updates the kubernetes version range used by the integration tests to include the new 1.20 release and removes the 1.16 release.

- [ ] Update version range in docs