### PR TITLE
Cache SDK Images As Artifacts

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -346,7 +346,9 @@ jobs:
           path: /tmp
 
       - name: Load Parser SDK Image
-        run: docker load --input /tmp/parser-sdk.tar
+        run: |
+          docker load --input /tmp/parser-sdk.tar
+          docker images | grep sdk
 
       - name: Build
         uses: docker/build-push-action@v2
@@ -446,7 +448,9 @@ jobs:
           path: /tmp
 
       - name: Load Hook SDK Image
-        run: docker load --input /tmp/hook-sdk.tar
+        run: |
+          docker load --input /tmp/hook-sdk.tar
+          docker images | grep sdk
 
       - name: Build and Push
         uses: docker/build-push-action@v2
@@ -530,7 +534,9 @@ jobs:
           path: /tmp
 
       - name: Load Parser SDK Image
-        run: docker load --input /tmp/parser-sdk.tar
+        run: |
+          docker load --input /tmp/parser-sdk.tar
+          docker images | grep sdk
 
       - name: Build and Push
         uses: docker/build-push-action@v2

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -332,6 +332,8 @@ jobs:
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v1
+        with:
+          driver: docker
 
       - name: Login to DockerHub
         uses: docker/login-action@v1
@@ -430,6 +432,8 @@ jobs:
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v1
+        with:
+          driver: docker
 
       - name: Login to DockerHub
         uses: docker/login-action@v1
@@ -516,6 +520,8 @@ jobs:
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v1
+        with:
+          driver: docker
 
       - name: Login to DockerHub
         uses: docker/login-action@v1

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -285,6 +285,7 @@ jobs:
         with:
           name: ${{ matrix.sdk }}-image
           path: ./${{ matrix.sdk }}/nodejs/${{ matrix.sdk }}.tar
+          retention-days: 1
 
   # ---- New Makefile based CI Pipeline steps ----
 

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -273,11 +273,11 @@ jobs:
         uses: actions/checkout@v2
 
       - name: Build Image
-        working-dir: ./${{ matrix.sdk }}/nodejs
+        working-directory: ./${{ matrix.sdk }}/nodejs
 	      run: make docker-build-sdk
 
       - name: Export Image
-        working-dir: ./${{ matrix.sdk }}/nodejs
+        working-directory: ./${{ matrix.sdk }}/nodejs
         run: make docker-export-sdk
 
       - name: Upload Artifact

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -272,33 +272,19 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v2
 
-      - name: Docker Meta
-        id: docker_meta
-        uses: docker/metadata-action@v3
-        with:
-          images: ${{ env.DOCKER_NAMESPACE }}/${{ matrix.sdk }}-nodejs
-          tags: |
-            type=sha
-            type=semver,pattern={{version}}
+      - name: Build Image
+        working-dir: ./${{ matrix.sdk }}/nodejs
+	      run: make docker-build-sdk
 
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v1
+      - name: Export Image
+        working-dir: ./${{ matrix.sdk }}/nodejs
+        run: make docker-export-sdk
 
-      - name: Login to DockerHub
-        uses: docker/login-action@v1
+      - name: Upload Artifact
+        uses: actions/upload-artifact@v2
         with:
-          username: ${{ secrets.DOCKER_USERNAME }}
-          password: ${{ secrets.DOCKER_TOKEN }}
-
-      - name: Build and Push
-        uses: docker/build-push-action@v2
-        with:
-          context: ./${{ matrix.sdk }}/nodejs
-          file: ./${{ matrix.sdk }}/nodejs/Dockerfile
-          platforms: linux/amd64
-          push: true
-          tags: ${{ steps.docker_meta.outputs.tags }}
-          labels: ${{ steps.docker_meta.outputs.labels }}
+          name: ${{ matrix.sdk }}-image
+          path: ./${{ matrix.sdk }}/nodejs/${{ matrix.sdk }}.tar
 
   # ---- New Makefile based CI Pipeline steps ----
 

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -339,6 +339,15 @@ jobs:
           username: ${{ secrets.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_TOKEN }}
 
+      - name: Download Parser SDK Image
+        uses: actions/download-artifact@v2
+        with:
+          name: parser-sdk-image
+          path: /tmp
+
+      - name: Load Parser SDK Image
+        run: docker load --input /tmp/parser-sdk.tar
+
       - name: Build
         uses: docker/build-push-action@v2
         with:
@@ -430,6 +439,15 @@ jobs:
         run: |
           echo "baseImageTag=sha-$(git rev-parse --short HEAD)" >> $GITHUB_ENV
 
+      - name: Download Hook SDK Image
+        uses: actions/download-artifact@v2
+        with:
+          name: hook-sdk-image
+          path: /tmp
+
+      - name: Load Hook SDK Image
+        run: docker load --input /tmp/hook-sdk.tar
+
       - name: Build and Push
         uses: docker/build-push-action@v2
         with:
@@ -504,6 +522,15 @@ jobs:
       - name: Set baseImageTag to commit hash
         run: |
           echo "baseImageTag=sha-$(git rev-parse --short HEAD)" >> $GITHUB_ENV
+
+      - name: Download Parser SDK Image
+        uses: actions/download-artifact@v2
+        with:
+          name: parser-sdk-image
+          path: /tmp
+
+      - name: Load Parser SDK Image
+        run: docker load --input /tmp/parser-sdk.tar
 
       - name: Build and Push
         uses: docker/build-push-action@v2

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -274,7 +274,7 @@ jobs:
 
       - name: Build Image
         working-directory: ./${{ matrix.sdk }}/nodejs
-	      run: make docker-build-sdk
+        run: make docker-build-sdk
 
       - name: Export Image
         working-directory: ./${{ matrix.sdk }}/nodejs

--- a/hook-sdk/nodejs/Makefile
+++ b/hook-sdk/nodejs/Makefile
@@ -1,0 +1,3 @@
+sdk = hook-sdk
+include_guard = set
+include ../../sdk.mk

--- a/parser-sdk/nodejs/Makefile
+++ b/parser-sdk/nodejs/Makefile
@@ -1,0 +1,3 @@
+sdk = parser-sdk
+include_guard = set
+include ../../sdk.mk

--- a/sdk.mk
+++ b/sdk.mk
@@ -1,0 +1,32 @@
+#!/usr/bin/make -f
+#
+# SPDX-FileCopyrightText: 2021 iteratec GmbH
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+#
+# This Makefile is intended to be used for developement and testing only.
+# For using this scanner/hook in production please use the helm chart.
+# See: <https://docs.securecodebox.io/docs/getting-started/installation>
+#
+# This Makefile expects some additional software to be installed:
+# - git
+# - node + npm
+# - docker
+# - kind
+# - kubectl
+# - helm
+# - yq
+
+
+name = ${sdk}
+module = ${sdk}
+include ../../common.mk
+
+docker-build-sdk:
+	@echo ".: ⚙️ Build '$(name)'."
+	docker build -t $(IMG_NS)/$(name)-nodejs:$(IMG_TAG) .
+
+docker-export-sdk:
+	@echo ".: ⚙️ Build '$(name)'."
+	docker save $(IMG_NS)/$(name)-nodejs:$(IMG_TAG) -o $(name).tar


### PR DESCRIPTION
If applied, this PR (depends on PR #653) will
- Refactor SDK Matrix To Use Makefiles
- Upload Images As Artifacts
- Remove DockerHub upload for hook-sdk and parser-sdk
- Update CI To Use SDKs From Artifact
