### PR TITLE
Update Base Image To Newer Version

### DIFF
--- a/scanners/git-repo-scanner/scanner/Dockerfile
+++ b/scanners/git-repo-scanner/scanner/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.9.0-alpine
+FROM docker.io/python:3-alpine
 COPY . /scripts/
 RUN pip install -r /scripts/requirements.txt
 CMD ["/bin/sh"]


### PR DESCRIPTION
Playing around with trivy I saw that this image contained at least
16 fixable vulnerabilities although it was build rather recently

I took a look at the base image (python:3.9.0-alpine) and noticed
it was last build 6 months ago

I decided to change the base image to python:3-alpine to resolve this
issue

Signed-off-by: Yannik Fuhrmeister <yannik.fuhrmeister@protonmail.com>
