### PR TITLE
Ensure that CRDs are Only Contained Once in the Helm2 Chart

### DIFF
--- a/.github/workflows/helm-charts.yaml
+++ b/.github/workflows/helm-charts.yaml
@@ -47,8 +47,8 @@ jobs:
             mv helm2.Chart.yaml Chart.yaml
             if [ "$(basename "$PWD")" = "operator" ]
             then
-                echo "Copying CRDS to templates folder, as helm2 doesn't have native crds support."
-                cp -R crds templates/crds
+                echo "Moving CRDS to templates folder, as helm2 doesn't have native crds support."
+                mv crds templates/crds
             fi
             echo "Restoring Helm2 Chart and replace Helm3 Chart temporary"
             [ ! -f helm2.requirements.lock ] || mv helm2.requirements.lock requirements.lock


### PR DESCRIPTION
Copying them over makes them appear twice in the chart, which doesn't work if helm3 is used to install the chart build for helm2.
This is sometimes required for organizations moving from helm 2 to 3.

This should not affect the helm3 build as the helm2 build happens after the helm3 build.