### PR TITLE
Replace latest with a upcomming alpha release

### DIFF
--- a/demo-apps/bodgeit/Chart.yaml
+++ b/demo-apps/bodgeit/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v2
-version: latest
+version: v2.5.0-alpha1
 type: application
 appVersion: "v1.4.0"
 name: bodgeit

--- a/demo-apps/bodgeit/helm2.Chart.yaml
+++ b/demo-apps/bodgeit/helm2.Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v1
-version: latest
+version: v2.5.0-alpha1
 type: application
 appVersion: "v1.4.0"
 name: bodgeit

--- a/demo-apps/dummy-ssh/Chart.yaml
+++ b/demo-apps/dummy-ssh/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v2
-version: latest
+version: v2.5.0-alpha1
 type: application
 appVersion: "v1.0.0"
 name: dummy-ssh

--- a/demo-apps/dummy-ssh/helm2.Chart.yaml
+++ b/demo-apps/dummy-ssh/helm2.Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v1
-version: latest
+version: v2.5.0-alpha1
 type: application
 appVersion: "v1.0.0"
 name: dummy-ssh

--- a/demo-apps/http-webhook/Chart.yaml
+++ b/demo-apps/http-webhook/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: latest
+version: v2.5.0-alpha1
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/demo-apps/juice-shop/Chart.yaml
+++ b/demo-apps/juice-shop/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v2
-version: latest
+version: v2.5.0-alpha1
 appVersion: "v12.4.0"
 name: juice-shop
 description: "OWASP Juice Shop: Probably the most modern and sophisticated insecure web application"

--- a/demo-apps/juice-shop/helm2.Chart.yaml
+++ b/demo-apps/juice-shop/helm2.Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v2
-version: latest
+version: v2.5.0-alpha1
 appVersion: "v12.4.0"
 name: juice-shop
 description: "OWASP Juice Shop: Probably the most modern and sophisticated insecure web application"

--- a/demo-apps/old-wordpress/Chart.yaml
+++ b/demo-apps/old-wordpress/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v2
-version: latest
+version: v2.5.0-alpha1
 appVersion: "4.0"
 name: old-wordpress
 description: "Insecure & Outdated Wordpress Instance: Never expose it to the internet!"

--- a/demo-apps/old-wordpress/helm2.Chart.yaml
+++ b/demo-apps/old-wordpress/helm2.Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v2
-version: latest
+version: v2.5.0-alpha1
 appVersion: "4.0"
 name: old-wordpress
 description: "Insecure & Outdated Wordpress Instance: Never expose it to the internet!"

--- a/demo-apps/swagger-petstore/Chart.yaml
+++ b/demo-apps/swagger-petstore/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v2
-version: latest
+version: v2.5.0-alpha1
 appVersion: "1.0.3"
 name: swagger-petstore
 description: "This is the sample petstore application"

--- a/demo-apps/swagger-petstore/helm2.Chart.yaml
+++ b/demo-apps/swagger-petstore/helm2.Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v2
-version: latest
+version: v2.5.0-alpha1
 appVersion: "1.0.3"
 name: swagger-petstore
 description: "This is the sample petstore application"

--- a/demo-apps/unsafe-https/Chart.yaml
+++ b/demo-apps/unsafe-https/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v2
-version: latest
+version: v2.5.0-alpha1
 type: application
 appVersion: "v1.0.0"
 name: unsafe-https

--- a/demo-apps/unsafe-https/helm2.Chart.yaml
+++ b/demo-apps/unsafe-https/helm2.Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v2
-version: latest
+version: v2.5.0-alpha1
 type: application
 appVersion: "v1.0.0"
 name: unsafe-https

--- a/hooks/declarative-subsequent-scans/Chart.yaml
+++ b/hooks/declarative-subsequent-scans/Chart.yaml
@@ -5,7 +5,7 @@ description: Starts possible subsequent security scans based on findings (e.g. o
 type: application
 
 # version - gets automatically set to the secureCodeBox release version when the helm charts gets published
-version: latest
+version: v2.5.0-alpha1
 kubeVersion: ">=v1.11.0-0"
 
 dependencies: []

--- a/hooks/declarative-subsequent-scans/helm2.Chart.yaml
+++ b/hooks/declarative-subsequent-scans/helm2.Chart.yaml
@@ -5,5 +5,5 @@ description: Starts possible subsequent security scans based on findings (e.g. o
 type: application
 
 # version - gets automatically set to the secureCodeBox release version when the helm charts gets published
-version: latest
+version: v2.5.0-alpha1
 kubeVersion: ">=v1.11.0-0"

--- a/hooks/finding-post-processing/Chart.yaml
+++ b/hooks/finding-post-processing/Chart.yaml
@@ -19,7 +19,7 @@ description: Lets you add or override a field to every finding that meets specif
 type: application
 
 # version - gets automatically set to the secureCodeBox release version when the helm charts gets published
-version: latest
+version: v2.5.0-alpha1
 kubeVersion: ">=v1.11.0-0"
 
 dependencies: []

--- a/hooks/finding-post-processing/helm2.Chart.yaml
+++ b/hooks/finding-post-processing/helm2.Chart.yaml
@@ -19,5 +19,5 @@ description: Lets you add or override a field to every finding that meets specif
 type: application
 
 # version - gets automatically set to the secureCodeBox release version when the helm charts gets published
-version: latest
+version: v2.5.0-alpha1
 kubeVersion: ">=v1.11.0-0"

--- a/hooks/generic-webhook/Chart.yaml
+++ b/hooks/generic-webhook/Chart.yaml
@@ -5,7 +5,7 @@ description: Lets you send http webhooks after scans are completed
 type: application
 
 # version - gets automatically set to the secureCodeBox release version when the helm charts gets published
-version: latest
+version: v2.5.0-alpha1
 kubeVersion: ">=v1.11.0-0"
 
 dependencies: []

--- a/hooks/generic-webhook/helm2.Chart.yaml
+++ b/hooks/generic-webhook/helm2.Chart.yaml
@@ -5,5 +5,5 @@ description: Lets you send http webhooks after scans are completed
 type: application
 
 # version - gets automatically set to the secureCodeBox release version when the helm charts gets published
-version: latest
+version: v2.5.0-alpha1
 kubeVersion: ">=v1.11.0-0"

--- a/hooks/persistence-elastic/Chart.yaml
+++ b/hooks/persistence-elastic/Chart.yaml
@@ -5,7 +5,7 @@ description: The elastic persistence provider persists secureCodeBox findings in
 type: application
 
 # version - gets automatically set to the secureCodeBox release version when the helm charts gets published
-version: latest
+version: v2.5.0-alpha1
 
 appVersion: 7.9.2
 kubeVersion: ">=v1.11.0-0"

--- a/hooks/persistence-elastic/helm2.Chart.yaml
+++ b/hooks/persistence-elastic/helm2.Chart.yaml
@@ -5,6 +5,6 @@ description: The elastic persistence provider persists secureCodeBox findings in
 type: application
 
 # version - gets automatically set to the secureCodeBox release version when the helm charts gets published
-version: latest
+version: v2.5.0-alpha1
 appVersion: 7.6.1
 kubeVersion: ">=v1.11.0-0"

--- a/hooks/teams-webhook/Chart.yaml
+++ b/hooks/teams-webhook/Chart.yaml
@@ -19,7 +19,7 @@ description: Lets you send a findings result summary as webhook to MS Teams, aft
 type: application
 
 # version - gets automatically set to the secureCodeBox release version when the helm charts gets published
-version: latest
+version: v2.5.0-alpha1
 kubeVersion: ">=v1.11.0-0"
 
 dependencies: []

--- a/hooks/teams-webhook/helm2.Chart.yaml
+++ b/hooks/teams-webhook/helm2.Chart.yaml
@@ -19,5 +19,5 @@ description: Lets you send a findings result summary as webhook to MS Teams, aft
 type: application
 
 # version - gets automatically set to the secureCodeBox release version when the helm charts gets published
-version: latest
+version: v2.5.0-alpha1
 kubeVersion: ">=v1.11.0-0"

--- a/hooks/update-field/Chart.yaml
+++ b/hooks/update-field/Chart.yaml
@@ -5,7 +5,7 @@ description: Lets you add or override a field to every finding
 type: application
 
 # version - gets automatically set to the secureCodeBox release version when the helm charts gets published
-version: latest
+version: v2.5.0-alpha1
 kubeVersion: ">=v1.11.0-0"
 
 dependencies: []

--- a/hooks/update-field/helm2.Chart.yaml
+++ b/hooks/update-field/helm2.Chart.yaml
@@ -5,5 +5,5 @@ description: Lets you add or override a field to every finding
 type: application
 
 # version - gets automatically set to the secureCodeBox release version when the helm charts gets published
-version: latest
+version: v2.5.0-alpha1
 kubeVersion: ">=v1.11.0-0"

--- a/operator/Chart.yaml
+++ b/operator/Chart.yaml
@@ -5,7 +5,7 @@ description: secureCodeBox Operator to automate the execution of security scans 
 type: application
 
 # version - gets automatically set to the secureCodeBox release version when the helm charts gets published
-version: latest
+version: v2.5.0-alpha1
 kubeVersion: ">=v1.11.0-0"
 
 keywords:

--- a/operator/helm2.Chart.yaml
+++ b/operator/helm2.Chart.yaml
@@ -5,7 +5,7 @@ description: secureCodeBox Operator to automate the execution of security scans 
 type: application
 
 # version - gets automatically set to the secureCodeBox release version when the helm charts gets published
-version: latest
+version: v2.5.0-alpha1
 kubeVersion: ">=v1.11.0-0"
 
 keywords:

--- a/scanners/amass/Chart.yaml
+++ b/scanners/amass/Chart.yaml
@@ -4,7 +4,7 @@ description: A Helm chart for the Amass security scanner that integrates with th
 
 type: application
 # version - gets automatically set to the secureCodeBox release version when the helm charts gets published
-version: latest
+version: v2.5.0-alpha1
 # Latest Amass release version can be found here: https://github.com/OWASP/Amass/releases 
 appVersion: "v3.10.5"
 kubeVersion: ">=v1.11.0-0"

--- a/scanners/amass/helm2.Chart.yaml
+++ b/scanners/amass/helm2.Chart.yaml
@@ -4,7 +4,7 @@ description: A Helm chart for the Amass security scanner that integrates with th
 
 type: application
 # version - gets automatically set to the secureCodeBox release version when the helm charts gets published
-version: latest
+version: v2.5.0-alpha1
 appVersion: "v3.10.4"
 kubeVersion: ">=v1.11.0-0"
 

--- a/scanners/git-repo-scanner/Chart.yaml
+++ b/scanners/git-repo-scanner/Chart.yaml
@@ -4,7 +4,7 @@ description: A Helm chart for the git-repo-scanner that integrates with the secu
 
 type: application
 # version - gets automatically set to the secureCodeBox release version when the helm charts gets published
-version: latest
+version: v2.5.0-alpha1
 kubeVersion: ">=v1.11.0-0"
 
 keywords:

--- a/scanners/git-repo-scanner/helm2.Chart.yaml
+++ b/scanners/git-repo-scanner/helm2.Chart.yaml
@@ -4,7 +4,7 @@ description: A Helm chart for the git-repo-scanner that integrates with the secu
 
 type: application
 # version - gets automatically set to the secureCodeBox release version when the helm charts gets published
-version: latest
+version: v2.5.0-alpha1
 kubeVersion: ">=v1.11.0-0"
 
 keywords:

--- a/scanners/gitleaks/Chart.yaml
+++ b/scanners/gitleaks/Chart.yaml
@@ -4,7 +4,7 @@ description: A Helm chart for the gitleaks repository scanner that integrates wi
 
 type: application
 # version - gets automatically set to the secureCodeBox release version when the helm charts gets published
-version: latest
+version: v2.5.0-alpha1
 appVersion: v6.1.2
 kubeVersion: ">=v1.11.0-0"
 

--- a/scanners/gitleaks/helm2.Chart.yaml
+++ b/scanners/gitleaks/helm2.Chart.yaml
@@ -4,7 +4,7 @@ description: A Helm chart for the gitleaks repository scanner that integrates wi
 
 type: application
 # version - gets automatically set to the secureCodeBox release version when the helm charts gets published
-version: latest
+version: v2.5.0-alpha1
 appVersion: v6.1.2
 kubeVersion: ">=v1.11.0-0"
 

--- a/scanners/kube-hunter/Chart.yaml
+++ b/scanners/kube-hunter/Chart.yaml
@@ -4,7 +4,7 @@ description: A Helm chart for the kube-hunter security scanner that integrates w
 
 type: application
 # version - gets automatically set to the secureCodeBox release version when the helm charts gets published
-version: latest
+version: v2.5.0-alpha1
 appVersion: 0.3.0
 kubeVersion: ">=v1.11.0-0"
 

--- a/scanners/kube-hunter/helm2.Chart.yaml
+++ b/scanners/kube-hunter/helm2.Chart.yaml
@@ -4,7 +4,7 @@ description: A Helm chart for the kube-hunter security scanner that integrates w
 
 type: application
 # version - gets automatically set to the secureCodeBox release version when the helm charts gets published
-version: latest
+version: v2.5.0-alpha1
 appVersion: "0.3.0"
 kubeVersion: ">=v1.11.0-0"
 

--- a/scanners/kubeaudit/Chart.yaml
+++ b/scanners/kubeaudit/Chart.yaml
@@ -3,7 +3,7 @@ name: kubeaudit
 description: A Helm chart for the kubeaudit security scanner that integrates with the secureCodeBox.
 
 type: application
-version: latest
+version: v2.5.0-alpha1
 appVersion: v0.11.5
 kubeVersion: ">=v1.11.0-0"
 

--- a/scanners/kubeaudit/helm2.Chart.yaml
+++ b/scanners/kubeaudit/helm2.Chart.yaml
@@ -3,7 +3,7 @@ name: kubeaudit
 description: A Helm chart for the kubeaudit security scanner that integrates with the secureCodeBox.
 
 type: application
-version: latest
+version: v2.5.0-alpha1
 appVersion: "v0.11.5"
 kubeVersion: ">=v1.11.0-0"
 

--- a/scanners/ncrack/Chart.yaml
+++ b/scanners/ncrack/Chart.yaml
@@ -4,7 +4,7 @@ description: A Helm chart for the NCRACK security Scanner that integrates with t
 
 type: application
 # version - gets automatically set to the secureCodeBox release version when the helm charts gets published
-version: latest
+version: v2.5.0-alpha1
 appVersion: 0.7
 kubeVersion: ">=v1.11.0-0"
 

--- a/scanners/ncrack/helm2.Chart.yaml
+++ b/scanners/ncrack/helm2.Chart.yaml
@@ -4,7 +4,7 @@ description: A Helm chart for the NCRACK security Scanner that integrates with t
 
 type: application
 # version - gets automatically set to the secureCodeBox release version when the helm charts gets published
-version: latest
+version: v2.5.0-alpha1
 appVersion: 0.7
 kubeVersion: ">=v1.11.0-0"
 

--- a/scanners/nikto/Chart.yaml
+++ b/scanners/nikto/Chart.yaml
@@ -4,7 +4,7 @@ description: A Helm chart for the Nikto security scanner that integrates with th
 
 type: application
 # version - gets automatically set to the secureCodeBox release version when the helm charts gets published
-version: latest
+version: v2.5.0-alpha1
 # appVersion - Nikto doesn't really version its releases
 appVersion: latest
 kubeVersion: ">=v1.11.0-0"

--- a/scanners/nikto/helm2.Chart.yaml
+++ b/scanners/nikto/helm2.Chart.yaml
@@ -4,7 +4,7 @@ description: A Helm chart for the Nikto security scanner that integrates with th
 
 type: application
 # version - gets automatically set to the secureCodeBox release version when the helm charts gets published
-version: latest
+version: v2.5.0-alpha1
 # appVersion - Nikto doesn't really version its releases
 appVersion: latest
 kubeVersion: ">=v1.11.0-0"

--- a/scanners/nmap/Chart.yaml
+++ b/scanners/nmap/Chart.yaml
@@ -4,7 +4,7 @@ description: A Helm chart for the NMAP security Scanner that integrates with the
 
 type: application
 # version - gets automatically set to the secureCodeBox release version when the helm charts gets published
-version: latest
+version: v2.5.0-alpha1
 appVersion: 7.91-r0
 kubeVersion: ">=v1.11.0-0"
 

--- a/scanners/nmap/helm2.Chart.yaml
+++ b/scanners/nmap/helm2.Chart.yaml
@@ -4,7 +4,7 @@ description: A Helm chart for the NMAP security Scanner that integrates with the
 
 type: application
 # version - gets automatically set to the secureCodeBox release version when the helm charts gets published
-version: latest
+version: v2.5.0-alpha1
 appVersion: 7.80-r2
 kubeVersion: ">=v1.11.0-0"
 

--- a/scanners/screenshooter/Chart.yaml
+++ b/scanners/screenshooter/Chart.yaml
@@ -4,7 +4,7 @@ description: A Helm chart for the Screenshooter that integrates with the secureC
 
 type: application
 # version - gets automatically set to the secureCodeBox release version when the helm charts gets published
-version: latest
+version: v2.5.0-alpha1
 kubeVersion: ">=v1.11.0-0"
 
 keywords:

--- a/scanners/screenshooter/helm2.Chart.yaml
+++ b/scanners/screenshooter/helm2.Chart.yaml
@@ -4,7 +4,7 @@ description: A Helm chart for the Screenshooter that integrates with the secureC
 
 type: application
 # version - gets automatically set to the secureCodeBox release version when the helm charts gets published
-version: latest
+version: v2.5.0-alpha1
 kubeVersion: ">=v1.11.0-0"
 
 keywords:

--- a/scanners/ssh-scan/Chart.yaml
+++ b/scanners/ssh-scan/Chart.yaml
@@ -4,7 +4,7 @@ description: A Helm chart for the SSH_Scan security scanner that integrates with
 
 type: application
 # version - gets automatically set to the secureCodeBox release version when the helm charts gets published
-version: latest
+version: v2.5.0-alpha1
 appVersion: "0.0.43"
 kubeVersion: ">=v1.11.0-0"
 

--- a/scanners/ssh-scan/helm2.Chart.yaml
+++ b/scanners/ssh-scan/helm2.Chart.yaml
@@ -4,7 +4,7 @@ description: A Helm chart for the SSH_Scan security scanner that integrates with
 
 type: application
 # version - gets automatically set to the secureCodeBox release version when the helm charts gets published
-version: latest
+version: v2.5.0-alpha1
 appVersion: "0.0.43"
 kubeVersion: ">=v1.11.0-0"
 

--- a/scanners/sslyze/Chart.yaml
+++ b/scanners/sslyze/Chart.yaml
@@ -4,7 +4,7 @@ description: A Helm chart for the SSLyze security scanner that integrates with t
 
 type: application
 # version - gets automatically set to the secureCodeBox release version when the helm charts gets published
-version: latest
+version: v2.5.0-alpha1
 appVersion: v3.0.6
 kubeVersion: ">=v1.11.0-0"
 

--- a/scanners/sslyze/helm2.Chart.yaml
+++ b/scanners/sslyze/helm2.Chart.yaml
@@ -4,7 +4,7 @@ description: A Helm chart for the SSLyze security scanner that integrates with t
 
 type: application
 # version - gets automatically set to the secureCodeBox release version when the helm charts gets published
-version: latest
+version: v2.5.0-alpha1
 appVersion: v3.0.6
 kubeVersion: ">=v1.11.0-0"
 

--- a/scanners/test-scan/Chart.yaml
+++ b/scanners/test-scan/Chart.yaml
@@ -4,7 +4,7 @@ description: A Helm chart to test the secureCodeBox operator
 
 type: application
 # version - gets automatically set to the secureCodeBox release version when the helm charts gets published
-version: latest
+version: v2.5.0-alpha1
 
 keywords:
   - security

--- a/scanners/test-scan/helm2.Chart.yaml
+++ b/scanners/test-scan/helm2.Chart.yaml
@@ -4,7 +4,7 @@ description: A Helm chart to test the secureCodeBox operator
 
 type: application
 # version - gets automatically set to the secureCodeBox release version when the helm charts gets published
-version: latest
+version: v2.5.0-alpha1
 
 keywords:
   - security

--- a/scanners/trivy/Chart.yaml
+++ b/scanners/trivy/Chart.yaml
@@ -4,7 +4,7 @@ description: A Helm chart for the trivy security scanner that integrates with th
 
 type: application
 # version - gets automatically set to the secureCodeBox release version when the helm charts gets published
-version: latest
+version: v2.5.0-alpha1
 appVersion: "0.6.0"
 kubeVersion: ">=v1.11.0-0"
 

--- a/scanners/trivy/helm2.Chart.yaml
+++ b/scanners/trivy/helm2.Chart.yaml
@@ -4,7 +4,7 @@ description: A Helm chart for the trivy security scanner that integrates with th
 
 type: application
 # version - gets automatically set to the secureCodeBox release version when the helm charts gets published
-version: latest
+version: v2.5.0-alpha1
 appVersion: "0.6.0"
 kubeVersion: ">=v1.11.0-0"
 

--- a/scanners/wpscan/Chart.yaml
+++ b/scanners/wpscan/Chart.yaml
@@ -4,7 +4,7 @@ description: A Helm chart for the WordPress security scanner that integrates wit
 
 type: application
 # version - gets automatically set to the secureCodeBox release version when the helm charts gets published
-version: latest
+version: v2.5.0-alpha1
 appVersion: latest
 kubeVersion: ">=v1.11.0-0"
 

--- a/scanners/wpscan/helm2.Chart.yaml
+++ b/scanners/wpscan/helm2.Chart.yaml
@@ -4,7 +4,7 @@ description: A Helm chart for the WordPress security scanner that integrates wit
 
 type: application
 # version - gets automatically set to the secureCodeBox release version when the helm charts gets published
-version: latest
+version: v2.5.0-alpha1
 appVersion: latest
 kubeVersion: ">=v1.11.0-0"
 

--- a/scanners/zap/Chart.yaml
+++ b/scanners/zap/Chart.yaml
@@ -4,7 +4,7 @@ description: A Helm chart for the OWASP ZAP security scanner that integrates wit
 
 type: application
 # version - gets automatically set to the secureCodeBox release version when the helm charts gets published
-version: latest
+version: v2.5.0-alpha1
 appVersion: "2.10.0"
 kubeVersion: ">=v1.11.0-0"
 

--- a/scanners/zap/helm2.Chart.yaml
+++ b/scanners/zap/helm2.Chart.yaml
@@ -4,7 +4,7 @@ description: A Helm chart for the OWASP ZAP security scanner that integrates wit
 
 type: application
 # version - gets automatically set to the secureCodeBox release version when the helm charts gets published
-version: latest
+version: v2.5.0-alpha1
 appVersion: v2.9.0
 kubeVersion: ">=v1.11.0-0"
 


### PR DESCRIPTION
Helm now validates the version on local install, making our "hack" to use a fixed "latest" version until we're publishing the chart not work anymore 😕
See: https://github.com/helm/helm/releases/tag/v3.5.2

This is only meant as a temporary workaround until we come up with a better / automated way to do this, as I dont really look forward to manually clone the repo and run a search and replace on the entire repo...