### PR TITLE
Revert Change in Helmignore to Include the Scripts Again

### DIFF
--- a/scanners/zap-advanced/.helmignore
+++ b/scanners/zap-advanced/.helmignore
@@ -11,7 +11,8 @@ scanner/zapclient/
 scanner/tests/
 scanner/venv/
 scanner/.pytest_cache/
-scanner/.idea/examples/
+scanner/.idea/
+examples/
 docs/
 integration-tests/
 coverage/

--- a/scanners/zap-advanced/.helmignore
+++ b/scanners/zap-advanced/.helmignore
@@ -5,8 +5,13 @@
 .DS_Store
 
 parser/
-scanner/
-examples/
+# this doesn't look too good but is required so that the scanners/scripts folder is included
+scanner/*.*
+scanner/zapclient/
+scanner/tests/
+scanner/venv/
+scanner/.pytest_cache/
+scanner/.idea/examples/
 docs/
 integration-tests/
 coverage/


### PR DESCRIPTION
This caused the configmaps to contain no scripts, as they were ignored from the charts :(