### PR TITLE
Allow to Configure DefectDojo Test Titles via Scan Annotations

### DIFF
--- a/hooks/persistence-defectdojo/README.md
+++ b/hooks/persistence-defectdojo/README.md
@@ -59,6 +59,7 @@ can add these via annotation to the scan. See examples below.
 | `defectdojo.securecodebox.io/engagement-name`    | Name of the Engagement     | Scan Name                                                            | Will be automatically created if not Engagement with that name **and** version exists |
 | `defectdojo.securecodebox.io/engagement-version` | Engagement Version         | Nothing                                                              |                                                                                       |
 | `defectdojo.securecodebox.io/engagement-tags`    | Engagement Tags            | Nothing                                                              | Only used when creating the Product not used for updating                             |
+| `defectdojo.securecodebox.io/test-title`         | Test Title                 | Scan Name                                                            |                                                                                       |
 
 ### Simple Example Scans
 

--- a/hooks/persistence-defectdojo/README.md
+++ b/hooks/persistence-defectdojo/README.md
@@ -100,6 +100,7 @@ metadata:
     defectdojo.securecodebox.io/engagement-name: "Juice Shop"
     defectdojo.securecodebox.io/engagement-version: "v12.6.1"
     defectdojo.securecodebox.io/engagement-tags: "automated,daily"
+    defectdojo.securecodebox.io/test-title: "Juice Shop - v12.6.1"
 spec:
   interval: 24h
   scanSpec:

--- a/hooks/persistence-defectdojo/README.md.gotmpl
+++ b/hooks/persistence-defectdojo/README.md.gotmpl
@@ -59,6 +59,7 @@ can add these via annotation to the scan. See examples below.
 | `defectdojo.securecodebox.io/engagement-name`    | Name of the Engagement     | Scan Name                                                            | Will be automatically created if not Engagement with that name **and** version exists |
 | `defectdojo.securecodebox.io/engagement-version` | Engagement Version         | Nothing                                                              |                                                                                       |
 | `defectdojo.securecodebox.io/engagement-tags`    | Engagement Tags            | Nothing                                                              | Only used when creating the Product not used for updating                             |
+| `defectdojo.securecodebox.io/test-title`         | Test Title                 | Scan Name                                                            |                                                                                       |
 
 ### Simple Example Scans
 

--- a/hooks/persistence-defectdojo/README.md.gotmpl
+++ b/hooks/persistence-defectdojo/README.md.gotmpl
@@ -100,6 +100,7 @@ metadata:
     defectdojo.securecodebox.io/engagement-name: "Juice Shop"
     defectdojo.securecodebox.io/engagement-version: "v12.6.1"
     defectdojo.securecodebox.io/engagement-tags: "automated,daily"
+    defectdojo.securecodebox.io/test-title: "Juice Shop - v12.6.1"
 spec:
   interval: 24h
   scanSpec:

--- a/hooks/persistence-defectdojo/src/main/java/io/securecodebox/persistence/models/Scan.java
+++ b/hooks/persistence-defectdojo/src/main/java/io/securecodebox/persistence/models/Scan.java
@@ -93,6 +93,10 @@ public class Scan extends V1Scan {
     return this.getKey(SecureCodeBoxScanAnnotations.PRODUCT_DESCRIPTION);
   }
 
+  public Optional<String> getTestTitle() {
+    return this.getKey(SecureCodeBoxScanAnnotations.TEST_TITLE);
+  }
+
   @AllArgsConstructor
   public enum SecureCodeBoxScanAnnotations {
     PRODUCT_TYPE("defectdojo.securecodebox.io/product-type-name"),
@@ -102,6 +106,7 @@ public class Scan extends V1Scan {
     ENGAGEMENT_NAME("defectdojo.securecodebox.io/engagement-name"),
     ENGAGEMENT_VERSION("defectdojo.securecodebox.io/engagement-version"),
     ENGAGEMENT_TAGS("defectdojo.securecodebox.io/engagement-tags"),
+    TEST_TITLE("defectdojo.securecodebox.io/test-title"),
     ;
 
     @Getter

--- a/hooks/persistence-defectdojo/src/main/java/io/securecodebox/persistence/strategies/VersionedEngagementsStrategy.java
+++ b/hooks/persistence-defectdojo/src/main/java/io/securecodebox/persistence/strategies/VersionedEngagementsStrategy.java
@@ -296,7 +296,7 @@ public class VersionedEngagementsStrategy implements Strategy {
    * Returns the DefectDojo Product Name related to the given scan.
    * If the Scan was created via a scheduled scan, the Name of the ScheduledScan should be preferred to the scans name.
    * 
-   * @param scan The scan the productName relates to.
+   * @param ownerReferences The ownerReferences of the child Object.
    * @return The productName related to the given scan.
    */
   protected String getProductNameForParentScan(List<V1OwnerReference> ownerReferences) {

--- a/hooks/persistence-defectdojo/src/main/java/io/securecodebox/persistence/strategies/VersionedEngagementsStrategy.java
+++ b/hooks/persistence-defectdojo/src/main/java/io/securecodebox/persistence/strategies/VersionedEngagementsStrategy.java
@@ -253,9 +253,10 @@ public class VersionedEngagementsStrategy implements Strategy {
 
     String scanType = ScanNameMapping.bySecureCodeBoxScanType(scan.getSpec().getScanType()).scanType.getTestType();
     TestType testType = testTypeService.searchUnique(TestType.builder().name(scanType).build()).orElseThrow(() -> new DefectDojoPersistenceException("Could not find test type '" + scanType + "' in DefectDojo API. DefectDojo might be running in an unsupported version."));
+    String testTitle = scan.getTestTitle().orElse(scan.getMetadata().getName());
 
     var test = Test.builder()
-      .title(scan.getMetadata().getName())
+      .title(testTitle)
       .description(descriptionGenerator.generate(scan))
       .testType(testType.getId())
       .targetStart(startDate)


### PR DESCRIPTION
This PR adds support for the DefectDojo hook to create a test with a fixed title, different from Scan name, configured via scan annotations.