### PR TITLE
Remove Invalid Fields from ScanTypes and ParseDefinitions

### DIFF
--- a/operator/templates/rbac/auth_proxy_client_clusterrole.yaml
+++ b/operator/templates/rbac/auth_proxy_client_clusterrole.yaml
@@ -1,7 +1,7 @@
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   name: metrics-reader
 rules:
-- nonResourceURLs: ["/metrics"]
-  verbs: ["get"]
+  - nonResourceURLs: ["/metrics"]
+    verbs: ["get"]

--- a/scanners/amass/templates/amass-parse-definition.yaml
+++ b/scanners/amass/templates/amass-parse-definition.yaml
@@ -3,6 +3,5 @@ kind: ParseDefinition
 metadata:
   name: "amass-jsonl"
 spec:
-  handlesResultsType: amass-jsonl
   image: "{{ .Values.parserImage.repository }}:{{ .Values.parserImage.tag | default .Chart.Version }}"
   ttlSecondsAfterFinished: {{ .Values.parseJob.ttlSecondsAfterFinished }}

--- a/scanners/amass/templates/amass-scan-type.yaml
+++ b/scanners/amass/templates/amass-scan-type.yaml
@@ -37,7 +37,7 @@ spec:
             {{- toYaml .Values.scannerJob.extraContainers | nindent 12 }}
             {{- end }}
           volumes:
-            {{- toYaml .Values.scannerJob.extraVolumeMounts | nindent 12 }}
+            {{- toYaml .Values.scannerJob.extraVolumes | nindent 12 }}
 ---
 apiVersion: v1
 kind: ConfigMap

--- a/scanners/angularjs-csti-scanner/templates/angularjs-csti-scanner-parse-definition.yaml
+++ b/scanners/angularjs-csti-scanner/templates/angularjs-csti-scanner-parse-definition.yaml
@@ -3,6 +3,5 @@ kind: ParseDefinition
 metadata:
   name: "acstis-log"
 spec:
-  handlesResultsType: acstis-log
   image: "{{ .Values.parserImage.repository }}:{{ .Values.parserImage.tag | default .Chart.Version }}"
   ttlSecondsAfterFinished: {{ .Values.parseJob.ttlSecondsAfterFinished }}

--- a/scanners/git-repo-scanner/templates/git-repo-scanner-parse-definition.yaml
+++ b/scanners/git-repo-scanner/templates/git-repo-scanner-parse-definition.yaml
@@ -3,6 +3,5 @@ kind: ParseDefinition
 metadata:
   name: "git-repo-scanner-json"
 spec:
-  handlesResultsType: git-repo-scanner-json
   image: "{{ .Values.parserImage.repository }}:{{ .Values.parserImage.tag | default .Chart.Version }}"
   ttlSecondsAfterFinished: {{ .Values.parseJob.ttlSecondsAfterFinished }}

--- a/scanners/gitleaks/templates/gitleaks-parse-definition.yaml
+++ b/scanners/gitleaks/templates/gitleaks-parse-definition.yaml
@@ -3,6 +3,5 @@ kind: ParseDefinition
 metadata:
   name: "gitleaks-json"
 spec:
-  handlesResultsType: gitleaks-json
   image: "{{ .Values.parserImage.repository }}:{{ .Values.parserImage.tag | default .Chart.Version }}"
   ttlSecondsAfterFinished: {{ .Values.parseJob.ttlSecondsAfterFinished }}

--- a/scanners/kube-hunter/templates/kube-hunter-parse-definition.yaml
+++ b/scanners/kube-hunter/templates/kube-hunter-parse-definition.yaml
@@ -3,6 +3,5 @@ kind: ParseDefinition
 metadata:
   name: "kube-hunter-json"
 spec:
-  handlesResultsType: kube-hunter-json
   image: "{{ .Values.parserImage.repository }}:{{ .Values.parserImage.tag | default .Chart.Version }}"
   ttlSecondsAfterFinished: {{ .Values.parseJob.ttlSecondsAfterFinished }}

--- a/scanners/kubeaudit/templates/kubeaudit-parse-definition.yaml
+++ b/scanners/kubeaudit/templates/kubeaudit-parse-definition.yaml
@@ -3,6 +3,5 @@ kind: ParseDefinition
 metadata:
   name: "kubeaudit-jsonl"
 spec:
-  handlesResultsType: kubeaudit-jsonl
   image: "{{ .Values.parserImage.repository }}:{{ .Values.parserImage.tag | default .Chart.Version }}"
   ttlSecondsAfterFinished: {{ .Values.parseJob.ttlSecondsAfterFinished }}

--- a/scanners/kubeaudit/templates/kubeaudit-rbac.yaml
+++ b/scanners/kubeaudit/templates/kubeaudit-rbac.yaml
@@ -6,7 +6,7 @@ metadata:
   namespace: {{ .Release.Namespace}}
 ---
 kind: RoleBinding
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: kubeaudit-lurcher
   namespace: {{ .Release.Namespace}}
@@ -21,7 +21,7 @@ roleRef:
 ---  
 {{- if eq .Values.kubeauditScope "namespace" }}
 kind: Role
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: kubeaudit
   namespace: {{ .Release.Namespace}}
@@ -49,7 +49,7 @@ rules:
     verbs: ["get", "list"]
 ---
 kind: RoleBinding
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: kubeaudit
   namespace: {{ .Release.Namespace}}
@@ -64,7 +64,7 @@ roleRef:
 {{- end }}
 {{- if eq .Values.kubeauditScope "cluster" }}
 kind: ClusterRole
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: kubeaudit
 rules:
@@ -91,7 +91,7 @@ rules:
     verbs: ["get", "list"]
 ---
 kind: ClusterRoleBinding
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: kubeaudit
 subjects:

--- a/scanners/ncrack/templates/ncrack-parse-definition.yaml
+++ b/scanners/ncrack/templates/ncrack-parse-definition.yaml
@@ -3,7 +3,6 @@ kind: ParseDefinition
 metadata:
   name: "ncrack-xml"
 spec:
-  handlesResultsType: ncrack-xml
   image: "{{ .Values.parserImage.repository }}:{{ .Values.parserImage.tag | default .Chart.Version }}"
   ttlSecondsAfterFinished: {{ .Values.parseJob.ttlSecondsAfterFinished }}
   {{- if .Values.encryptPasswords.existingSecret }}

--- a/scanners/nikto/templates/nikto-parse-definition.yaml
+++ b/scanners/nikto/templates/nikto-parse-definition.yaml
@@ -3,6 +3,5 @@ kind: ParseDefinition
 metadata:
   name: "nikto-json"
 spec:
-  handlesResultsType: nikto-json
   image: "{{ .Values.parserImage.repository }}:{{ .Values.parserImage.tag | default .Chart.Version }}"
   ttlSecondsAfterFinished: {{ .Values.parseJob.ttlSecondsAfterFinished }}

--- a/scanners/nmap/templates/nmap-parse-definition.yaml
+++ b/scanners/nmap/templates/nmap-parse-definition.yaml
@@ -3,6 +3,5 @@ kind: ParseDefinition
 metadata:
   name: "nmap-xml"
 spec:
-  handlesResultsType: nmap-xml
   image: "{{ .Values.parserImage.repository }}:{{ .Values.parserImage.tag | default .Chart.Version }}"
   ttlSecondsAfterFinished: {{ .Values.parseJob.ttlSecondsAfterFinished }}

--- a/scanners/screenshooter/templates/screenshooter-parse-definition.yaml
+++ b/scanners/screenshooter/templates/screenshooter-parse-definition.yaml
@@ -3,6 +3,5 @@ kind: ParseDefinition
 metadata:
   name: "screenshot-png"
 spec:
-  handlesResultsType: screenshot-png
   image: "{{ .Values.parserImage.repository }}:{{ .Values.parserImage.tag | default .Chart.Version }}"
   ttlSecondsAfterFinished: {{ .Values.parseJob.ttlSecondsAfterFinished }}

--- a/scanners/ssh-scan/templates/ssh-scan-parse-definition.yaml
+++ b/scanners/ssh-scan/templates/ssh-scan-parse-definition.yaml
@@ -3,6 +3,5 @@ kind: ParseDefinition
 metadata:
   name: "ssh-scan-json"
 spec:
-  handlesResultsType: ssh-scan-json
   image: "{{ .Values.parserImage.repository }}:{{ .Values.parserImage.tag | default .Chart.Version }}"
   ttlSecondsAfterFinished: {{ .Values.parseJob.ttlSecondsAfterFinished }}

--- a/scanners/ssh-scan/templates/ssh-scan-scan-type.yaml
+++ b/scanners/ssh-scan/templates/ssh-scan-scan-type.yaml
@@ -3,7 +3,6 @@ kind: ScanType
 metadata:
   name: "ssh-scan"
 spec:
-  name: "ssh-scan"
   extractResults:
     type: ssh-scan-json
     location: "/home/securecodebox/ssh-scan-results.json"

--- a/scanners/sslyze/templates/sslyze-parse-definition.yaml
+++ b/scanners/sslyze/templates/sslyze-parse-definition.yaml
@@ -3,6 +3,5 @@ kind: ParseDefinition
 metadata:
   name: "sslyze-json"
 spec:
-  handlesResultsType: sslyze-json
   image: "{{ .Values.parserImage.repository }}:{{ .Values.parserImage.tag | default .Chart.Version }}"
   ttlSecondsAfterFinished: {{ .Values.parseJob.ttlSecondsAfterFinished }}

--- a/scanners/test-scan/templates/test-scan-parse-definition.yaml
+++ b/scanners/test-scan/templates/test-scan-parse-definition.yaml
@@ -3,6 +3,5 @@ kind: ParseDefinition
 metadata:
   name: "test-txt"
 spec:
-  handlesResultsType: test-txt
   image: "{{ .Values.parserImage.repository }}:{{ .Values.parserImage.tag | default .Chart.Version }}"
   ttlSecondsAfterFinished: {{ .Values.parseJob.ttlSecondsAfterFinished }}

--- a/scanners/trivy/templates/trivy-parse-definition.yaml
+++ b/scanners/trivy/templates/trivy-parse-definition.yaml
@@ -3,6 +3,5 @@ kind: ParseDefinition
 metadata:
   name: "trivy-json"
 spec:
-  handlesResultsType: trivy-json
   image: "{{ .Values.parserImage.repository }}:{{ .Values.parserImage.tag | default .Chart.Version }}"
   ttlSecondsAfterFinished: {{ .Values.parseJob.ttlSecondsAfterFinished }}

--- a/scanners/wpscan/templates/wpscan-parse-definition.yaml
+++ b/scanners/wpscan/templates/wpscan-parse-definition.yaml
@@ -3,6 +3,5 @@ kind: ParseDefinition
 metadata:
   name: "wpscan-json"
 spec:
-  handlesResultsType: wpscan-json
   image: "{{ .Values.parserImage.repository }}:{{ .Values.parserImage.tag | default .Chart.Version }}"
   ttlSecondsAfterFinished: {{ .Values.parseJob.ttlSecondsAfterFinished }}

--- a/scanners/wpscan/templates/wpscan-scan-type.yaml
+++ b/scanners/wpscan/templates/wpscan-scan-type.yaml
@@ -3,7 +3,6 @@ kind: ScanType
 metadata:
   name: "wpscan"
 spec:
-  name: "wpscan"
   extractResults:
     type: wpscan-json
     location: "/home/securecodebox/wpscan-results.json"

--- a/scanners/zap/templates/zap-parse-definition.yaml
+++ b/scanners/zap/templates/zap-parse-definition.yaml
@@ -3,6 +3,5 @@ kind: ParseDefinition
 metadata:
   name: "zap-xml"
 spec:
-  handlesResultsType: zap-xml
   image: "{{ .Values.parserImage.repository }}:{{ .Values.parserImage.tag | default .Chart.Version }}"
   ttlSecondsAfterFinished: {{ .Values.parseJob.ttlSecondsAfterFinished }}


### PR DESCRIPTION
These changes should help with #399 as this fixes invalid fields we've accidentally added to some of our CR which will cause errors once we update the CRD from `v1beta1` to `v1`.

- Removed deprecated and invalid `handlesResultsType` field from ParseDefinitions
- Removed invalid `spec.name` field from some ScanTypes
- Updated the last two remainders of `rbac.authorization.k8s.io/v1beta1` ClusterRoles to `rbac.authorization.k8s.io/v1`. These look like they were introduced accidentally, as we're already using the new apiVersion in all other places.

