### PR TITLE
🐞 Bugfixed the image tag reference in the kube-hunter helmchart template

### DIFF
--- a/scanners/kube-hunter/templates/kubehunter-scan-type.yaml
+++ b/scanners/kube-hunter/templates/kubehunter-scan-type.yaml
@@ -17,7 +17,7 @@ spec:
           restartPolicy: Never
           containers:
             - name: kube-hunter
-              image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.Version }}"
+              image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
               command:
                 - 'sh'
                 - '/wrapper.sh'


### PR DESCRIPTION
<!-- 
Thank you for your contribution to our Project 🙌 

Before submitting your Pull Request, please take the time to check the points below and provide some descriptive information.
* [ ] If this PR comes from a fork, please [Allow edits from maintainers](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork)
* [ ] Set a meaningful title. Format: {task_name} (closes #{issue_number}). For example: Use logger (closes #41)
* [ ] [Link your Pull Request to an issue](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) (if applicable)
* [ ] Create Draft pull requests if you need clarification or an explicit review before you can continue your work item.
* [ ] Make sure that your PR is not introducing _unncessary_ reformatting (e.g., introduced by on-save hooks in your IDE)
* [ ] Make sure each new source file you add has a correct license header.
-->

## Checklist

* [ ] Test your changes as thoroughly as possible before you commit them. Preferably, automate your test by unit/integration tests.
* [ ] Make sure `npm test` runs for the whole project.

## Description

<!-- Please be brief in describing which issue is solved by your PR or which enhancement it brings -->
The kube-hunter helmChart `scan-type` template referenced the `helmChart` Version instead of the `AppVersion`. But the scanner image docker tag references to the AppVersion as one can see here: https://hub.docker.com/repository/docker/securecodebox/scanner-kube-hunter/tags?page=1&ordering=last_updated

Maybe it would be easier to be more consistent here 🤔 Some of the scanner image docker tags are referencing the SCB release version and some are referencing the underling app version of the security scanner used.