### PR TITLE
[Bugfix] Fixing Angularjs Csti Scanner ⛑  HelmChart

### DIFF
--- a/scanners/angularjs-csti-scanner/Chart.yaml
+++ b/scanners/angularjs-csti-scanner/Chart.yaml
@@ -1,4 +1,4 @@
-apiVersion: v1
+apiVersion: v2
 name: angularja-csti-scanner
 description: A Helm chart for the  angularja csti scanner that integrates with the secureCodeBox.
 

--- a/scanners/angularjs-csti-scanner/Chart.yaml
+++ b/scanners/angularjs-csti-scanner/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
-name: angularja-csti-scanner
-description: A Helm chart for the  angularja csti scanner that integrates with the secureCodeBox.
+name: angularjs-csti-scanner
+description: A Helm chart for the angularjs csti scanner that integrates with the secureCodeBox.
 
 type: application
 # version - gets automatically set to the secureCodeBox release version when the helm charts gets published
@@ -13,7 +13,7 @@ keywords:
   - acstis
   - scanner
   - secureCodeBox
-home: https://docs.securecodebox.io/docs/scanners/angularja-csti-scanner
+home: https://docs.securecodebox.io/docs/scanners/angularjs-csti-scanner
 icon: https://docs.securecodebox.io/img/integrationIcons/Acstis.svg
 sources:
   - https://github.com/secureCodeBox/secureCodeBox

--- a/scanners/angularjs-csti-scanner/helm2.Chart.yaml
+++ b/scanners/angularjs-csti-scanner/helm2.Chart.yaml
@@ -1,4 +1,4 @@
-apiVersion: v1
+apiVersion: v2
 name: angularja-csti-scanner
 description: A Helm chart for the  angularja csti scanner that integrates with the secureCodeBox.
 

--- a/scanners/angularjs-csti-scanner/helm2.Chart.yaml
+++ b/scanners/angularjs-csti-scanner/helm2.Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
-name: angularja-csti-scanner
-description: A Helm chart for the  angularja csti scanner that integrates with the secureCodeBox.
+name: angularjs-csti-scanner
+description: A Helm chart for the angularjs csti scanner that integrates with the secureCodeBox.
 
 type: application
 # version - gets automatically set to the secureCodeBox release version when the helm charts gets published
@@ -12,7 +12,7 @@ keywords:
   - acstis
   - scanner
   - secureCodeBox
-home: https://docs.securecodebox.io/docs/scanners/angularja-csti-scanner
+home: https://docs.securecodebox.io/docs/scanners/angularjs-csti-scanner
 icon: https://docs.securecodebox.io/img/integrationIcons/Acstis.svg
 sources:
   - https://github.com/secureCodeBox/secureCodeBox

--- a/scanners/angularjs-csti-scanner/templates/angularjs-csti-scanner-scan-type.yaml
+++ b/scanners/angularjs-csti-scanner/templates/angularjs-csti-scanner-scan-type.yaml
@@ -17,7 +17,7 @@ spec:
           restartPolicy: OnFailure
           containers:
             - name: acstis-scanner
-              image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.appVersion }}"
+              image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
               command:
                 - "sh"
                 - "/wrapper.sh"


### PR DESCRIPTION
## Description
Fixing version and typos in Chart.yaml and helm2.Chart.yaml:
* apiVersion v1 -> apiVersion v2
* name angularja-csti-scanner -> name angularjs-csti-scanner

Fixing templates/angularjs-csti-scanner-scan-type.yaml:
* Changing image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.**appVersion** }}" to
              image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.**AppVersion** }}"

The last issue prevented the scanner from getting installed. 
