### PR TITLE
Fix inconsistent casing in findings created in DefectDojo Hooks `syncFindingsBack` Mode

### DIFF
--- a/hooks/persistence-defectdojo/hook/src/main/java/io/securecodebox/persistence/mapping/DefectDojoFindingToSecureCodeBoxMapper.java
+++ b/hooks/persistence-defectdojo/hook/src/main/java/io/securecodebox/persistence/mapping/DefectDojoFindingToSecureCodeBoxMapper.java
@@ -45,16 +45,16 @@ public class DefectDojoFindingToSecureCodeBoxMapper {
     switch (defectDojoFinding.getSeverity()) {
       case Critical:
       case High:
-        finding.setSeverity(SecureCodeBoxFinding.Severities.High);
+        finding.setSeverity(SecureCodeBoxFinding.Severities.HIGH);
         break;
       case Medium:
-        finding.setSeverity(SecureCodeBoxFinding.Severities.Medium);
+        finding.setSeverity(SecureCodeBoxFinding.Severities.MEDIUM);
         break;
       case Low:
-        finding.setSeverity(SecureCodeBoxFinding.Severities.Low);
+        finding.setSeverity(SecureCodeBoxFinding.Severities.LOW);
         break;
       case Informational:
-        finding.setSeverity(SecureCodeBoxFinding.Severities.Informational);
+        finding.setSeverity(SecureCodeBoxFinding.Severities.INFORMATIONAL);
         break;
     }
 

--- a/hooks/persistence-defectdojo/hook/src/main/java/io/securecodebox/persistence/models/SecureCodeBoxFinding.java
+++ b/hooks/persistence-defectdojo/hook/src/main/java/io/securecodebox/persistence/models/SecureCodeBoxFinding.java
@@ -42,14 +42,10 @@ public class SecureCodeBoxFinding {
   Map<String, Object> attributes;
 
   public enum Severities {
-    @JsonProperty("HIGH")
-    High,
-    @JsonProperty("MEDIUM")
-    Medium,
-    @JsonProperty("LOW")
-    Low,
-    @JsonProperty("INFORMATIONAL")
-    Informational
+    HIGH,
+    MEDIUM,
+    LOW,
+    INFORMATIONAL
     ;
   }
 }

--- a/hooks/persistence-defectdojo/hook/src/main/java/io/securecodebox/persistence/service/KubernetesService.java
+++ b/hooks/persistence-defectdojo/hook/src/main/java/io/securecodebox/persistence/service/KubernetesService.java
@@ -108,16 +108,16 @@ public class KubernetesService {
     severities.setHigh(0L);
     for (var finding: secureCodeBoxFindings) {
       switch (finding.getSeverity()) {
-        case High:
+        case HIGH:
           severities.setHigh(severities.getHigh() + 1L);
           break;
-        case Medium:
+        case MEDIUM:
           severities.setMedium(severities.getMedium() + 1L);
           break;
-        case Low:
+        case LOW:
           severities.setLow(severities.getLow() + 1L);
           break;
-        case Informational:
+        case INFORMATIONAL:
           severities.setInformational(severities.getInformational() + 1L);
           break;
       }

--- a/hooks/persistence-defectdojo/hook/src/test/java/io/securecodebox/persistence/mapping/DefectDojoFindingToSecureCodeBoxMapperTest.java
+++ b/hooks/persistence-defectdojo/hook/src/test/java/io/securecodebox/persistence/mapping/DefectDojoFindingToSecureCodeBoxMapperTest.java
@@ -65,7 +65,7 @@ class DefectDojoFindingToSecureCodeBoxMapperTest {
 
     assertEquals(
       actualFinding.getSeverity(),
-      SecureCodeBoxFinding.Severities.Medium
+      SecureCodeBoxFinding.Severities.MEDIUM
     );
 
     assertEquals(

--- a/hooks/persistence-defectdojo/hook/src/test/java/io/securecodebox/persistence/mapping/SecureCodeBoxFindingsToDefectDojoMapperTest.java
+++ b/hooks/persistence-defectdojo/hook/src/test/java/io/securecodebox/persistence/mapping/SecureCodeBoxFindingsToDefectDojoMapperTest.java
@@ -44,7 +44,7 @@ public class SecureCodeBoxFindingsToDefectDojoMapperTest {
   public void correctlyParsesFindings() throws IOException {
     var name = "Name";
     var description = "Description";
-    var severity = "High";
+    var severity = "HIGH";
     var id = "123";
     var location = "ldap://[2001:db8::7]/c=GB?objectClass?one";
     var attributes = new HashMap<String, Object>();
@@ -54,7 +54,7 @@ public class SecureCodeBoxFindingsToDefectDojoMapperTest {
     attributes.put("attribute_2", "2");
     attributes.put("attribute_3", "3");
     var scbFinding = SecureCodeBoxFinding.builder().name(name).description(description)
-      .severity(SecureCodeBoxFinding.Severities.High).id(id).location(location).attributes(attributes)
+      .severity(SecureCodeBoxFinding.Severities.HIGH).id(id).location(location).attributes(attributes)
       .build();
 
     var ddFinding = SecureCodeBoxFindingsToDefectDojoMapper.fromSecureCodeBoxFinding(scbFinding);

--- a/hooks/persistence-defectdojo/hook/src/test/java/io/securecodebox/persistence/service/KubernetesServiceTest.java
+++ b/hooks/persistence-defectdojo/hook/src/test/java/io/securecodebox/persistence/service/KubernetesServiceTest.java
@@ -17,10 +17,10 @@ class KubernetesServiceTest {
   @Test
   public void calculatesFindingStatsCorrectly() throws Exception{
     var findings = List.of(
-      SecureCodeBoxFinding.builder().category("Open Port").severity(SecureCodeBoxFinding.Severities.Informational).build(),
-      SecureCodeBoxFinding.builder().category("Open Port").severity(SecureCodeBoxFinding.Severities.Informational).build(),
-      SecureCodeBoxFinding.builder().category("Open Port").severity(SecureCodeBoxFinding.Severities.Informational).build(),
-      SecureCodeBoxFinding.builder().category("Host").severity(SecureCodeBoxFinding.Severities.Informational).build()
+      SecureCodeBoxFinding.builder().category("Open Port").severity(SecureCodeBoxFinding.Severities.INFORMATIONAL).build(),
+      SecureCodeBoxFinding.builder().category("Open Port").severity(SecureCodeBoxFinding.Severities.INFORMATIONAL).build(),
+      SecureCodeBoxFinding.builder().category("Open Port").severity(SecureCodeBoxFinding.Severities.INFORMATIONAL).build(),
+      SecureCodeBoxFinding.builder().category("Host").severity(SecureCodeBoxFinding.Severities.INFORMATIONAL).build()
     );
 
     var actualStats = KubernetesService.recalculateFindingStats(findings);

--- a/hooks/persistence-defectdojo/hook/src/test/resources/kubehunter-dd-findings.json
+++ b/hooks/persistence-defectdojo/hook/src/test/resources/kubehunter-dd-findings.json
@@ -3,7 +3,7 @@
     {
       "title": "Read access to pod's service account token",
       "description": " Accessing the pod service account token gives an attacker the option to use the server API \n {\n  \"evidence\" : \"eyJhbGciOiJSUzI1NiIsImtpZCI6IkxuOE9ZaGt1SFFabmwzN3ZEYlg1R2ZqX25VVWtnWUlnU0VOdExBbWE4VFEifQ.eyJpc3MiOiJrdWJlcm5ldGVzL3NlcnZpY2VhY2NvdW50Iiwia3ViZXJuZXRlcy5pby9zZXJ2aWNlYWNjb3VudC9uYW1lc3BhY2UiOiJkZWZhdWx0Iiwia3ViZXJuZXRlcy5pby9zZXJ2aWNlYWNjb3VudC9zZWNyZXQubmFtZSI6Imx1cmNoZXItdG9rZW4tdjI4cWIiLCJrdWJlcm5ldGVzLmlvL3NlcnZpY2VhY2NvdW50L3NlcnZpY2UtYWNjb3VudC5uYW1lIjoibHVyY2hlciIsImt1YmVybmV0ZXMuaW8vc2VydmljZWFjY291bnQvc2VydmljZS1hY2NvdW50LnVpZCI6IjIzMTg2YTI5LTY0NDQtNGI3Ny1hZjA1LTY5YzcyYWViZWYwZCIsInN1YiI6InN5c3RlbTpzZXJ2aWNlYWNjb3VudDpkZWZhdWx0Omx1cmNoZXIifQ.IeiByhB-g3W6Zzr4_cEU2sdfyAHVwgnKn-apu8YVkS9886zSeg_BB4F-KsljFApt8gZA4gzLEMuDTEubURkD-omaWw6_eHkV_SfIiD69rvLFC-wTtLLxQijrfBa1ZJ6PxI1kVnykaWMnmBUbkqaK-xsnhw8_pk536qWjwEFUyf6PUUg1wzk_IpEQAY8paDzB1Od2eoE18NbXUFZYllsqKZly59jvsjwPRRHk8yYr3eQW6AyxBezOhpY9qI3kooKY2_mzMXAiyrcmb-apucQabMuDfVaFF7zR0OQ-1wR_hwH-ZfLZXjf9S0Im8_Hf0WLPw60iWp5d9g_kdKuysPlJGg\",\n  \"kubeHunterRule\" : \"Access Secrets\"\n}",
-      "severity": "Low",
+      "severity": "LOW",
       "date": "2020-04-15",
       "unique_id_from_tool": "df9afbb5-f0c4-475b-a0e5-e3635c55917a",
       "endpoints": [
@@ -13,7 +13,7 @@
     {
       "title": "CAP_NET_RAW Enabled",
       "description": "CAP_NET_RAW is enabled by default for pods.\n    If an attacker manages to compromise a pod,\n    they could potentially take advantage of this capability to perform network\n    attacks on other pods running on the same node\n {\n  \"evidence\" : \"\",\n  \"kubeHunterRule\" : \"Pod Capabilities Hunter\"\n}",
-      "severity": "Low",
+      "severity": "LOW",
       "date": "2020-04-16",
       "unique_id_from_tool": "341ad0c8-0f3b-47ff-9b89-83d4a7e121f7",
       "endpoints": [
@@ -23,7 +23,7 @@
     {
       "title": "Access to pod's secrets",
       "description": " Accessing the pod's secrets within a compromised pod might disclose valuable data to a potential attacker\n {\n  \"evidence\" : \"['/var/run/secrets/kubernetes.io/serviceaccount/token', '/var/run/secrets/kubernetes.io/serviceaccount/namespace', '/var/run/secrets/kubernetes.io/serviceaccount/ca.crt', '/var/run/secrets/kubernetes.io/serviceaccount/..2021_05_17_21_58_54.448582170/token', '/var/run/secrets/kubernetes.io/serviceaccount/..2021_05_17_21_58_54.448582170/namespace', '/var/run/secrets/kubernetes.io/serviceaccount/..2021_05_17_21_58_54.448582170/ca.crt']\",\n  \"kubeHunterRule\" : \"Access Secrets\"\n}",
-      "severity": "Low",
+      "severity": "LOW",
       "date": "2020-04-17",
       "unique_id_from_tool": "eb0c75cf-beef-4fd8-b2ed-6e46a5afa1bc",
       "endpoints": [


### PR DESCRIPTION
Severities were accidentally formatted incorrectly by using the jackson annotations wrongly.