### PR TITLE
Cascading Scans bugfixing

### DIFF
--- a/hooks/cascading-scans/hook/hook.test.js
+++ b/hooks/cascading-scans/hook/hook.test.js
@@ -660,6 +660,16 @@ test("should properly parse template values in scanLabels and scanAnnotations", 
 
   const findings = [
     {
+      name: "Port 8443 is open",
+      category: "Open Port",
+      attributes: {
+        state: "open",
+        hostname: "foobar.com",
+        port: 8443,
+        service: "https"
+      }
+    },
+    {
       name: "Port 443 is open",
       category: "Open Port",
       attributes: {
@@ -677,6 +687,8 @@ test("should properly parse template values in scanLabels and scanAnnotations", 
     sslyzeCascadingRules,
     sslyzeCascadingRules[0]
   );
+
+  expect(sslyzeCascadingRules[0].spec.scanSpec.parameters).toEqual(["--regular", "{{$.hostOrIP}}:{{attributes.port}}"])
 
   const { labels, annotations } = cascadedScans[0].metadata;
 

--- a/hooks/cascading-scans/hook/hook.ts
+++ b/hooks/cascading-scans/hook/hook.ts
@@ -121,6 +121,7 @@ function getCascadingScan(
       generateName: `${generateCascadingScanName(parentScan, cascadingRule)}-`,
       labels,
       annotations: {
+        ...annotations,
         "securecodebox.io/hook": "cascading-scans",
         "cascading.securecodebox.io/parent-scan": parentScan.metadata.name,
         "cascading.securecodebox.io/matched-finding": finding.id,
@@ -128,7 +129,6 @@ function getCascadingScan(
           ...cascadingChain,
           cascadingRule.metadata.name
         ].join(","),
-        ...annotations,
       },
       ownerReferences: [
         {

--- a/hooks/cascading-scans/hook/hook.ts
+++ b/hooks/cascading-scans/hook/hook.ts
@@ -2,7 +2,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-import { isMatch, isMatchWith, isString, mapValues } from "lodash";
+import { isMatch, isMatchWith, isString, mapValues, cloneDeep } from "lodash";
 import { isMatch as wildcardIsMatch } from "matcher";
 import * as Mustache from "mustache";
 
@@ -105,7 +105,8 @@ function getCascadingScan(
   finding: Finding,
   cascadingRule: CascadingRule
 ) {
-  cascadingRule = templateCascadingRule(parentScan, finding, cascadingRule);
+  // Make a deep copy of the original cascading rule so that we can template it again with different findings.
+  cascadingRule = templateCascadingRule(parentScan, finding, cloneDeep(cascadingRule));
 
   let { scanType, parameters } = cascadingRule.spec.scanSpec;
 

--- a/hooks/cascading-scans/hook/hook.ts
+++ b/hooks/cascading-scans/hook/hook.ts
@@ -112,12 +112,7 @@ function getCascadingScan(
 
   let { annotations, labels, env, volumes, volumeMounts } = mergeCascadingRuleWithScan(parentScan, cascadingRule);
 
-  let cascadingChain: Array<string> = [];
-  if (parentScan.metadata.annotations && parentScan.metadata.annotations["cascading.securecodebox.io/chain"]) {
-    cascadingChain = parentScan.metadata.annotations[
-      "cascading.securecodebox.io/chain"
-    ].split(",");
-  }
+  let cascadingChain = getScanChain(parentScan);
 
   return {
     apiVersion: "execution.securecodebox.io/v1",


### PR DESCRIPTION
## Description
- 0471226 fixes a bug where if a single rule would be applied to two findings, it would only be templated using the first finding.
- 545898e simple cleanup.
- 5896910 fixes a bug where the new secureCodeBox.io annotations (such as parent-scan, matched-finding, and chain) would be overwritten by the parent's annotations (if inheritAnnotations was enabled; default).

### Checklist

* [x] Test your changes as thoroughly as possible before you commit them. Preferably, automate your test by unit/integration tests.
* [x] Make sure `npm test` runs for the whole project.
* [x] Make codeclimate checks happy
