### PR TITLE
Ensure that kubeaudit is build with the intended version

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -430,6 +430,7 @@ jobs:
           repository: securecodebox/scanner-kubeaudit
           path: ./scanners/kubeaudit/scanner/
           tags: "v0.11.5,latest"
+          build_args: "version=v0.11.5"
       - uses: docker/build-push-action@v1
         name: "Build & Push test-scan Scanner Image"
         with:

--- a/scanners/kubeaudit/scanner/Dockerfile
+++ b/scanners/kubeaudit/scanner/Dockerfile
@@ -6,7 +6,8 @@ ENV CGO_ENABLED=0 GOOS=linux GOARCH=amd64
 # this is where we build our app
 WORKDIR /go/src/app/
 
-RUN git clone https://github.com/Shopify/kubeaudit.git /go/src/app/
+ARG version
+RUN git clone --depth 1 --branch $version https://github.com/Shopify/kubeaudit.git /go/src/app/
 RUN go mod download
 
 RUN go build -a -ldflags '-w -s -extldflags "-static"' -o /go/bin/kubeaudit ./cmd/ \


### PR DESCRIPTION
This PR ensures that Kubeaudit is actually build with the version we've intended it to be in.
Previously the docker build accidentally used the latest version.