### PR TITLE
Fix Incorrect Path for API Import in Petstore Example

### DIFF
--- a/scanners/zap-advanced/examples/demo-petstoreapi-scan-unauthenticated/scan.yaml
+++ b/scanners/zap-advanced/examples/demo-petstoreapi-scan-unauthenticated/scan.yaml
@@ -54,8 +54,8 @@ data:
         format: openapi
         # -- Url to start spidering from, default: first context URL
         url: http://petstore.demo-targets.svc/v2/swagger.json
-        # -- Relative path for the given targetUrl. mutually exclusiv to the URL configuration.
-        relativePath: /v2/swagger.json
+        # -- Relative path for the given targetUrl. mutually exclusive to the URL configuration.
+        path: /v2/swagger.json
         # -- Override host setting in swagger.json
         hostOverride: http://petstore.demo-targets.svc
 

--- a/scanners/zap-advanced/examples/demo-petstoreapi-scan-unauthenticated/scan.yaml
+++ b/scanners/zap-advanced/examples/demo-petstoreapi-scan-unauthenticated/scan.yaml
@@ -55,7 +55,7 @@ data:
         # -- Url to start spidering from, default: first context URL
         url: http://petstore.demo-targets.svc/v2/swagger.json
         # -- Relative path for the given targetUrl. mutually exclusive to the URL configuration.
-        path: /v2/swagger.json
+        # path: /v2/swagger.json
         # -- Override host setting in swagger.json
         hostOverride: http://petstore.demo-targets.svc
 


### PR DESCRIPTION
Changed `relativePath` to the correct `path` and commented it out as it can't be used together with `url`.