### PR TITLE
Fix wrong container repo for the angularjs-csti-scanner

### DIFF
--- a/scanners/angularjs-csti-scanner/README.md
+++ b/scanners/angularjs-csti-scanner/README.md
@@ -135,10 +135,10 @@ options.scope.request_methods = [
 
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
-| image.repository | string | `"docker.io/securecodebox/scanner-acstis"` | Container Image to run the scan |
+| image.repository | string | `"docker.io/securecodebox/scanner-angularjs-csti-scanner"` | Container Image to run the scan |
 | image.tag | string | `nil` | defaults to the charts version |
 | parseJob.ttlSecondsAfterFinished | string | `nil` | seconds after which the kubernetes job for the parser will be deleted. Requires the Kubernetes TTLAfterFinished controller: https://kubernetes.io/docs/concepts/workloads/controllers/ttlafterfinished/ |
-| parserImage.repository | string | `"docker.io/securecodebox/parser-acstis"` | Parser image repository |
+| parserImage.repository | string | `"docker.io/securecodebox/parser-angularjs-csti-scanner"` | Parser image repository |
 | parserImage.tag | string | defaults to the charts version | Parser image tag |
 | scannerJob.env | list | `[]` | Optional environment variables mapped into each scanJob (see: https://kubernetes.io/docs/tasks/inject-data-application/define-environment-variable-container/) |
 | scannerJob.extraContainers | list | `[]` | Optional additional Containers started with each scanJob (see: https://kubernetes.io/docs/concepts/workloads/pods/init-containers/) |

--- a/scanners/angularjs-csti-scanner/values.yaml
+++ b/scanners/angularjs-csti-scanner/values.yaml
@@ -4,14 +4,14 @@
 
 image:
   # image.repository -- Container Image to run the scan
-  repository: docker.io/securecodebox/scanner-acstis
+  repository: docker.io/securecodebox/scanner-angularjs-csti-scanner
   # image.tag -- defaults to the charts version
   tag: null
 
 parserImage:
   # parserImage.tag - defaults to the charts version
   # parserImage.repository -- Parser image repository
-  repository: docker.io/securecodebox/parser-acstis
+  repository: docker.io/securecodebox/parser-angularjs-csti-scanner
   # parserImage.tag -- Parser image tag
   # @default -- defaults to the charts version
   tag: null


### PR DESCRIPTION
Signed-off-by: Tim Walter <tim.walter@iteratec.com>

<!-- 
Thank you for your contribution to our Project 🙌 

Before submitting your Pull Request, please take the time to check the points below and provide some descriptive information.
* [ ] If this PR comes from a fork, please [Allow edits from maintainers](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork)
* [ ] Set a meaningful title. Format: {task_name} (closes #{issue_number}). For example: Use logger (closes #41)
* [ ] [Link your Pull Request to an issue](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) (if applicable)
* [ ] Create Draft pull requests if you need clarification or an explicit review before you can continue your work item.
* [ ] Make sure that your PR is not introducing _unncessary_ reformatting (e.g., introduced by on-save hooks in your IDE)
* [ ] Make sure each new source file you add has a correct license header.
-->

## Description
<!-- Please be brief in describing which issue is solved by your PR or which enhancement it brings -->
The wrong docker repository was referenced in the `values.yaml` of the `angularjs-csti-scanner` and thus the latest container builds are not used since 4 months.

### Checklist

* [x] Test your changes as thoroughly as possible before you commit them. Preferably, automate your test by unit/integration tests.
* [x] Make sure `npm test` runs for the whole project.
* [x] Make codeclimate checks happy
