### PR TITLE
Fix Crash in Wpscan Parser When No Wordpress Version Got Identified

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -3,3 +3,4 @@
 hooks/declarative-subsequent-scans/hook.js
 hooks/declarative-subsequent-scans/scan-helpers.js
 hooks/declarative-subsequent-scans/kubernetes-label-selector.js
+**/build/reports/*

--- a/.eslintrc
+++ b/.eslintrc
@@ -6,7 +6,7 @@
     "es6": true
   },
   "parserOptions": {
-    "ecmaVersion": 2018
+    "ecmaVersion": 2020
   },
   "extends": ["eslint:recommended", "plugin:security/recommended"],
   "plugins": ["prettier", "security"],

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
   "scripts": {
     "build": "npx typescript hook.ts --sourceMap",
     "test": "jest",
-    "lint": "eslint **/*.js"
+    "lint": "eslint '**/*.js'"
   },
   "keywords": [
     "secureCodeBox",

--- a/scanners/ncrack/parser/parser.js
+++ b/scanners/ncrack/parser/parser.js
@@ -2,6 +2,7 @@ const xml2js = require('xml2js');
 const crypto = require("crypto");
 const fs = require('fs');
 const util = require('util');
+// eslint-disable-next-line security/detect-non-literal-fs-filename
 const readFile = util.promisify(fs.readFile);
 
 async function parse (fileContent, scan, encryptionKeyLocation = process.env['ENCRYPTION_KEY_LOCATION']) {

--- a/scanners/wpscan/parser/__testFiles__/no-version-detected.json
+++ b/scanners/wpscan/parser/__testFiles__/no-version-detected.json
@@ -1,0 +1,176 @@
+{
+    "banner": {
+      "description": "WordPress Security Scanner by the WPScan Team",
+      "version": "3.8.17",
+      "authors": [
+        "@_WPScan_",
+        "@ethicalhack3r",
+        "@erwan_lr",
+        "@firefart"
+      ],
+      "sponsor": "Sponsored by Automattic - https://automattic.com/"
+    },
+    "start_time": 1621260955,
+    "start_memory": 45334528,
+    "target_url": "https://wp.example.com/",
+    "target_ip": "203.0.113.42",
+    "effective_url": "https://wp.example.com/",
+    "interesting_findings": [
+      {
+        "url": "https://wp.example.com/",
+        "to_s": "Headers",
+        "type": "headers",
+        "found_by": "Headers (Passive Detection)",
+        "confidence": 100,
+        "confirmed_by": {
+  
+        },
+        "references": {
+  
+        },
+        "interesting_entries": [
+          "Server: Apache",
+          "Expect-CT: max-age=86400, enforce"
+        ]
+      },
+      {
+        "url": "https://wp.example.com/robots.txt",
+        "to_s": "robots.txt found: https://wp.example.com/robots.txt",
+        "type": "robots_txt",
+        "found_by": "Robots Txt (Aggressive Detection)",
+        "confidence": 100,
+        "confirmed_by": {
+  
+        },
+        "references": {
+  
+        },
+        "interesting_entries": [
+          "/wp-admin/",
+          "/wp-admin/admin-ajax.php"
+        ]
+      },
+      {
+        "url": "https://wp.example.com/readme.html",
+        "to_s": "WordPress readme found: https://wp.example.com/readme.html",
+        "type": "readme",
+        "found_by": "Direct Access (Aggressive Detection)",
+        "confidence": 100,
+        "confirmed_by": {
+  
+        },
+        "references": {
+  
+        },
+        "interesting_entries": [
+  
+        ]
+      },
+      {
+        "url": "https://wp.example.com/wp-content/mu-plugins/",
+        "to_s": "This site has 'Must Use Plugins': https://wp.example.com/wp-content/mu-plugins/",
+        "type": "mu_plugins",
+        "found_by": "Direct Access (Aggressive Detection)",
+        "confidence": 80,
+        "confirmed_by": {
+  
+        },
+        "references": {
+          "url": [
+            "http://codex.wordpress.org/Must_Use_Plugins"
+          ]
+        },
+        "interesting_entries": [
+  
+        ]
+      },
+      {
+        "url": "https://wp.example.com/wp-cron.php",
+        "to_s": "The external WP-Cron seems to be enabled: https://wp.example.com/wp-cron.php",
+        "type": "wp_cron",
+        "found_by": "Direct Access (Aggressive Detection)",
+        "confidence": 60,
+        "confirmed_by": {
+  
+        },
+        "references": {
+          "url": [
+            "https://www.iplocation.net/defend-wordpress-from-ddos",
+            "https://github.com/wpscanteam/wpscan/issues/1299"
+          ]
+        },
+        "interesting_entries": [
+  
+        ]
+      }
+    ],
+    "version": null,
+    "main_theme": {
+      "slug": "twentyseventeen",
+      "location": "https://wp.example.com/wp-content/themes/twentyseventeen/",
+      "latest_version": "2.6",
+      "last_updated": "2021-03-09T00:00:00.000Z",
+      "outdated": true,
+      "readme_url": "https://wp.example.com/wp-content/themes/twentyseventeen/README.txt",
+      "directory_listing": false,
+      "error_log_url": null,
+      "style_url": "https://wp.example.com/wp-content/themes/twentyseventeen/style.css?ver=5.3.8",
+      "style_name": "Twenty Seventeen",
+      "style_uri": "https://wordpress.org/themes/twentyseventeen/",
+      "description": "Twenty Seventeen brings your site to life with header video and immersive featured images. With a focus on business sites, it features multiple sections on the front page as well as widgets, navigation and social menus, a logo, and more. Personalize its asymmetrical grid with a custom color scheme and showcase your multimedia content with post formats. Our default theme for 2017 works great in many languages, for any abilities, and on any device.",
+      "author": "the WordPress team",
+      "author_uri": "https://wordpress.org/",
+      "template": null,
+      "license": "GNU General Public License v2 or later",
+      "license_uri": "http://www.gnu.org/licenses/gpl-2.0.html",
+      "tags": "one-column, two-columns, right-sidebar, flexible-header, accessibility-ready, custom-colors, custom-header, custom-menu, custom-logo, editor-style, featured-images, footer-widgets, post-formats, rtl-language-support, sticky-post, theme-options, threaded-comments, translation-ready",
+      "text_domain": "twentyseventeen",
+      "found_by": "Css Style In Homepage (Passive Detection)",
+      "confidence": 100,
+      "interesting_entries": [
+  
+      ],
+      "confirmed_by": {
+        "Css Style In 404 Page (Passive Detection)": {
+          "confidence": 70,
+          "interesting_entries": [
+  
+          ]
+        }
+      },
+      "vulnerabilities": [
+  
+      ],
+      "version": {
+        "number": "2.2",
+        "confidence": 80,
+        "found_by": "Style (Passive Detection)",
+        "interesting_entries": [
+          "https://wp.example.com/wp-content/themes/twentyseventeen/style.css?ver=5.3.8, Match: 'Version: 2.2'"
+        ],
+        "confirmed_by": {
+  
+        }
+      },
+      "parents": [
+  
+      ]
+    },
+    "plugins": {
+  
+    },
+    "vuln_api": {
+      "error": "No WPScan API Token given, as a result vulnerability data has not been output.\nYou can get a free API token with 25 daily requests by registering at https://wpscan.com/register"
+    },
+    "stop_time": 1621261086,
+    "elapsed": 130,
+    "requests_done": 3734,
+    "cached_requests": 9,
+    "data_sent": 1110616,
+    "data_sent_humanised": "1.059 MB",
+    "data_received": 20758381,
+    "data_received_humanised": "19.797 MB",
+    "used_memory": 256139264,
+    "used_memory_humanised": "244.273 MB"
+  }
+  

--- a/scanners/wpscan/parser/parser.js
+++ b/scanners/wpscan/parser/parser.js
@@ -2,14 +2,13 @@
  * Convert the WPScan file / json into secureCodeBox Findings
  */
 async function parse(scanResults) {
+  const wpscanVersion = scanResults.banner.version;
+  const wpscanRequestsDone = scanResults.requests_done;
 
-  const wpscanVersion       = scanResults.banner.version;
-  const wpscanRequestsDone  = scanResults.requests_done;
-  
   const targetUrl = scanResults.target_url;
-  const targetIp  = scanResults.target_ip;
+  const targetIp = scanResults.target_ip;
 
-  const wp            = scanResults.version
+  const wp = scanResults.version;
 
   const findings = [];
 
@@ -30,19 +29,19 @@ async function parse(scanResults) {
       wpscan_requests: wpscanRequestsDone,
       wp_version: wp.number,
       wp_release_date: wp.release_date,
-      wp_release_status: wp.status, 
+      wp_release_status: wp.status,
       wp_interesting_entries: wp.interesting_entries,
       wp_found_by: wp.found_by,
       wp_confirmed_by: wp.confirmed_by,
       wp_vulnerabilities: wp.vulnerabilities
-    },
+    }
   });
 
   // add all interesting findings as INFORMATIONAL
   for (const interestingFinding of scanResults.interesting_findings) {
     //console.log(interestingFinding);
     findings.push({
-      name: "WordPress finding '"+ interestingFinding.type + "'",
+      name: "WordPress finding '" + interestingFinding.type + "'",
       description: interestingFinding.to_s,
       category: "WordPress " + interestingFinding.type,
       location: interestingFinding.url,
@@ -51,11 +50,11 @@ async function parse(scanResults) {
       confidence: interestingFinding.confidence,
       reference: {},
       attributes: {
-	hostname: targetUrl,
+        hostname: targetUrl,
         wp_interesting_entries: interestingFinding.interesting_entries,
         wp_found_by: interestingFinding.found_by,
         wp_confirmed_by: interestingFinding.confirmed_by
-      },
+      }
     });
   }
 

--- a/scanners/wpscan/parser/parser.js
+++ b/scanners/wpscan/parser/parser.js
@@ -8,8 +8,6 @@ async function parse(scanResults) {
   const targetUrl = scanResults.target_url;
   const targetIp = scanResults.target_ip;
 
-  const wp = scanResults.version;
-
   const findings = [];
 
   // add a general INFORMATIONAL summary finding
@@ -21,20 +19,20 @@ async function parse(scanResults) {
     osi_layer: "APPLICATION",
     severity: "INFORMATIONAL",
     reference: {},
-    confidence: wp.confidence,
+    confidence: scanResults.version?.confidence,
     attributes: {
       hostname: targetUrl,
       ip_address: targetIp,
       wpscan_version: wpscanVersion,
       wpscan_requests: wpscanRequestsDone,
-      wp_version: wp.number,
-      wp_release_date: wp.release_date,
-      wp_release_status: wp.status,
-      wp_interesting_entries: wp.interesting_entries,
-      wp_found_by: wp.found_by,
-      wp_confirmed_by: wp.confirmed_by,
-      wp_vulnerabilities: wp.vulnerabilities
-    }
+      wp_version: scanResults.version?.number,
+      wp_release_date: scanResults.version?.release_date,
+      wp_release_status: scanResults.version?.status,
+      wp_interesting_entries: scanResults.version?.interesting_entries,
+      wp_found_by: scanResults.version?.found_by,
+      wp_confirmed_by: scanResults.version?.confirmed_by,
+      wp_vulnerabilities: scanResults.version?.vulnerabilities,
+    },
   });
 
   // add all interesting findings as INFORMATIONAL
@@ -53,8 +51,8 @@ async function parse(scanResults) {
         hostname: targetUrl,
         wp_interesting_entries: interestingFinding.interesting_entries,
         wp_found_by: interestingFinding.found_by,
-        wp_confirmed_by: interestingFinding.confirmed_by
-      }
+        wp_confirmed_by: interestingFinding.confirmed_by,
+      },
     });
   }
 

--- a/scanners/wpscan/parser/parser.test.js
+++ b/scanners/wpscan/parser/parser.test.js
@@ -6,20 +6,10 @@ const readFile = util.promisify(fs.readFile);
 
 const { parse } = require("./parser");
 
-// test("WPScan parser parses errored result (no Wordpress server) to zero findings", async () => {
-//   const hosts = JSON.parse(
-//     await readFile(__dirname + "/__testFiles__/empty-localhost.json", {
-//       encoding: "utf8"
-//     })
-//   );
-
-//   expect(await parse(hosts)).toEqual([]);
-// });
-
-test("WPScan parser parses a successfull scan result with at least one informational finding", async () => {
+test("WPScan parser parses a successfully scan result with at least one informational finding", async () => {
   const scanResults = JSON.parse(
     await readFile(__dirname + "/__testFiles__/example-latest.json", {
-      encoding: "utf8"
+      encoding: "utf8",
     })
   );
 
@@ -131,6 +121,128 @@ test("WPScan parser parses a successfull scan result with at least one informati
         "confidence": 60,
         "description": "The external WP-Cron seems to be enabled: https://www.example.com/wp-cron.php",
         "location": "https://www.example.com/wp-cron.php",
+        "name": "WordPress finding 'wp_cron'",
+        "osi_layer": "APPLICATION",
+        "reference": Object {},
+        "severity": "INFORMATIONAL",
+      },
+    ]
+  `);
+});
+
+test("WPScan parser parses a scan result file without a detected wp version correctly", async () => {
+  const scanResults = JSON.parse(
+    await readFile(__dirname + "/__testFiles__/no-version-detected.json", {
+      encoding: "utf8",
+    })
+  );
+
+  expect(await parse(scanResults)).toMatchInlineSnapshot(`
+    Array [
+      Object {
+        "attributes": Object {
+          "hostname": "https://wp.example.com/",
+          "ip_address": "203.0.113.42",
+          "wp_confirmed_by": undefined,
+          "wp_found_by": undefined,
+          "wp_interesting_entries": undefined,
+          "wp_release_date": undefined,
+          "wp_release_status": undefined,
+          "wp_version": undefined,
+          "wp_vulnerabilities": undefined,
+          "wpscan_requests": 3734,
+          "wpscan_version": "3.8.17",
+        },
+        "category": "WordPress Service",
+        "confidence": undefined,
+        "description": "WordPress Service Information",
+        "location": "https://wp.example.com/",
+        "name": "WordPress Service",
+        "osi_layer": "APPLICATION",
+        "reference": Object {},
+        "severity": "INFORMATIONAL",
+      },
+      Object {
+        "attributes": Object {
+          "hostname": "https://wp.example.com/",
+          "wp_confirmed_by": Object {},
+          "wp_found_by": "Headers (Passive Detection)",
+          "wp_interesting_entries": Array [
+            "Server: Apache",
+            "Expect-CT: max-age=86400, enforce",
+          ],
+        },
+        "category": "WordPress headers",
+        "confidence": 100,
+        "description": "Headers",
+        "location": "https://wp.example.com/",
+        "name": "WordPress finding 'headers'",
+        "osi_layer": "APPLICATION",
+        "reference": Object {},
+        "severity": "INFORMATIONAL",
+      },
+      Object {
+        "attributes": Object {
+          "hostname": "https://wp.example.com/",
+          "wp_confirmed_by": Object {},
+          "wp_found_by": "Robots Txt (Aggressive Detection)",
+          "wp_interesting_entries": Array [
+            "/wp-admin/",
+            "/wp-admin/admin-ajax.php",
+          ],
+        },
+        "category": "WordPress robots_txt",
+        "confidence": 100,
+        "description": "robots.txt found: https://wp.example.com/robots.txt",
+        "location": "https://wp.example.com/robots.txt",
+        "name": "WordPress finding 'robots_txt'",
+        "osi_layer": "APPLICATION",
+        "reference": Object {},
+        "severity": "INFORMATIONAL",
+      },
+      Object {
+        "attributes": Object {
+          "hostname": "https://wp.example.com/",
+          "wp_confirmed_by": Object {},
+          "wp_found_by": "Direct Access (Aggressive Detection)",
+          "wp_interesting_entries": Array [],
+        },
+        "category": "WordPress readme",
+        "confidence": 100,
+        "description": "WordPress readme found: https://wp.example.com/readme.html",
+        "location": "https://wp.example.com/readme.html",
+        "name": "WordPress finding 'readme'",
+        "osi_layer": "APPLICATION",
+        "reference": Object {},
+        "severity": "INFORMATIONAL",
+      },
+      Object {
+        "attributes": Object {
+          "hostname": "https://wp.example.com/",
+          "wp_confirmed_by": Object {},
+          "wp_found_by": "Direct Access (Aggressive Detection)",
+          "wp_interesting_entries": Array [],
+        },
+        "category": "WordPress mu_plugins",
+        "confidence": 80,
+        "description": "This site has 'Must Use Plugins': https://wp.example.com/wp-content/mu-plugins/",
+        "location": "https://wp.example.com/wp-content/mu-plugins/",
+        "name": "WordPress finding 'mu_plugins'",
+        "osi_layer": "APPLICATION",
+        "reference": Object {},
+        "severity": "INFORMATIONAL",
+      },
+      Object {
+        "attributes": Object {
+          "hostname": "https://wp.example.com/",
+          "wp_confirmed_by": Object {},
+          "wp_found_by": "Direct Access (Aggressive Detection)",
+          "wp_interesting_entries": Array [],
+        },
+        "category": "WordPress wp_cron",
+        "confidence": 60,
+        "description": "The external WP-Cron seems to be enabled: https://wp.example.com/wp-cron.php",
+        "location": "https://wp.example.com/wp-cron.php",
         "name": "WordPress finding 'wp_cron'",
         "osi_layer": "APPLICATION",
         "reference": Object {},


### PR DESCRIPTION
This PR fixes a issue in the WPScan Parser which causes it to crash when WPScan wasn't able to identify the WPScan version.

Also upgraded the ecmascript version specified in eslint to match our node.js version used so that we are can use modern js features like optional chaining without eslint complaining about it.