### PR TITLE
Add Alternate Slack Notifier using Slack App instead of Webhooks

### DIFF
--- a/hooks/notification-hook/.gitignore
+++ b/hooks/notification-hook/.gitignore
@@ -3,4 +3,5 @@
 # SPDX-License-Identifier: Apache-2.0
 
 node_modules
-
+**.js
+**.js.map

--- a/hooks/notification-hook/NotifierFactory.ts
+++ b/hooks/notification-hook/NotifierFactory.ts
@@ -2,23 +2,31 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-import { Notifier } from "./Notifier"
+import { Notifier } from "./Notifier";
 import { NotifierType } from "./NotifierType";
-import { SlackNotifier } from "./Notifiers/SlackNotifier"
-import { EMailNotifier } from "./Notifiers/EMailNotifier"
+import { SlackNotifier } from "./Notifiers/SlackNotifier";
+import { SlackAppNotifier } from "./Notifiers/SlackAppNotifier";
+import { EMailNotifier } from "./Notifiers/EMailNotifier";
 import { NotificationChannel } from "./model/NotificationChannel";
 import { Scan } from "./model/Scan";
 import { Finding } from "./model/Finding";
 
 export class NotifierFactory {
-  static create(channel: NotificationChannel, scan: Scan, findings: Finding[], args: any): Notifier {
+  static create(
+    channel: NotificationChannel,
+    scan: Scan,
+    findings: Finding[],
+    args: any
+  ): Notifier {
     switch (channel.type) {
       case NotifierType.SLACK:
         return new SlackNotifier(channel, scan, findings, args);
       case NotifierType.EMAIL:
         return new EMailNotifier(channel, scan, findings, args);
+      case NotifierType.SLACK_APP:
+        return new SlackAppNotifier(channel, scan, findings, args);
       default:
-        throw new Error("This Type is not Implemented :(")
+        throw new Error("This Type is not Implemented :(");
     }
   }
 }

--- a/hooks/notification-hook/NotifierType.ts
+++ b/hooks/notification-hook/NotifierType.ts
@@ -4,6 +4,7 @@
 
 export enum NotifierType {
   SLACK = "slack",
+  SLACK_APP = "slack-app",
   MS_TEAMS = "ms-teams",
-  EMAIL = "email"
+  EMAIL = "email",
 }

--- a/hooks/notification-hook/Notifiers/AbstractNotifier.ts
+++ b/hooks/notification-hook/Notifiers/AbstractNotifier.ts
@@ -8,11 +8,14 @@ import { Finding } from "../model/Finding";
 import { NotificationChannel } from "../model/NotificationChannel";
 import * as jsyaml from "js-yaml";
 import { Scan } from "../model/Scan";
-import * as path from 'path';
-import * as nunjucks from 'nunjucks';
+import * as path from "path";
+import * as nunjucks from "nunjucks";
 
 export abstract class AbstractNotifier implements Notifier {
-  private static readonly TEMPLATE_DIR: string = path.join(__dirname, "../notification-templates");
+  private static readonly TEMPLATE_DIR: string = path.join(
+    __dirname,
+    "../notification-templates"
+  );
   private static readonly TEMPLATE_FILE_TYPE = "njk";
   protected channel: NotificationChannel;
   protected scan: Scan;
@@ -21,27 +24,39 @@ export abstract class AbstractNotifier implements Notifier {
   protected abstract type: NotifierType;
   protected args: Object;
 
-  constructor(channel: NotificationChannel, scan: Scan, findings: Finding[], args: Object) {
+  constructor(
+    channel: NotificationChannel,
+    scan: Scan,
+    findings: Finding[],
+    args: Object
+  ) {
     this.channel = channel;
     this.scan = scan;
     this.findings = findings;
     this.args = args;
   }
 
-  public abstract sendMessage(): Promise<void>
+  public abstract sendMessage(): Promise<void>;
 
   protected renderMessage(): string {
+    return JSON.stringify(this.renderYamlTemplate());
+  }
+
+  protected renderYamlTemplate(): any {
     nunjucks.configure(AbstractNotifier.TEMPLATE_DIR);
-    const renderedTemplate = nunjucks.render(`${this.channel.template}.${AbstractNotifier.TEMPLATE_FILE_TYPE}`, {
-      findings: this.findings,
-      scan: this.scan,
-      args: this.args
-    });
+    const renderedTemplate = nunjucks.render(
+      `${this.channel.template}.${AbstractNotifier.TEMPLATE_FILE_TYPE}`,
+      {
+        findings: this.findings,
+        scan: this.scan,
+        args: this.args,
+      }
+    );
     try {
       const templateObject = jsyaml.load(renderedTemplate);
-      return JSON.stringify(templateObject);
+      return templateObject;
     } catch (e) {
-      console.log(e)
+      console.log(e);
     }
   }
 }

--- a/hooks/notification-hook/Notifiers/SlackAppNotifier.test.ts
+++ b/hooks/notification-hook/Notifiers/SlackAppNotifier.test.ts
@@ -1,0 +1,72 @@
+// SPDX-FileCopyrightText: 2020 iteratec GmbH
+//
+// SPDX-License-Identifier: Apache-2.0
+
+import { SlackAppNotifier } from "./SlackAppNotifier";
+import axios from "axios";
+import { NotificationChannel } from "../model/NotificationChannel";
+import { NotifierType } from "../NotifierType";
+import { Scan } from "../model/Scan";
+
+jest.mock("axios");
+
+beforeEach(() => {
+  jest.clearAllMocks();
+});
+
+const channel: NotificationChannel = {
+  name: "Channel Name",
+  type: NotifierType.SLACK_APP,
+  template: "slack-messageCard",
+  rules: [],
+};
+
+test("Should Send Message With Findings And Severities", async () => {
+  const scan: Scan = {
+    metadata: {
+      uid: "09988cdf-1fc7-4f85-95ee-1b1d65dbc7cc",
+      name: "demo-scan-1601086432",
+      namespace: "my-scans",
+      creationTimestamp: new Date("2021-01-01T14:29:25Z"),
+      labels: {
+        company: "iteratec",
+        "attack-surface": "external",
+      },
+      annotations: {
+        "notification.securecodebox.io/slack-channel": "#foobar",
+      },
+    },
+    spec: {
+      scanType: "Nmap",
+      parameters: ["-Pn", "localhost"],
+    },
+    status: {
+      findingDownloadLink:
+        "https://my-secureCodeBox-instance.com/scan-b9as-sdweref--sadf-asdfsdf-dasdgf-asdffdsfa7/findings.json",
+      findings: {
+        categories: {
+          "A Client Error response code was returned by the server": 1,
+          "Information Disclosure - Sensitive Information in URL": 1,
+          "Strict-Transport-Security Header Not Set": 1,
+        },
+        count: 3,
+        severities: {
+          high: 10,
+          medium: 5,
+          low: 2,
+          informational: 1,
+        },
+      },
+      finishedAt: new Date("2020-05-25T02:38:13Z"),
+      rawResultDownloadLink:
+        "https://my-secureCodeBox-instance.com/scan-blkfsdg-sdgfsfgd-sfg-sdfg-dfsg-gfs98-e8af2172caa7/zap-results.json?Expires=1601691232",
+      rawResultFile: "zap-results.json",
+      rawResultType: "zap-json",
+      state: "Done",
+    },
+  };
+
+  const slackNotifier = new SlackAppNotifier(channel, scan, [], []);
+  slackNotifier.sendMessage();
+  expect(axios.post).toBeCalled();
+});

--- a/hooks/notification-hook/Notifiers/SlackAppNotifier.ts
+++ b/hooks/notification-hook/Notifiers/SlackAppNotifier.ts
@@ -1,0 +1,76 @@
+// SPDX-FileCopyrightText: 2020 iteratec GmbH
+//
+// SPDX-License-Identifier: Apache-2.0
+
+import { NotifierType } from "../NotifierType";
+import { AbstractNotifier } from "./AbstractNotifier";
+import { Finding } from "../model/Finding";
+import axios from "axios";
+import { NotificationChannel } from "../model/NotificationChannel";
+import { Scan } from "../model/Scan";
+
+interface SlackApiResponse {
+  ok: boolean;
+  error?: string;
+}
+
+export class SlackAppNotifier extends AbstractNotifier {
+  protected type: NotifierType = NotifierType.SLACK_APP;
+
+  protected slackChannel: string;
+
+  constructor(
+    channel: NotificationChannel,
+    scan: Scan,
+    findings: Finding[],
+    args: Object
+  ) {
+    super(channel, scan, findings, args);
+
+    // Use slack channel configured via scan annotation or fall back to a default one configured via env args
+    this.slackChannel =
+      scan.metadata?.annotations?.[
+        "notification.securecodebox.io/slack-channel"
+      ] ?? args["SLACK_DEFAULT_CHANNEL"];
+
+    if (this.slackChannel === undefined) {
+      throw new Error(
+        "Not Slack channel configured via 'notification.securecodebox.io/slack-channel' scan annotation or via the 'SLACK_DEFAULT_CHANNEL' env variable."
+      );
+    }
+  }
+
+  public async sendMessage(): Promise<void> {
+    await this.sendPostRequest(this.renderYamlTemplate());
+  }
+
+  protected async sendPostRequest(message: any) {
+    try {
+      console.log(
+        `Sending notification to Slack Channel: ${this.slackChannel}`
+      );
+
+      const { data: response } = await axios.post<SlackApiResponse>(
+        "https://slack.com/api/chat.postMessage",
+        {
+          ...message,
+          channel: this.slackChannel,
+        },
+        {
+          headers: {
+            Authorization: `Bearer ${process.env["SLACK_APP_TOKEN"]}`,
+          },
+        }
+      );
+
+      if (!response.ok) {
+        throw new Error(`Slack API Call Failed: ${response.error}`);
+      }
+    } catch (e) {
+      console.log(
+        `There was an Error sending the Message for the Slack App Notifier "${this.channel.name}"`
+      );
+      console.log(e);
+    }
+  }
+}

--- a/hooks/notification-hook/README.md
+++ b/hooks/notification-hook/README.md
@@ -15,13 +15,15 @@ Installing the Notification hook will add a ReadOnly Hook to your namespace.
 ```bash
 helm upgrade --install nwh ./hooks/notification-hook/ --values /path/to/your/values"
 ```
+
 The `values.yaml` you need depends on the notification type you want to use.
 Please take a look at the documentation for each type (e.g. for slack see [Configuration of a Slack Notification](#configuration-o-a-slack-notification))
 
 ## Available Notifier
 
-* [Slack](#configuration-of-a-slack-notification)
-* [Email](#configuration-of-an-email-notification)
+- [Slack](#configuration-of-a-slack-notification)
+- [Slack App](#configuration-of-a-slack-app-notification)
+- [Email](#configuration-of-an-email-notification)
 
 ## Configuration of a Notification
 
@@ -42,14 +44,14 @@ env:
   - name: SOME_ENV
     valueFrom:
       secretRefKey:
-       secret: some-secret
-       key: some-key
+        secret: some-secret
+        key: some-key
 ```
 
 The Notification Hook enables you to define multiple so called `notificationChannels`. A `notificationChannel` defines the Notification to a specific platform (e.g. Slack or Teams).
 
 The `name` is used to for debugging failing notifications.
-it can be a *string* of you choice.
+it can be a _string_ of you choice.
 
 The `type` specifies the type of the notification (in this example slack).
 Currently `slack` is the only available type, but we are working on others (e.g. MS Teams or email) as well.
@@ -101,13 +103,72 @@ Notice that only one of these elements needs to match the finding for the rule t
 
 To configure a Slack notification set the `type` to `slack` and the `endPoint` to point to your env containing your Webhook URL to slack.
 You can use one of the following default templates:
-* slack-messageCard
+
+- `slack-messageCard`: Sends a message with a summary listing the number of findings per category and severity.
+- `slack-individual-findings-with-defectdojo`: Sends a message with a list of all findings with a link to the finding in DefectDojo. Will only work correctly if the DefectDojo hook is installed in the same namespace.
+
+### Configuration of a Slack App Notification
+
+The `slack-app` notifier is an _alternate_ way to send notifications to slack using the slack api directly rather then using webhooks.
+Use `slack-app` over the normal `slack` if you want to send notifications into different slack channels on a per scan basis.
+
+#### Slack App Configuration
+
+To set it up, you'll need to create a new slack app at [https://api.slack.com/apps/](https://api.slack.com/apps/) and add the `chat:write` "Bot Token Scope" to it on the "OAuth & Permissions" tab. Then add the bot to your workspace, this will give you the access token (should begin with a `xoxb-`).
+
+To configure a Slack notification set the `type` to `slack-app` and reference the secret via the `SLACK_APP_TOKEN` env var.
+
+#### Example Config
+
+```yaml
+notificationChannels:
+  - name: slack
+    type: slack-app
+    template: slack-messageCard
+    rules: []
+
+env:
+  # you can create the secret via: kubectl create secret generic slack-app-token --from-literal="token=xoxb-..."
+  - name: SLACK_APP_TOKEN
+    valueFrom:
+      secretKeyRef:
+        name: slack-app-token
+        key: token
+  # configures which channel the messages are send to if the scan doesn't specify a channel
+  - name: SLACK_DEFAULT_CHANNEL
+    value: "#example-channel"
+```
+
+#### Supported Notification Channels
+
+The `slack-app` notifier supports the same message templates as the `slack` notifier.
+See [slack](#configuration-of-a-slack-notification) for the supported message types.
+
+#### Scan / Channel Config
+
+You can configure to which channel the message is sent to by setting the `notification.securecodebox.io/slack-channel` to the channel the message should be sent to, the following example will send its notifications to the `#juice-shop-dev` channel in the slack workspace of the configured token.
+
+> Note: The channel needs to have the app you've create invited to it. Otherwise the app will not be permitted to write to it.
+
+```yaml
+apiVersion: "execution.securecodebox.io/v1"
+kind: Scan
+metadata:
+  name: "nmap-juice-shop"
+  annotations:
+    notification.securecodebox.io/slack-channel: "#juice-shop-dev"
+spec:
+  scanType: "nmap"
+  parameters:
+    - juice-shop.default.svc
+```
 
 ### Configuration Of An Email Notification
 
 To configure an email notification set the `type` to `email` and the `endPoint` to point to your env containing your target email address.
 You can use one of the following default templates:
-* email
+
+- `email`: Sends a email with a summary listing the number of findings per category and severity.
 
 Additional to this configuration you will have to provide a special smtp configuration URL.
 This config reflects the transporter configuration of nodemailer (See [nodemailer | SMTP Transport](https://nodemailer.com/smtp/)).
@@ -142,11 +203,11 @@ Templates for this hook are written using the [Nunjucks](https://mozilla.github.
 
 To fill your template with data we provide the following objects.
 
-| object   | Details                                                                                                                     |
-|----------|-----------------------------------------------------------------------------------------------------------------------------|
-| findings | An array of the findings matching your rules (See [Finding | secureCodeBox](https://docs.securecodebox.io/docs/api/finding) |
-| scan     | An Object containing information about the scan that triggered the notification (See [Scan | secureCodeBox](https://docs.securecodebox.io/docs/api/crds/scan) |
-| args     | contains `process.env` (See: [process.env | nodejs](https://nodejs.org/api/process.html#process_process_env)) you can use this to access data defined in `env` of the `values.yaml` |
+| object   | Details                                                                                    |
+| -------- | ------------------------------------------------------------------------------------------ | --------------------------------------------------------------------------------------------------------------------------------------- |
+| findings | An array of the findings matching your rules (See [Finding                                 | secureCodeBox](https://docs.securecodebox.io/docs/api/finding)                                                                          |
+| scan     | An Object containing information about the scan that triggered the notification (See [Scan | secureCodeBox](https://docs.securecodebox.io/docs/api/crds/scan)                                                                        |
+| args     | contains `process.env` (See: [process.env                                                  | nodejs](https://nodejs.org/api/process.html#process_process_env)) you can use this to access data defined in `env` of the `values.yaml` |
 
 ## Chart Configuration
 

--- a/hooks/notification-hook/README.md.gotmpl
+++ b/hooks/notification-hook/README.md.gotmpl
@@ -20,13 +20,15 @@ Installing the Notification hook will add a ReadOnly Hook to your namespace.
 ```bash
 helm upgrade --install nwh ./hooks/notification-hook/ --values /path/to/your/values"
 ```
+
 The `values.yaml` you need depends on the notification type you want to use.
 Please take a look at the documentation for each type (e.g. for slack see [Configuration of a Slack Notification](#configuration-o-a-slack-notification))
 
 ## Available Notifier
 
-* [Slack](#configuration-of-a-slack-notification)
-* [Email](#configuration-of-an-email-notification)
+- [Slack](#configuration-of-a-slack-notification)
+- [Slack App](#configuration-of-a-slack-app-notification)
+- [Email](#configuration-of-an-email-notification)
 
 ## Configuration of a Notification
 
@@ -47,14 +49,14 @@ env:
   - name: SOME_ENV
     valueFrom:
       secretRefKey:
-       secret: some-secret
-       key: some-key
+        secret: some-secret
+        key: some-key
 ```
 
 The Notification Hook enables you to define multiple so called `notificationChannels`. A `notificationChannel` defines the Notification to a specific platform (e.g. Slack or Teams).
 
 The `name` is used to for debugging failing notifications.
-it can be a *string* of you choice.
+it can be a _string_ of you choice.
 
 The `type` specifies the type of the notification (in this example slack).
 Currently `slack` is the only available type, but we are working on others (e.g. MS Teams or email) as well.
@@ -106,13 +108,72 @@ Notice that only one of these elements needs to match the finding for the rule t
 
 To configure a Slack notification set the `type` to `slack` and the `endPoint` to point to your env containing your Webhook URL to slack.
 You can use one of the following default templates:
-* slack-messageCard
+
+- `slack-messageCard`: Sends a message with a summary listing the number of findings per category and severity.
+- `slack-individual-findings-with-defectdojo`: Sends a message with a list of all findings with a link to the finding in DefectDojo. Will only work correctly if the DefectDojo hook is installed in the same namespace.
+
+### Configuration of a Slack App Notification
+
+The `slack-app` notifier is an _alternate_ way to send notifications to slack using the slack api directly rather then using webhooks.
+Use `slack-app` over the normal `slack` if you want to send notifications into different slack channels on a per scan basis.
+
+#### Slack App Configuration
+
+To set it up, you'll need to create a new slack app at [https://api.slack.com/apps/](https://api.slack.com/apps/) and add the `chat:write` "Bot Token Scope" to it on the "OAuth & Permissions" tab. Then add the bot to your workspace, this will give you the access token (should begin with a `xoxb-`).
+
+To configure a Slack notification set the `type` to `slack-app` and reference the secret via the `SLACK_APP_TOKEN` env var.
+
+#### Example Config
+
+```yaml
+notificationChannels:
+  - name: slack
+    type: slack-app
+    template: slack-messageCard
+    rules: []
+
+env:
+  # you can create the secret via: kubectl create secret generic slack-app-token --from-literal="token=xoxb-..."
+  - name: SLACK_APP_TOKEN
+    valueFrom:
+      secretKeyRef:
+        name: slack-app-token
+        key: token
+  # configures which channel the messages are send to if the scan doesn't specify a channel
+  - name: SLACK_DEFAULT_CHANNEL
+    value: "#example-channel"
+```
+
+#### Supported Notification Channels
+
+The `slack-app` notifier supports the same message templates as the `slack` notifier.
+See [slack](#configuration-of-a-slack-notification) for the supported message types.
+
+#### Scan / Channel Config
+
+You can configure to which channel the message is sent to by setting the `notification.securecodebox.io/slack-channel` to the channel the message should be sent to, the following example will send its notifications to the `#juice-shop-dev` channel in the slack workspace of the configured token.
+
+> Note: The channel needs to have the app you've create invited to it. Otherwise the app will not be permitted to write to it.
+
+```yaml
+apiVersion: "execution.securecodebox.io/v1"
+kind: Scan
+metadata:
+  name: "nmap-juice-shop"
+  annotations:
+    notification.securecodebox.io/slack-channel: "#juice-shop-dev"
+spec:
+  scanType: "nmap"
+  parameters:
+    - juice-shop.default.svc
+```
 
 ### Configuration Of An Email Notification
 
 To configure an email notification set the `type` to `email` and the `endPoint` to point to your env containing your target email address.
 You can use one of the following default templates:
-* email
+
+- `email`: Sends a email with a summary listing the number of findings per category and severity.
 
 Additional to this configuration you will have to provide a special smtp configuration URL.
 This config reflects the transporter configuration of nodemailer (See [nodemailer | SMTP Transport](https://nodemailer.com/smtp/)).
@@ -138,7 +199,6 @@ env:
     value: secureCodeBox
 ```
 
-
 ## Custom Message Templates
 
 CAUTION: Nunjucks templates allow code to be injected! Use templates from trusted sources only!
@@ -148,11 +208,11 @@ Templates for this hook are written using the [Nunjucks](https://mozilla.github.
 
 To fill your template with data we provide the following objects.
 
-| object   | Details                                                                                                                     |
-|----------|-----------------------------------------------------------------------------------------------------------------------------|
-| findings | An array of the findings matching your rules (See [Finding | secureCodeBox](https://docs.securecodebox.io/docs/api/finding) |
-| scan     | An Object containing information about the scan that triggered the notification (See [Scan | secureCodeBox](https://docs.securecodebox.io/docs/api/crds/scan) |
-| args     | contains `process.env` (See: [process.env | nodejs](https://nodejs.org/api/process.html#process_process_env)) you can use this to access data defined in `env` of the `values.yaml` |
+| object   | Details                                                                                    |
+| -------- | ------------------------------------------------------------------------------------------ | --------------------------------------------------------------------------------------------------------------------------------------- |
+| findings | An array of the findings matching your rules (See [Finding                                 | secureCodeBox](https://docs.securecodebox.io/docs/api/finding)                                                                          |
+| scan     | An Object containing information about the scan that triggered the notification (See [Scan | secureCodeBox](https://docs.securecodebox.io/docs/api/crds/scan)                                                                        |
+| args     | contains `process.env` (See: [process.env                                                  | nodejs](https://nodejs.org/api/process.html#process_process_env)) you can use this to access data defined in `env` of the `values.yaml` |
 
 ## Chart Configuration
 

--- a/hooks/notification-hook/model/NotificationChannel.ts
+++ b/hooks/notification-hook/model/NotificationChannel.ts
@@ -2,12 +2,12 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-import { NotifierType } from "../NotifierType"
+import { NotifierType } from "../NotifierType";
 
 export interface NotificationChannel {
   name: string;
   type: NotifierType;
   template: string;
   rules: any;
-  endPoint: string;
+  endPoint?: string;
 }


### PR DESCRIPTION
## Description

This PR adds a alternate Slack notifier which uses Slack Apps to control which channel the messages are send to on a per scan basis. More info in the notfiers readme :)

### Checklist

* [x] Test your changes as thoroughly as possible before you commit them. Preferably, automate your test by unit/integration tests.
* [x] Make sure `npm test` runs for the whole project.
* [ ] Make codeclimate checks happy
