### PR TITLE
Fix Helm Chart Build

### DIFF
--- a/.github/workflows/helm-charts.yaml
+++ b/.github/workflows/helm-charts.yaml
@@ -18,6 +18,8 @@ jobs:
           PASSWORD: ${{ secrets.HELM_REGISTRY_PASSWORD }}
         run: |
           RELEASE_VERSION="${GITHUB_REF#refs/*/}"
+          # Remove leading 'v' from git tag to create valid semver
+          RELEASE_VERSION="${RELEASE_VERSION//v}"
           # Publish all helm3 charts in all folders containing a `Chart.yaml` file
           # https://github.com/koalaman/shellcheck/wiki/SC2044
           find . -type f -name Chart.yaml -print0 | while IFS= read -r -d '' chart; do
@@ -37,6 +39,8 @@ jobs:
           PASSWORD: ${{ secrets.HELM_REGISTRY_PASSWORD }}
         run: |
           RELEASE_VERSION="${GITHUB_REF#refs/*/}"
+          # Remove leading 'v' from git tag to create valid semver
+          RELEASE_VERSION="${RELEASE_VERSION//v}"
           # Publish all helm2 charts in all folders containing a `helm2.Chart.yaml` file
           # https://github.com/koalaman/shellcheck/wiki/SC2044
           find . -type f -name helm2.Chart.yaml -print0 | while IFS= read -r -d '' chart; do


### PR DESCRIPTION
We noticed that our current release process did not use the right docker
images anymore. This problem was created after switching to the new
build and push docker action because the images are now tagged with a
valid semver instead of a version with a leading 'v' but the release
tried to use the 'old' version style with a leading 'v'.

To resolve this issue we decided to trim the leading 'v' in our Release
Action because we want to have consistent tags in GitHub

Signed-off-by: Yannik Fuhrmeister <yannik.fuhrmeister@iteratec.com>
