### PR TITLE
[Bugfix] Remove Name Property From Scan Spec

### DIFF
--- a/scanners/trivy/templates/trivy-scan-type.yaml
+++ b/scanners/trivy/templates/trivy-scan-type.yaml
@@ -7,7 +7,6 @@ kind: ScanType
 metadata:
   name: "trivy{{ .Values.scanner.nameAppend | default ""}}"
 spec:
-  name: "trivy"
   extractResults:
     type: trivy-json
     location: "/home/securecodebox/trivy-results.json"


### PR DESCRIPTION
It looks like this name property was added by accident, as it does not
pass the scantype spec.
This caused the installation of the helm chart to fail

closes #589 

Signed-off-by: Yannik Fuhrmeister <yannik.fuhrmeister@protonmail.com>
