### PR TITLE
Fix Bug Preventing `skipNotificationOnZeroFindings` from Working Correctly

### DIFF
--- a/hooks/notification-hook/hook.ts
+++ b/hooks/notification-hook/hook.ts
@@ -20,7 +20,7 @@ export async function handle({ getFindings, scan }) {
     channel.endPoint = mapToEndPoint(channel.endPoint);
     const findingsToNotify = findings.filter(finding => matches(finding, channel.rules));
 
-    if (channel.skipNotificationOnZeroFindings === true && findings.length === 0) {
+    if (channel.skipNotificationOnZeroFindings === true && findingsToNotify.length === 0) {
       continue;
     }
 


### PR DESCRIPTION
Found a bug which prevents the `skipNotificationOnZeroFindings` setting for the Notification hook.

I opened this against our 2.9 release branch to include this in a v2.9.1 patch release.