### PR TITLE
Update Docker Image For Amass

### DIFF
--- a/scanners/amass/Chart.yaml
+++ b/scanners/amass/Chart.yaml
@@ -10,7 +10,7 @@ type: application
 # version - gets automatically set to the secureCodeBox release version when the helm charts gets published
 version: v2.7.0-alpha1
 # Latest Amass release version can be found here: https://github.com/OWASP/Amass/releases
-appVersion: "v3.11.13"
+appVersion: "v3.13"
 kubeVersion: ">=v1.11.0-0"
 
 keywords:


### PR DESCRIPTION
The image used for amass did not exist anymore
I updated the Image to v3.13

Signed-off-by: Yannik Fuhrmeister <yannik.fuhrmeister@iteratec.com>
