### PR TITLE
Upgrade all npm packages with npm audit fix

### DIFF
--- a/hook-sdk/nodejs/package-lock.json
+++ b/hook-sdk/nodejs/package-lock.json
@@ -4456,9 +4456,9 @@
       "dev": true
     },
     "node_modules/tar": {
-      "version": "6.1.8",
-      "resolved": "https://registry.npmjs.org/tar/-/tar-6.1.8.tgz",
-      "integrity": "sha512-sb9b0cp855NbkMJcskdSYA7b11Q8JsX4qe4pyUAfHp+Y6jBjJeek2ZVlwEfWayshEIwlIzXx0Fain3QG9JPm2A==",
+      "version": "6.1.11",
+      "resolved": "https://registry.npmjs.org/tar/-/tar-6.1.11.tgz",
+      "integrity": "sha512-an/KZQzQUkZCkuoAA64hM92X0Urb6VpRhAFllDzz44U2mcD5scmT3zBc4VgVpkugF580+DQn8eAFSyoQt0tznA==",
       "dependencies": {
         "chownr": "^2.0.0",
         "fs-minipass": "^2.0.0",
@@ -8328,9 +8328,9 @@
       "dev": true
     },
     "tar": {
-      "version": "6.1.8",
-      "resolved": "https://registry.npmjs.org/tar/-/tar-6.1.8.tgz",
-      "integrity": "sha512-sb9b0cp855NbkMJcskdSYA7b11Q8JsX4qe4pyUAfHp+Y6jBjJeek2ZVlwEfWayshEIwlIzXx0Fain3QG9JPm2A==",
+      "version": "6.1.11",
+      "resolved": "https://registry.npmjs.org/tar/-/tar-6.1.11.tgz",
+      "integrity": "sha512-an/KZQzQUkZCkuoAA64hM92X0Urb6VpRhAFllDzz44U2mcD5scmT3zBc4VgVpkugF580+DQn8eAFSyoQt0tznA==",
       "requires": {
         "chownr": "^2.0.0",
         "fs-minipass": "^2.0.0",

--- a/hooks/cascading-scans/hook/package-lock.json
+++ b/hooks/cascading-scans/hook/package-lock.json
@@ -4516,9 +4516,9 @@
       "dev": true
     },
     "node_modules/tar": {
-      "version": "6.1.8",
-      "resolved": "https://registry.npmjs.org/tar/-/tar-6.1.8.tgz",
-      "integrity": "sha512-sb9b0cp855NbkMJcskdSYA7b11Q8JsX4qe4pyUAfHp+Y6jBjJeek2ZVlwEfWayshEIwlIzXx0Fain3QG9JPm2A==",
+      "version": "6.1.11",
+      "resolved": "https://registry.npmjs.org/tar/-/tar-6.1.11.tgz",
+      "integrity": "sha512-an/KZQzQUkZCkuoAA64hM92X0Urb6VpRhAFllDzz44U2mcD5scmT3zBc4VgVpkugF580+DQn8eAFSyoQt0tznA==",
       "dependencies": {
         "chownr": "^2.0.0",
         "fs-minipass": "^2.0.0",
@@ -8453,9 +8453,9 @@
       "dev": true
     },
     "tar": {
-      "version": "6.1.8",
-      "resolved": "https://registry.npmjs.org/tar/-/tar-6.1.8.tgz",
-      "integrity": "sha512-sb9b0cp855NbkMJcskdSYA7b11Q8JsX4qe4pyUAfHp+Y6jBjJeek2ZVlwEfWayshEIwlIzXx0Fain3QG9JPm2A==",
+      "version": "6.1.11",
+      "resolved": "https://registry.npmjs.org/tar/-/tar-6.1.11.tgz",
+      "integrity": "sha512-an/KZQzQUkZCkuoAA64hM92X0Urb6VpRhAFllDzz44U2mcD5scmT3zBc4VgVpkugF580+DQn8eAFSyoQt0tznA==",
       "requires": {
         "chownr": "^2.0.0",
         "fs-minipass": "^2.0.0",

--- a/hooks/finding-post-processing/hook/package.json
+++ b/hooks/finding-post-processing/hook/package.json
@@ -1,5 +1,5 @@
 {
-"name": "@securecodebox/hook-finding-post-processing",
+  "name": "@securecodebox/hook-finding-post-processing",
   "version": "1.0.0",
   "description": "secureCodeBox Finding Post Processing Hook",
   "main": "hook.js",

--- a/hooks/generic-webhook/hook/package.json
+++ b/hooks/generic-webhook/hook/package.json
@@ -1,5 +1,5 @@
 {
-"name": "@securecodebox/hook-generic-webhook",
+  "name": "@securecodebox/hook-generic-webhook",
   "version": "1.0.0",
   "description": "secureCodeBox Generic WebHook.",
   "homepage": "https://www.secureCodeBox.io",

--- a/hooks/notification/hook/package-lock.json
+++ b/hooks/notification/hook/package-lock.json
@@ -5056,9 +5056,9 @@
       "dev": true
     },
     "node_modules/tar": {
-      "version": "6.1.8",
-      "resolved": "https://registry.npmjs.org/tar/-/tar-6.1.8.tgz",
-      "integrity": "sha512-sb9b0cp855NbkMJcskdSYA7b11Q8JsX4qe4pyUAfHp+Y6jBjJeek2ZVlwEfWayshEIwlIzXx0Fain3QG9JPm2A==",
+      "version": "6.1.11",
+      "resolved": "https://registry.npmjs.org/tar/-/tar-6.1.11.tgz",
+      "integrity": "sha512-an/KZQzQUkZCkuoAA64hM92X0Urb6VpRhAFllDzz44U2mcD5scmT3zBc4VgVpkugF580+DQn8eAFSyoQt0tznA==",
       "dependencies": {
         "chownr": "^2.0.0",
         "fs-minipass": "^2.0.0",
@@ -9442,9 +9442,9 @@
       "dev": true
     },
     "tar": {
-      "version": "6.1.8",
-      "resolved": "https://registry.npmjs.org/tar/-/tar-6.1.8.tgz",
-      "integrity": "sha512-sb9b0cp855NbkMJcskdSYA7b11Q8JsX4qe4pyUAfHp+Y6jBjJeek2ZVlwEfWayshEIwlIzXx0Fain3QG9JPm2A==",
+      "version": "6.1.11",
+      "resolved": "https://registry.npmjs.org/tar/-/tar-6.1.11.tgz",
+      "integrity": "sha512-an/KZQzQUkZCkuoAA64hM92X0Urb6VpRhAFllDzz44U2mcD5scmT3zBc4VgVpkugF580+DQn8eAFSyoQt0tznA==",
       "requires": {
         "chownr": "^2.0.0",
         "fs-minipass": "^2.0.0",

--- a/hooks/persistence-elastic/hook/package.json
+++ b/hooks/persistence-elastic/hook/package.json
@@ -1,5 +1,5 @@
 {
-"name": "@securecodebox/hook-persistence-elastic",
+  "name": "@securecodebox/hook-persistence-elastic",
   "version": "1.0.0",
   "description": "secureCodeBox Hook to persist results to elasticsearch.",
   "homepage": "https://www.secureCodeBox.io",

--- a/hooks/update-field/hook/package.json
+++ b/hooks/update-field/hook/package.json
@@ -1,5 +1,5 @@
 {
-"name": "@securecodebox/hook-update-field",
+  "name": "@securecodebox/hook-update-field",
   "version": "1.0.0",
   "description": "secureCodeBox Hook for Update Field",
   "homepage": "https://www.secureCodeBox.io",

--- a/parser-sdk/nodejs/package-lock.json
+++ b/parser-sdk/nodejs/package-lock.json
@@ -1419,9 +1419,9 @@
       }
     },
     "node_modules/tar": {
-      "version": "6.1.8",
-      "resolved": "https://registry.npmjs.org/tar/-/tar-6.1.8.tgz",
-      "integrity": "sha512-sb9b0cp855NbkMJcskdSYA7b11Q8JsX4qe4pyUAfHp+Y6jBjJeek2ZVlwEfWayshEIwlIzXx0Fain3QG9JPm2A==",
+      "version": "6.1.11",
+      "resolved": "https://registry.npmjs.org/tar/-/tar-6.1.11.tgz",
+      "integrity": "sha512-an/KZQzQUkZCkuoAA64hM92X0Urb6VpRhAFllDzz44U2mcD5scmT3zBc4VgVpkugF580+DQn8eAFSyoQt0tznA==",
       "dependencies": {
         "chownr": "^2.0.0",
         "fs-minipass": "^2.0.0",
@@ -2620,9 +2620,9 @@
       "integrity": "sha512-BrpvfNAE3dcvq7ll3xVumzjKjZQ5tI1sEUIKr3Uoks0XUl45St3FlatVqef9prk4jRDzhW6WZg+3bk93y6pLjA=="
     },
     "tar": {
-      "version": "6.1.8",
-      "resolved": "https://registry.npmjs.org/tar/-/tar-6.1.8.tgz",
-      "integrity": "sha512-sb9b0cp855NbkMJcskdSYA7b11Q8JsX4qe4pyUAfHp+Y6jBjJeek2ZVlwEfWayshEIwlIzXx0Fain3QG9JPm2A==",
+      "version": "6.1.11",
+      "resolved": "https://registry.npmjs.org/tar/-/tar-6.1.11.tgz",
+      "integrity": "sha512-an/KZQzQUkZCkuoAA64hM92X0Urb6VpRhAFllDzz44U2mcD5scmT3zBc4VgVpkugF580+DQn8eAFSyoQt0tznA==",
       "requires": {
         "chownr": "^2.0.0",
         "fs-minipass": "^2.0.0",

--- a/scanners/nuclei/parser/package-lock.json
+++ b/scanners/nuclei/parser/package-lock.json
@@ -1,5 +1,14 @@
 {
   "name": "@securecodebox/parser-nuclei",
   "version": "1.0.0",
-  "lockfileVersion": 1
+  "lockfileVersion": 2,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "@securecodebox/parser-nuclei",
+      "version": "1.0.0",
+      "license": "Apache-2.0",
+      "devDependencies": {}
+    }
+  }
 }

--- a/scanners/nuclei/parser/package.json
+++ b/scanners/nuclei/parser/package.json
@@ -7,6 +7,5 @@
   "keywords": [],
   "author": "iteratec GmbH",
   "license": "Apache-2.0",
-  "dependencies": {},
   "devDependencies": {}
 }

--- a/tests/integration/package-lock.json
+++ b/tests/integration/package-lock.json
@@ -4749,9 +4749,9 @@
       "dev": true
     },
     "node_modules/tar": {
-      "version": "6.1.8",
-      "resolved": "https://registry.npmjs.org/tar/-/tar-6.1.8.tgz",
-      "integrity": "sha512-sb9b0cp855NbkMJcskdSYA7b11Q8JsX4qe4pyUAfHp+Y6jBjJeek2ZVlwEfWayshEIwlIzXx0Fain3QG9JPm2A==",
+      "version": "6.1.11",
+      "resolved": "https://registry.npmjs.org/tar/-/tar-6.1.11.tgz",
+      "integrity": "sha512-an/KZQzQUkZCkuoAA64hM92X0Urb6VpRhAFllDzz44U2mcD5scmT3zBc4VgVpkugF580+DQn8eAFSyoQt0tznA==",
       "dev": true,
       "dependencies": {
         "chownr": "^2.0.0",
@@ -8896,9 +8896,9 @@
       "dev": true
     },
     "tar": {
-      "version": "6.1.8",
-      "resolved": "https://registry.npmjs.org/tar/-/tar-6.1.8.tgz",
-      "integrity": "sha512-sb9b0cp855NbkMJcskdSYA7b11Q8JsX4qe4pyUAfHp+Y6jBjJeek2ZVlwEfWayshEIwlIzXx0Fain3QG9JPm2A==",
+      "version": "6.1.11",
+      "resolved": "https://registry.npmjs.org/tar/-/tar-6.1.11.tgz",
+      "integrity": "sha512-an/KZQzQUkZCkuoAA64hM92X0Urb6VpRhAFllDzz44U2mcD5scmT3zBc4VgVpkugF580+DQn8eAFSyoQt0tznA==",
       "dev": true,
       "requires": {
         "chownr": "^2.0.0",


### PR DESCRIPTION
Upgraded all npm dependencies, with our `./bin/npm-audit-fix-all.sh` script.
This should replace the open snyk prs.

Closes #626
Closes #627
Closes #628
Closes #629
Closes #631