### PR TITLE
Use proper DefectDojo importer for nuclei and wpscan scans

### DIFF
--- a/hooks/persistence-defectdojo/hook/build.gradle
+++ b/hooks/persistence-defectdojo/hook/build.gradle
@@ -22,7 +22,7 @@ repositories {
 dependencies {
   implementation 'io.kubernetes:client-java:12.0.0'
 
-  implementation 'io.securecodebox:defectdojo-client:0.0.19-SNAPSHOT'
+  implementation 'io.securecodebox:defectdojo-client:0.0.20-SNAPSHOT'
 
   implementation group: 'org.springframework', name: 'spring-web', version: '5.3.9'
   implementation 'com.fasterxml.jackson.core:jackson-core:2.12.4'

--- a/hooks/persistence-defectdojo/hook/src/main/java/io/securecodebox/persistence/util/ScanNameMapping.java
+++ b/hooks/persistence-defectdojo/hook/src/main/java/io/securecodebox/persistence/util/ScanNameMapping.java
@@ -15,7 +15,9 @@ public enum ScanNameMapping {
   SSLYZE("sslyze", ScanType.SSLYZE_3_JSON_SCAN),
   TRIVY("trivy", ScanType.TRIVY_SCAN),
   GITLEAKS("gitleaks", ScanType.GITLEAKS_SCAN),
-  NIKTO("nikto", ScanType.NIKTO_SCAN), 
+  NIKTO("nikto", ScanType.NIKTO_SCAN),
+  NUCLEI("nuclei", ScanType.NUCLEI_SCAN),
+  WPSCAN("wpscan", ScanType.WPSCAN),
   GENERIC(null, ScanType.GENERIC_FINDINGS_IMPORT)
   ;
 

--- a/hooks/persistence-defectdojo/hook/src/test/java/io/securecodebox/persistence/mapping/DefectDojoFindingToSecureCodeBoxMapperTest.java
+++ b/hooks/persistence-defectdojo/hook/src/test/java/io/securecodebox/persistence/mapping/DefectDojoFindingToSecureCodeBoxMapperTest.java
@@ -33,7 +33,7 @@ class DefectDojoFindingToSecureCodeBoxMapperTest {
 
   @BeforeEach
   public void setup(){
-    var config = new DefectDojoConfig("http://example.defectdojo.com", "placeholder", "placeholder");
+    var config = new DefectDojoConfig("http://example.defectdojo.com", "placeholder", "placeholder", 1000);
     this.mapper = new DefectDojoFindingToSecureCodeBoxMapper(config, endpointService);
   }
 

--- a/hooks/persistence-defectdojo/hook/src/test/java/io/securecodebox/persistence/strategies/VersionedEngagementsStrategyTest.java
+++ b/hooks/persistence-defectdojo/hook/src/test/java/io/securecodebox/persistence/strategies/VersionedEngagementsStrategyTest.java
@@ -54,7 +54,7 @@ public class VersionedEngagementsStrategyTest {
 
   @BeforeEach
   public void setup() throws Exception {
-    versionedEngagementsStrategy.config = new DefectDojoConfig("https://defectdojo.example.com", "<key>", "foobar");
+    versionedEngagementsStrategy.config = new DefectDojoConfig("https://defectdojo.example.com", "<key>", "foobar", 1000);
 
     scan = new Scan();
     scan.setApiVersion("execution.securecodebox.io/v1");


### PR DESCRIPTION
## Description

DD Hook now uses the native importers included in newer DefectDojo versions for wpscan and nuclei instead of falling back to the generic importer.
Tested both scanTypes import to DefectDojo still works correctly.

Also updates the tests to a change in the DD Client Config Class which now requires an additional argument.

### Checklist

* [x] Test your changes as thoroughly as possible before you commit them. Preferably, automate your test by unit/integration tests.
* [x] Make sure `npm test` runs for the whole project.
* [x] Make codeclimate checks happy
