### PR TITLE
Automatically Use Correct Batch Apiversion for Nuclei Cronjob

### DIFF
--- a/scanners/nuclei/templates/nuclei-scan-type.yaml
+++ b/scanners/nuclei/templates/nuclei-scan-type.yaml
@@ -16,7 +16,9 @@ spec:
       ttlSecondsAfterFinished: {{ .Values.scanner.ttlSecondsAfterFinished }}
       {{- end }}
       backoffLimit: {{ .Values.scanner.backoffLimit }}
+      {{- if .Values.scanner.activeDeadlineSeconds }}
       activeDeadlineSeconds: {{ .Values.scanner.activeDeadlineSeconds }}
+      {{- end }}
       template:
         spec:
           restartPolicy: OnFailure

--- a/scanners/nuclei/templates/nuclei-update-cache-job.yaml
+++ b/scanners/nuclei/templates/nuclei-update-cache-job.yaml
@@ -4,7 +4,7 @@
 
 # We use a persistent volume for central storing of all nuclei-templates to prevent downloading it for each scan again, enabled by default.
 {{ if .Values.nucleiTemplateCache.enabled }}
-{{- if semverCompare ">=1.21-0" .Capabilities.KubeVersion.GitVersion -}}
+{{- if .Capabilities.APIVersions.Has "batch/v1/CronJob" -}}
 apiVersion: batch/v1
 {{- else -}}
 apiVersion: batch/v1beta1

--- a/scanners/nuclei/templates/nuclei-update-cache-job.yaml
+++ b/scanners/nuclei/templates/nuclei-update-cache-job.yaml
@@ -4,7 +4,11 @@
 
 # We use a persistent volume for central storing of all nuclei-templates to prevent downloading it for each scan again, enabled by default.
 {{ if .Values.nucleiTemplateCache.enabled }}
+{{- if semverCompare ">=1.21-0" .Capabilities.KubeVersion.GitVersion -}}
 apiVersion: batch/v1
+{{- else -}}
+apiVersion: batch/v1beta1
+{{- end }}
 kind: CronJob
 metadata:
   name: nuclei-update-template-cache


### PR DESCRIPTION
Fixes an issue for older Kubernetes versions (1.20 and lower) where the nuclei chart could not be installed correctly.