### PR TITLE
Update Kubernetes Versions used in CI

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -356,7 +356,7 @@ jobs:
       - name: "Start kind cluster"
         run: |
           kind version
-          kind create cluster --image kindest/node:v1.22.0@sha256:b8bda84bb3a190e6e028b1760d277454a72267a5454b57db34437c34a588d047
+          kind create cluster --wait 3m --image kindest/node:v1.22.0@sha256:b8bda84bb3a190e6e028b1760d277454a72267a5454b57db34437c34a588d047
 
       - name: "Inspect kind cluster"
         run: |

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -356,7 +356,7 @@ jobs:
       - name: "Start kind cluster"
         run: |
           kind version
-          kind create cluster --image kindest/node:v1.21.1@sha256:69860bda5563ac81e3c0057d654b5253219618a22ec3a346306239bba8cfa1a6 --wait 3m
+          kind create cluster --image kindest/node:v1.22.0@sha256:b8bda84bb3a190e6e028b1760d277454a72267a5454b57db34437c34a588d047
 
       - name: "Inspect kind cluster"
         run: |
@@ -753,10 +753,10 @@ jobs:
     strategy:
       matrix:
         k8sVersion:
+          - v1.22.0@sha256:b8bda84bb3a190e6e028b1760d277454a72267a5454b57db34437c34a588d047
           - v1.21.1@sha256:69860bda5563ac81e3c0057d654b5253219618a22ec3a346306239bba8cfa1a6
           - v1.20.7@sha256:cbeaf907fc78ac97ce7b625e4bf0de16e3ea725daf6b04f930bd14c67c671ff9
           - v1.19.11@sha256:07db187ae84b4b7de440a73886f008cf903fcf5764ba8106a9fd5243d6f32729
-          - v1.18.19@sha256:7af1492e19b3192a79f606e43c35fb741e520d195f96399284515f077b3b622c 
     steps:
       - uses: actions/checkout@master
       - name: "Start kind cluster"


### PR DESCRIPTION
Adds Kubernetes 1.22 and removes Kubernetes 1.18 from Test matrix.
Also switches the new Makefile builds to 1.22 from 1.21