### PR TITLE
Update ZAP and Integrations Tests for ZAP 2.10.0

### DIFF
--- a/scanners/zap/Chart.yaml
+++ b/scanners/zap/Chart.yaml
@@ -5,7 +5,7 @@ description: A Helm chart for the OWASP ZAP security scanner that integrates wit
 type: application
 # version - gets automatically set to the secureCodeBox release version when the helm charts gets published
 version: latest
-appVersion: "w2020-10-13"
+appVersion: "2.10.0"
 kubeVersion: ">=v1.11.0-0"
 
 keywords:

--- a/scanners/zap/README.md
+++ b/scanners/zap/README.md
@@ -62,7 +62,7 @@ Options:
 
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
-| image.repository | string | `"owasp/zap2docker-weekly"` | Container Image to run the scan |
+| image.repository | string | `"owasp/zap2docker-stable"` | Container Image to run the scan |
 | image.tag | string | `nil` | defaults to the charts appVersion |
 | parseJob.ttlSecondsAfterFinished | string | `nil` | seconds after which the kubernetes job for the parser will be deleted. Requires the Kubernetes TTLAfterFinished controller: https://kubernetes.io/docs/concepts/workloads/controllers/ttlafterfinished/ |
 | parserImage.repository | string | `"docker.io/securecodebox/parser-zap"` | Parser image repository |

--- a/scanners/zap/values.yaml
+++ b/scanners/zap/values.yaml
@@ -1,6 +1,6 @@
 image:
   # image.repository -- Container Image to run the scan
-  repository: owasp/zap2docker-weekly
+  repository: owasp/zap2docker-stable
   # image.tag -- defaults to the charts appVersion
   tag: null
 

--- a/tests/integration/scanner/zap.test.js
+++ b/tests/integration/scanner/zap.test.js
@@ -10,16 +10,20 @@ test(
       60 * 4
     );
 
-    expect(categories).toMatchObject({
-      "Content Security Policy (CSP) Header Not Set": 1,
-      'Server Leaks Version Information via "Server" HTTP Response Header Field': 1,
-      "X-Content-Type-Options Header Missing": 1,
-      "X-Frame-Options Header Not Set": 1,
-    });
-    expect(severities).toMatchObject({
-      low: 3,
-      medium: 1,
-    });
+    expect(categories).toMatchInlineSnapshot(`
+      Object {
+        "Content Security Policy (CSP) Header Not Set": 1,
+        "Server Leaks Version Information via \\"Server\\" HTTP Response Header Field": 1,
+        "X-Content-Type-Options Header Missing": 1,
+        "X-Frame-Options Header Not Set": 1,
+      }
+    `);
+    expect(severities).toMatchInlineSnapshot(`
+      Object {
+        "low": 2,
+        "medium": 2,
+      }
+    `);
   },
   5 * 60 * 1000
 );


### PR DESCRIPTION
Seems like ZAP has updated some Plugins with their 2.10 release which ZAP automatically updates on start up.
This has caused some assertions in the integration test to fail, because ZAP produces different findings then before.

This PR:

- Updates the used ZAP image to 2.10
- Updates the assertions to match the current findings