### PR TITLE
Fix File Mount Options For Hooks

### DIFF
--- a/operator/controllers/execution/scans/hook_reconciler.go
+++ b/operator/controllers/execution/scans/hook_reconciler.go
@@ -421,6 +421,23 @@ func (r *ScanReconciler) createJobForHook(hook *executionv1.ScanCompletionHook, 
 	r.Log.V(8).Info("Configuring customCACerts for Hook")
 	injectCustomCACertsIfConfigured(job)
 
+	// Merge Env from HookTemplate
+	job.Spec.Template.Spec.Containers[0].Env = append(
+		job.Spec.Template.Spec.Containers[0].Env,
+
+		hook.Spec.Env...,
+	)
+	// Merge VolumeMounts from HookTemplate
+	job.Spec.Template.Spec.Containers[0].VolumeMounts = append(
+		job.Spec.Template.Spec.Containers[0].VolumeMounts,
+		hook.Spec.VolumeMounts...,
+	)
+	// Merge Volumes from HookTemplate
+	job.Spec.Template.Spec.Volumes = append(
+		job.Spec.Template.Spec.Volumes,
+		hook.Spec.Volumes...,
+	)
+
 	if err := ctrl.SetControllerReference(scan, job, r.Scheme); err != nil {
 		r.Log.Error(err, "Unable to set controllerReference on job", "job", job)
 		return "", err


### PR DESCRIPTION
Working on the notification-hook I noticed that the File Mount Option
for Hooks were defined in the CRD for hooks but they were never used on
job creation

Signed-off-by: Yannik Fuhrmeister <yannik.fuhrmeister@iteratec.com>
