### PR TITLE
Make annotations on demo-apps configurable

### DIFF
--- a/demo-apps/bodgeit/README.md
+++ b/demo-apps/bodgeit/README.md
@@ -26,6 +26,7 @@ BodgeIt Store is a serverside rendering based html website without any heavy jav
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
 | affinity | object | `{}` |  |
+| annotations | object | `{}` | add annotations to the deployment, service and pods |
 | fullnameOverride | string | `""` |  |
 | image.pullPolicy | string | `"IfNotPresent"` |  |
 | image.repository | string | `"docker.io/psiinon/bodgeit"` | Container Image containing the bodgeit |
@@ -36,6 +37,7 @@ BodgeIt Store is a serverside rendering based html website without any heavy jav
 | ingress.hosts[0].host | string | `"chart-example.local"` |  |
 | ingress.hosts[0].paths | list | `[]` |  |
 | ingress.tls | list | `[]` |  |
+| labels | object | `{}` | add labels to the deployment, service and pods |
 | nameOverride | string | `""` |  |
 | nodeSelector | object | `{}` |  |
 | podSecurityContext | object | `{}` |  |

--- a/demo-apps/bodgeit/templates/_helpers.tpl
+++ b/demo-apps/bodgeit/templates/_helpers.tpl
@@ -46,6 +46,9 @@ helm.sh/chart: {{ include "bodgeit.chart" . }}
 app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
 {{- end }}
 app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- if .Values.labels }}
+{{ .Values.labels | toYaml }}
+{{- end }}
 {{- end -}}
 
 {{/*
@@ -65,4 +68,8 @@ Create the name of the service account to use
 {{- else -}}
     {{ default "default" .Values.serviceAccount.name }}
 {{- end -}}
+{{- end -}}
+
+{{- define "bodgeit.annotations" -}}
+{{ .Values.annotations | toYaml }}
 {{- end -}}

--- a/demo-apps/bodgeit/templates/deployment.yaml
+++ b/demo-apps/bodgeit/templates/deployment.yaml
@@ -8,6 +8,8 @@ metadata:
   name: {{ include "bodgeit.fullname" . }}
   labels:
     {{- include "bodgeit.labels" . | nindent 4 }}
+  annotations:
+    {{- include "bodgeit.annotations" . | nindent 4 }}
 spec:
   replicas: {{ .Values.replicaCount }}
   selector:
@@ -17,6 +19,8 @@ spec:
     metadata:
       labels:
         {{- include "bodgeit.selectorLabels" . | nindent 8 }}
+      annotations:
+        {{- include "bodgeit.annotations" . | nindent 8 }}
     spec:
     {{- with .Values.imagePullSecrets }}
       imagePullSecrets:

--- a/demo-apps/bodgeit/templates/service.yaml
+++ b/demo-apps/bodgeit/templates/service.yaml
@@ -8,6 +8,8 @@ metadata:
   name: {{ include "bodgeit.fullname" . }}
   labels:
     {{- include "bodgeit.labels" . | nindent 4 }}
+  annotations:
+    {{- include "bodgeit.annotations" . | nindent 4 }}
 spec:
   type: {{ .Values.service.type }}
   ports:

--- a/demo-apps/bodgeit/values.yaml
+++ b/demo-apps/bodgeit/values.yaml
@@ -21,6 +21,12 @@ imagePullSecrets: []
 nameOverride: ""
 fullnameOverride: ""
 
+# -- add labels to the deployment, service and pods
+labels: {}
+
+# -- add annotations to the deployment, service and pods
+annotations: {}
+
 podSecurityContext: {}
   # fsGroup: 2000
 

--- a/demo-apps/dummy-ssh/README.md
+++ b/demo-apps/dummy-ssh/README.md
@@ -22,11 +22,13 @@ Port 22: Username root, Password: THEPASSWORDYOUCREATED
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
 | affinity | object | `{}` |  |
+| annotations | object | `{}` | add annotations to the deployment, service and pods |
 | fullnameOverride | string | `""` |  |
 | image.pullPolicy | string | `"IfNotPresent"` |  |
 | image.repository | string | `"docker.io/securecodebox/dummy-ssh"` | Container Image |
 | image.tag | string | defaults to the appVersion | The image tag |
 | imagePullSecrets | list | `[]` |  |
+| labels | object | `{}` | add labels to the deployment, service and pods |
 | nameOverride | string | `""` |  |
 | nodeSelector | object | `{}` |  |
 | podSecurityContext | object | `{}` |  |

--- a/demo-apps/dummy-ssh/templates/_helpers.tpl
+++ b/demo-apps/dummy-ssh/templates/_helpers.tpl
@@ -46,6 +46,9 @@ helm.sh/chart: {{ include "dummy-ssh.chart" . }}
 app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
 {{- end }}
 app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- if .Values.labels }}
+{{ .Values.labels | toYaml }}
+{{- end }}
 {{- end -}}
 
 {{/*
@@ -54,4 +57,8 @@ Selector labels
 {{- define "dummy-ssh.selectorLabels" -}}
 app.kubernetes.io/name: {{ include "dummy-ssh.name" . }}
 app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end -}}
+
+{{- define "dummy-ssh.annotations" -}}
+{{ .Values.annotations | toYaml }}
 {{- end -}}

--- a/demo-apps/dummy-ssh/templates/deployment.yaml
+++ b/demo-apps/dummy-ssh/templates/deployment.yaml
@@ -8,6 +8,8 @@ metadata:
   name: {{ include "dummy-ssh.fullname" . }}
   labels:
     {{- include "dummy-ssh.labels" . | nindent 4 }}
+  annotations:
+    {{- include "dummy-ssh.annotations" . | nindent 4 }}
 spec:
   replicas: {{ .Values.replicaCount }}
   selector:
@@ -17,6 +19,8 @@ spec:
     metadata:
       labels:
         {{- include "dummy-ssh.selectorLabels" . | nindent 8 }}
+      annotations:
+        {{- include "dummy-ssh.annotations" . | nindent 8 }}
     spec:
     {{- with .Values.imagePullSecrets }}
       imagePullSecrets:

--- a/demo-apps/dummy-ssh/templates/service.yaml
+++ b/demo-apps/dummy-ssh/templates/service.yaml
@@ -8,6 +8,8 @@ metadata:
   name: {{ include "dummy-ssh.fullname" . }}
   labels:
     {{- include "dummy-ssh.labels" . | nindent 4 }}
+  annotations:
+    {{- include "dummy-ssh.annotations" . | nindent 4 }}
 spec:
   type: {{ .Values.service.type }}
   ports:

--- a/demo-apps/dummy-ssh/values.yaml
+++ b/demo-apps/dummy-ssh/values.yaml
@@ -20,6 +20,12 @@ imagePullSecrets: []
 nameOverride: ""
 fullnameOverride: ""
 
+# -- add labels to the deployment, service and pods
+labels: {}
+
+# -- add annotations to the deployment, service and pods
+annotations: {}
+
 podSecurityContext: {}
   # fsGroup: 2000
 

--- a/demo-apps/http-webhook/README.md
+++ b/demo-apps/http-webhook/README.md
@@ -22,6 +22,7 @@ A Dummy webserver to echo HTTP requests in log
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
 | affinity | object | `{}` |  |
+| annotations | object | `{}` | add annotations to the deployment, service and pods |
 | autoscaling.enabled | bool | `false` |  |
 | autoscaling.maxReplicas | int | `100` |  |
 | autoscaling.minReplicas | int | `1` |  |
@@ -36,9 +37,10 @@ A Dummy webserver to echo HTTP requests in log
 | ingress.hosts[0].host | string | `"chart-example.local"` |  |
 | ingress.hosts[0].paths | list | `[]` |  |
 | ingress.tls | list | `[]` |  |
+| labels | object | `{}` | add labels to the deployment, service and pods |
 | nameOverride | string | `""` |  |
 | nodeSelector | object | `{}` |  |
-| podAnnotations | object | `{}` |  |
+| podAnnotations | object | `{}` | deprecated. use `labels` instead. Will be removed in v3. todo(@J12934) remove podAnnotations in v3 |
 | podSecurityContext | object | `{}` |  |
 | replicaCount | int | `1` |  |
 | resources | object | `{}` |  |

--- a/demo-apps/http-webhook/templates/_helpers.tpl
+++ b/demo-apps/http-webhook/templates/_helpers.tpl
@@ -46,6 +46,9 @@ helm.sh/chart: {{ include "http-webhook.chart" . }}
 app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
 {{- end }}
 app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- if .Values.labels }}
+{{ .Values.labels | toYaml }}
+{{- end }}
 {{- end }}
 
 {{/*
@@ -66,3 +69,7 @@ Create the name of the service account to use
 {{- default "default" .Values.serviceAccount.name }}
 {{- end }}
 {{- end }}
+
+{{- define "http-webhook.annotations" -}}
+{{ .Values.annotations | toYaml }}
+{{- end -}}

--- a/demo-apps/http-webhook/templates/deployment.yaml
+++ b/demo-apps/http-webhook/templates/deployment.yaml
@@ -8,6 +8,8 @@ metadata:
   name: {{ include "http-webhook.fullname" . }}
   labels:
     {{- include "http-webhook.labels" . | nindent 4 }}
+  annotations:
+    {{- include "http-webhook.annotations" . | nindent 4 }}
 spec:
 {{- if not .Values.autoscaling.enabled }}
   replicas: {{ .Values.replicaCount }}
@@ -17,12 +19,18 @@ spec:
       {{- include "http-webhook.selectorLabels" . | nindent 6 }}
   template:
     metadata:
+      labels:
+        {{- include "http-webhook.selectorLabels" . | nindent 8 }}
+{{/* todo(@J12934) remove podAnnotations in v3, and migrate this to look like the other demo app deployments */}}
+{{- if .Values.annotations }}
+      annotations:
+        {{- include "http-webhook.annotations" . | nindent 8 }}
+{{- else }}
     {{- with .Values.podAnnotations }}
       annotations:
         {{- toYaml . | nindent 8 }}
     {{- end }}
-      labels:
-        {{- include "http-webhook.selectorLabels" . | nindent 8 }}
+{{- end }}
     spec:
       {{- with .Values.imagePullSecrets }}
       imagePullSecrets:

--- a/demo-apps/http-webhook/templates/service.yaml
+++ b/demo-apps/http-webhook/templates/service.yaml
@@ -8,6 +8,8 @@ metadata:
   name: {{ include "http-webhook.fullname" . }}
   labels:
     {{- include "http-webhook.labels" . | nindent 4 }}
+  annotations:
+    {{- include "http-webhook.annotations" . | nindent 4 }}
 spec:
   type: {{ .Values.service.type }}
   ports:

--- a/demo-apps/http-webhook/values.yaml
+++ b/demo-apps/http-webhook/values.yaml
@@ -20,6 +20,12 @@ imagePullSecrets: []
 nameOverride: ""
 fullnameOverride: ""
 
+# -- add labels to the deployment, service and pods
+labels: {}
+
+# -- add annotations to the deployment, service and pods
+annotations: {}
+
 serviceAccount:
   # Specifies whether a service account should be created
   create: true
@@ -29,6 +35,7 @@ serviceAccount:
   # If not set and create is true, a name is generated using the fullname template
   name: ""
 
+# -- deprecated. use `labels` instead. Will be removed in v3. todo(@J12934) remove podAnnotations in v3
 podAnnotations: {}
 
 podSecurityContext: {}

--- a/demo-apps/juice-shop/README.md
+++ b/demo-apps/juice-shop/README.md
@@ -22,6 +22,7 @@ OWASP Juice Shop: Probably the most modern and sophisticated insecure web applic
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
 | affinity | object | `{}` |  |
+| annotations | object | `{}` | add annotations to the deployment, service and pods |
 | fullnameOverride | string | `""` |  |
 | image.pullPolicy | string | `"IfNotPresent"` |  |
 | image.repository | string | `"docker.io/bkimminich/juice-shop"` | Container Image containing the juice-shop |
@@ -32,6 +33,7 @@ OWASP Juice Shop: Probably the most modern and sophisticated insecure web applic
 | ingress.hosts[0].host | string | `"chart-example.local"` |  |
 | ingress.hosts[0].paths | list | `[]` |  |
 | ingress.tls | list | `[]` |  |
+| labels | object | `{}` | add labels to the deployment, service and pods |
 | nameOverride | string | `""` |  |
 | nodeSelector | object | `{}` |  |
 | podSecurityContext | object | `{}` |  |

--- a/demo-apps/juice-shop/templates/_helpers.tpl
+++ b/demo-apps/juice-shop/templates/_helpers.tpl
@@ -46,6 +46,9 @@ helm.sh/chart: {{ include "juice-shop.chart" . }}
 app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
 {{- end }}
 app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- if .Values.labels }}
+{{ .Values.labels | toYaml }}
+{{- end }}
 {{- end -}}
 
 {{/*
@@ -54,4 +57,8 @@ Selector labels
 {{- define "juice-shop.selectorLabels" -}}
 app.kubernetes.io/name: {{ include "juice-shop.name" . }}
 app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end -}}
+
+{{- define "juice-shop.annotations" -}}
+{{ .Values.annotations | toYaml }}
 {{- end -}}

--- a/demo-apps/juice-shop/templates/deployment.yaml
+++ b/demo-apps/juice-shop/templates/deployment.yaml
@@ -8,6 +8,8 @@ metadata:
   name: {{ include "juice-shop.fullname" . }}
   labels:
     {{- include "juice-shop.labels" . | nindent 4 }}
+  annotations:
+    {{- include "juice-shop.annotations" . | nindent 4 }}
 spec:
   replicas: {{ .Values.replicaCount }}
   selector:
@@ -17,6 +19,8 @@ spec:
     metadata:
       labels:
         {{- include "juice-shop.selectorLabels" . | nindent 8 }}
+      annotations:
+        {{- include "juice-shop.annotations" . | nindent 8 }}
     spec:
     {{- with .Values.imagePullSecrets }}
       imagePullSecrets:

--- a/demo-apps/juice-shop/templates/service.yaml
+++ b/demo-apps/juice-shop/templates/service.yaml
@@ -8,6 +8,8 @@ metadata:
   name: {{ include "juice-shop.fullname" . }}
   labels:
     {{- include "juice-shop.labels" . | nindent 4 }}
+  annotations:
+    {{- include "juice-shop.annotations" . | nindent 4 }}
 spec:
   type: {{ .Values.service.type }}
   ports:

--- a/demo-apps/juice-shop/values.yaml
+++ b/demo-apps/juice-shop/values.yaml
@@ -20,6 +20,12 @@ imagePullSecrets: []
 nameOverride: ""
 fullnameOverride: ""
 
+# -- add labels to the deployment, service and pods
+labels: {}
+
+# -- add annotations to the deployment, service and pods
+annotations: {}
+
 podSecurityContext: {}
   # fsGroup: 2000
 

--- a/demo-apps/old-wordpress/README.md
+++ b/demo-apps/old-wordpress/README.md
@@ -21,11 +21,13 @@ Insecure & Outdated WordPress Instance: Never expose it to the internet!
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
 | affinity | object | `{}` |  |
+| annotations | object | `{}` | add annotations to the deployment, service and pods |
 | fullnameOverride | string | `""` |  |
 | image.pullPolicy | string | `"IfNotPresent"` |  |
 | image.repository | string | `"docker.io/securecodebox/old-wordpress"` | Container Image |
 | image.tag | string | defaults to the appVersion | The image tag |
 | imagePullSecrets | list | `[]` |  |
+| labels | object | `{}` | add labels to the deployment, service and pods |
 | nameOverride | string | `""` |  |
 | nodeSelector | object | `{}` |  |
 | podSecurityContext | object | `{}` |  |

--- a/demo-apps/old-wordpress/templates/_helpers.tpl
+++ b/demo-apps/old-wordpress/templates/_helpers.tpl
@@ -46,6 +46,9 @@ helm.sh/chart: {{ include "old-wordpress.chart" . }}
 app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
 {{- end }}
 app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- if .Values.labels }}
+{{ .Values.labels | toYaml }}
+{{- end }}
 {{- end -}}
 
 {{/*
@@ -54,4 +57,8 @@ Selector labels
 {{- define "old-wordpress.selectorLabels" -}}
 app.kubernetes.io/name: {{ include "old-wordpress.name" . }}
 app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end -}}
+
+{{- define "old-wordpress.annotations" -}}
+{{ .Values.annotations | toYaml }}
 {{- end -}}

--- a/demo-apps/old-wordpress/templates/deployment.yaml
+++ b/demo-apps/old-wordpress/templates/deployment.yaml
@@ -8,6 +8,8 @@ metadata:
   name: {{ include "old-wordpress.fullname" . }}
   labels:
     {{- include "old-wordpress.labels" . | nindent 4 }}
+  annotations:
+    {{- include "old-wordpress.annotations" . | nindent 4 }}
 spec:
   replicas: {{ .Values.replicaCount }}
   selector:
@@ -17,6 +19,8 @@ spec:
     metadata:
       labels:
         {{- include "old-wordpress.selectorLabels" . | nindent 8 }}
+      annotations:
+        {{- include "old-wordpress.annotations" . | nindent 8 }}
     spec:
     {{- with .Values.imagePullSecrets }}
       imagePullSecrets:

--- a/demo-apps/old-wordpress/templates/service.yaml
+++ b/demo-apps/old-wordpress/templates/service.yaml
@@ -8,6 +8,8 @@ metadata:
   name: {{ include "old-wordpress.fullname" . }}
   labels:
     {{- include "old-wordpress.labels" . | nindent 4 }}
+  annotations:
+    {{- include "old-wordpress.annotations" . | nindent 4 }}
 spec:
   type: {{ .Values.service.type }}
   ports:

--- a/demo-apps/old-wordpress/values.yaml
+++ b/demo-apps/old-wordpress/values.yaml
@@ -20,6 +20,12 @@ imagePullSecrets: []
 nameOverride: ""
 fullnameOverride: ""
 
+# -- add labels to the deployment, service and pods
+labels: {}
+
+# -- add annotations to the deployment, service and pods
+annotations: {}
+
 podSecurityContext: {}
   # fsGroup: 2000
 

--- a/demo-apps/swagger-petstore/README.md
+++ b/demo-apps/swagger-petstore/README.md
@@ -22,6 +22,7 @@ This is the sample petstore application with a restful API.
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
 | affinity | object | `{}` |  |
+| annotations | object | `{}` | add annotations to the deployment, service and pods |
 | fullnameOverride | string | `""` |  |
 | image.pullPolicy | string | `"IfNotPresent"` |  |
 | image.repository | string | `"docker.io/swaggerapi/petstore"` | Container Image |
@@ -32,6 +33,7 @@ This is the sample petstore application with a restful API.
 | ingress.hosts[0].host | string | `"chart-example.local"` |  |
 | ingress.hosts[0].paths | list | `[]` |  |
 | ingress.tls | list | `[]` |  |
+| labels | object | `{}` | add labels to the deployment, service and pods |
 | nameOverride | string | `""` |  |
 | nodeSelector | object | `{}` |  |
 | podSecurityContext | object | `{}` |  |

--- a/demo-apps/swagger-petstore/templates/_helpers.tpl
+++ b/demo-apps/swagger-petstore/templates/_helpers.tpl
@@ -46,6 +46,9 @@ helm.sh/chart: {{ include "swagger-petstore.chart" . }}
 app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
 {{- end }}
 app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- if .Values.labels }}
+{{ .Values.labels | toYaml }}
+{{- end }}
 {{- end -}}
 
 {{/*
@@ -54,4 +57,8 @@ Selector labels
 {{- define "swagger-petstore.selectorLabels" -}}
 app.kubernetes.io/name: {{ include "swagger-petstore.name" . }}
 app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end -}}
+
+{{- define "swagger-petstore.annotations" -}}
+{{ .Values.annotations | toYaml }}
 {{- end -}}

--- a/demo-apps/swagger-petstore/templates/deployment.yaml
+++ b/demo-apps/swagger-petstore/templates/deployment.yaml
@@ -8,6 +8,8 @@ metadata:
   name: {{ include "swagger-petstore.fullname" . }}
   labels:
     {{- include "swagger-petstore.labels" . | nindent 4 }}
+  annotations:
+    {{- include "swagger-petstore.annotations" . | nindent 4 }}
 spec:
   replicas: {{ .Values.replicaCount }}
   selector:
@@ -17,6 +19,8 @@ spec:
     metadata:
       labels:
         {{- include "swagger-petstore.selectorLabels" . | nindent 8 }}
+      annotations:
+        {{- include "swagger-petstore.annotations" . | nindent 8 }}
     spec:
     {{- with .Values.imagePullSecrets }}
       imagePullSecrets:

--- a/demo-apps/swagger-petstore/templates/service.yaml
+++ b/demo-apps/swagger-petstore/templates/service.yaml
@@ -8,6 +8,8 @@ metadata:
   name: {{ include "swagger-petstore.fullname" . }}
   labels:
     {{- include "swagger-petstore.labels" . | nindent 4 }}
+  annotations:
+    {{- include "swagger-petstore.annotations" . | nindent 4 }}
 spec:
   type: {{ .Values.service.type }}
   ports:

--- a/demo-apps/swagger-petstore/values.yaml
+++ b/demo-apps/swagger-petstore/values.yaml
@@ -24,6 +24,12 @@ imagePullSecrets: []
 nameOverride: ""
 fullnameOverride: ""
 
+# -- add labels to the deployment, service and pods
+labels: {}
+
+# -- add annotations to the deployment, service and pods
+annotations: {}
+
 podSecurityContext: {}
   # fsGroup: 2000
 

--- a/demo-apps/unsafe-https/README.md
+++ b/demo-apps/unsafe-https/README.md
@@ -23,11 +23,13 @@ which contains both private and public key and is not authorized by a third part
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
 | affinity | object | `{}` |  |
+| annotations | object | `{}` | add annotations to the deployment, service and pods |
 | fullnameOverride | string | `""` |  |
 | image.pullPolicy | string | `"IfNotPresent"` |  |
 | image.repository | string | `"docker.io/securecodebox/unsafe-https"` | Container Image |
 | image.tag | string | `nil` |  |
 | imagePullSecrets | list | `[]` |  |
+| labels | object | `{}` | add labels to the deployment, service and pods |
 | nameOverride | string | `""` |  |
 | nodeSelector | object | `{}` |  |
 | podSecurityContext | object | `{}` |  |

--- a/demo-apps/unsafe-https/templates/_helpers.tpl
+++ b/demo-apps/unsafe-https/templates/_helpers.tpl
@@ -46,6 +46,9 @@ helm.sh/chart: {{ include "unsafe-https.chart" . }}
 app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
 {{- end }}
 app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- if .Values.labels }}
+{{ .Values.labels | toYaml }}
+{{- end }}
 {{- end -}}
 
 {{/*
@@ -54,4 +57,8 @@ Selector labels
 {{- define "unsafe-https.selectorLabels" -}}
 app.kubernetes.io/name: {{ include "unsafe-https.name" . }}
 app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end -}}
+
+{{- define "unsafe-https.annotations" -}}
+{{ .Values.annotations | toYaml }}
 {{- end -}}

--- a/demo-apps/unsafe-https/templates/deployment.yaml
+++ b/demo-apps/unsafe-https/templates/deployment.yaml
@@ -8,6 +8,8 @@ metadata:
   name: {{ include "unsafe-https.fullname" . }}
   labels:
     {{- include "unsafe-https.labels" . | nindent 4 }}
+  annotations:
+    {{- include "unsafe-https.annotations" . | nindent 4 }}
 spec:
   replicas: {{ .Values.replicaCount }}
   selector:
@@ -17,6 +19,8 @@ spec:
     metadata:
       labels:
         {{- include "unsafe-https.selectorLabels" . | nindent 8 }}
+      annotations:
+        {{- include "unsafe-https.annotations" . | nindent 8 }}
     spec:
     {{- with .Values.imagePullSecrets }}
       imagePullSecrets:

--- a/demo-apps/unsafe-https/templates/service.yaml
+++ b/demo-apps/unsafe-https/templates/service.yaml
@@ -8,6 +8,8 @@ metadata:
   name: {{ include "unsafe-https.fullname" . }}
   labels:
     {{- include "unsafe-https.labels" . | nindent 4 }}
+  annotations:
+    {{- include "unsafe-https.annotations" . | nindent 4 }}
 spec:
   type: {{ .Values.service.type }}
   ports:

--- a/demo-apps/unsafe-https/values.yaml
+++ b/demo-apps/unsafe-https/values.yaml
@@ -20,6 +20,12 @@ imagePullSecrets: []
 nameOverride: ""
 fullnameOverride: ""
 
+# -- add labels to the deployment, service and pods
+labels: {}
+
+# -- add annotations to the deployment, service and pods
+annotations: {}
+
 podSecurityContext: {}
   # fsGroup: 2000
 


### PR DESCRIPTION
## Description

Add `labels` and `annotations` helm values to configure the labels on the demo-apps deployed via our helm-charts.

HttpWebhook already had a simmilar mechanism for podAnnotations, i marked it as deprecated to be removed in v3 as this would be confusing to have two separate mechanisms for it. I'll add it to the list in #293 

### Checklist

* [x] Test your changes as thoroughly as possible before you commit them. Preferably, automate your test by unit/integration tests.
* [x] Make sure `npm test` runs for the whole project.
* [ ] Make codeclimate checks happy
