### PR TITLE
Rename `matchExpression` to `matchExpressions` in cascading scans

### DIFF
--- a/hooks/declarative-subsequent-scans/README.md
+++ b/hooks/declarative-subsequent-scans/README.md
@@ -77,7 +77,7 @@ smtps-tls-scan   sslyze     non-invasive   light
 ssh-scan         ssh-scan   non-invasive   light
 ```
 
-The label selectors also allow the more powerful matchExpression selectors:
+The label selectors also allow the more powerful matchExpressions selectors:
 
 ```yaml
 cat <<EOF | kubectl apply -f -
@@ -91,9 +91,9 @@ spec:
     - -p22,80,443
     - example.com
   cascades:
-    # Using matchExpression instead of matchLabels
-    matchExpression:
-      key: "securecodebox.io/intensive"
+    # Using matchExpressions instead of matchLabels
+    matchExpressions:
+    - key: "securecodebox.io/intensive"
       operator: In
       # This select both light and medium intensity rules
       values: [light, medium]

--- a/hooks/declarative-subsequent-scans/README.md.gotmpl
+++ b/hooks/declarative-subsequent-scans/README.md.gotmpl
@@ -77,7 +77,7 @@ smtps-tls-scan   sslyze     non-invasive   light
 ssh-scan         ssh-scan   non-invasive   light
 ```
 
-The label selectors also allow the more powerful matchExpression selectors:
+The label selectors also allow the more powerful matchExpressions selectors:
 
 ```yaml
 cat <<EOF | kubectl apply -f -
@@ -91,9 +91,9 @@ spec:
     - -p22,80,443
     - example.com
   cascades:
-    # Using matchExpression instead of matchLabels
-    matchExpression:
-      key: "securecodebox.io/intensive"
+    # Using matchExpressions instead of matchLabels
+    matchExpressions:
+    - key: "securecodebox.io/intensive"
       operator: In
       # This select both light and medium intensity rules
       values: [light, medium]

--- a/hooks/declarative-subsequent-scans/kubernetes-label-selector.test.js
+++ b/hooks/declarative-subsequent-scans/kubernetes-label-selector.test.js
@@ -41,7 +41,7 @@ test("should generate basic label string for multiple key values selector", () =
 test("should generate label string for set based expressions", () => {
   expect(
     generateLabelSelectorString({
-      matchExpression: [
+      matchExpressions: [
         {
           key: "environment",
           operator: "In",
@@ -53,7 +53,7 @@ test("should generate label string for set based expressions", () => {
 
   expect(
     generateLabelSelectorString({
-      matchExpression: [
+      matchExpressions: [
         {
           key: "environment",
           operator: "In",
@@ -67,7 +67,7 @@ test("should generate label string for set based expressions", () => {
 test("should generate label string for set based expressions with multiple entries", () => {
   expect(
     generateLabelSelectorString({
-      matchExpression: [
+      matchExpressions: [
         {
           key: "environment",
           operator: "NotIn",
@@ -86,7 +86,7 @@ test("should generate label string for set based expressions with multiple entri
 test("should generate label string for set based Exists and DoesNotExist operators", () => {
   expect(
     generateLabelSelectorString({
-      matchExpression: [
+      matchExpressions: [
         {
           key: "environment",
           operator: "Exists"
@@ -103,7 +103,7 @@ test("should generate label string for set based Exists and DoesNotExist operato
 test("should generate selectors with both expression and labelMatching", () => {
   expect(
     generateLabelSelectorString({
-      matchExpression: [
+      matchExpressions: [
         {
           key: "environment",
           operator: "NotIn",
@@ -135,7 +135,7 @@ test("should generate selectors with both expression and labelMatching", () => {
 test("should throw a exception when passed a unknown operator", () => {
   expect(() =>
     generateLabelSelectorString({
-      matchExpression: [
+      matchExpressions: [
         {
           key: "environment",
           operator: "FooBar",

--- a/hooks/declarative-subsequent-scans/kubernetes-label-selector.ts
+++ b/hooks/declarative-subsequent-scans/kubernetes-label-selector.ts
@@ -15,20 +15,20 @@ export interface LabelSelectorRequirement {
 }
 
 export interface LabelSelector {
-  matchExpression: Array<LabelSelectorRequirement>;
+  matchExpressions: Array<LabelSelectorRequirement>;
   matchLabels: Map<string, string>;
 }
 
 // generateLabelSelectorString transforms a kubernetes labelSelector object in to the string representation
 export function generateLabelSelectorString({
-  matchExpression = [],
+  matchExpressions = [],
   matchLabels = new Map()
 }: LabelSelector): string {
   const matchLabelsSelector = Array.from(Object.entries(matchLabels)).map(
     ([key, values]) => `${key}=${values}`
   );
 
-  const matchExpressionsSelector = matchExpression.map(
+  const matchExpressionsSelector = matchExpressions.map(
     ({ key, values, operator }) => {
       if (
         operator === LabelSelectorRequirementOperator.In ||

--- a/operator/Chart.yaml
+++ b/operator/Chart.yaml
@@ -108,8 +108,8 @@ annotations:
         cascades:
           matchLabels:
             securecodebox.io/intensive: light
-          matchExpression:
-            key: "securecodebox.io/invasive"
+          matchExpressions:
+          - key: "securecodebox.io/invasive"
             operator: In
             values: [non-invasive, invasive]
     - apiVersion: "execution.securecodebox.io/v1"


### PR DESCRIPTION
## Description
This PR solves the issues described in #438 related to inconsistencies between `matchExpression` and `matchExpressions`.

### Checklist

* [x] Test your changes as thoroughly as possible before you commit them. Preferably, automate your test by unit/integration tests.
* [x] Make sure `npm test` runs for the whole project.
* [x] Make codeclimate checks happy
