### PR TITLE
Cache Operator and Lurker Images In CI

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -172,6 +172,7 @@ jobs:
         with:
           name: ${{ matrix.component }}-image
           path: ./operator/${{ matrix.component }}.tar
+          retention-days: 1
 
   # ---- Build Stage | AutoDiscovery ----
 

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -359,6 +359,22 @@ jobs:
           kubectl config current-context
           kubectl get node
 
+      - name: Download Operator Image
+        uses: actions/download-artifact@v2
+        with:
+          name: operator-image
+          path: ./operator
+
+      - name: Download Lurker Image
+        uses: actions/download-artifact@v2
+        with:
+          name: lurker-image
+          path: ./operator
+
+      - name: Import Operator & Lurker Image
+        working-directory: ./operator
+        run: make kind-import
+
       - name: Kind Import Images
         working-directory: ./scanners/${{ matrix.unit }}/
         run: make kind-import

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -154,46 +154,24 @@ jobs:
           go-version: ${{ env.GO_VERSION }}
 
       - name: Lint Go Code
+        working-directory: ./${{ matrix.component }}
         run: |
-          cd ${{ matrix.component }}/
           go fmt ./...
           go vet ./...
 
-      - name: Docker Meta
-        id: docker_meta
-        uses: docker/metadata-action@v3
-        with:
-          images: ${{ env.DOCKER_NAMESPACE }}/${{ matrix.component }}
-          tags: |
-            type=sha
-            type=semver,pattern={{version}}
+      - name: Build Container Image
+        working-directory: ./operator
+        run: make docker-build
 
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v1
+      - name: Export Container Image
+        working-directory: ./operator
+        run: make docker-export-${{ matrix.component }}
 
-      - name: Login to DockerHub
-        uses: docker/login-action@v1
+      - name: Upload Image As Artifact
+        uses: actions/upload-artifact@v2
         with:
-          username: ${{ secrets.DOCKER_USERNAME }}
-          password: ${{ secrets.DOCKER_TOKEN }}
-
-      - name: Build and Push
-        uses: docker/build-push-action@v2
-        with:
-          context: ./${{ matrix.component }}
-          file: ./${{ matrix.component }}/Dockerfile
-          platforms: linux/amd64
-          push: true
-          tags: ${{ steps.docker_meta.outputs.tags }}
-          labels: ${{ steps.docker_meta.outputs.labels }}
-
-      - name: Update Docker Hub Description
-        uses: peter-evans/dockerhub-description@v2
-        with:
-          username: ${{ secrets.DOCKERHUB_USERNAME }}
-          password: ${{ secrets.DOCKERHUB_PASSWORD }}
-          repository: ${{ env.DOCKER_NAMESPACE }}/${{ matrix.component }}
-          readme-filepath: ./${{ matrix.component }}/docs/README.DockerHub-Core.md
+          name: ${{ matrix.component }}-image
+          path: ./operator/${{ matrix.component }}.tar
 
   # ---- Build Stage | AutoDiscovery ----
 
@@ -712,6 +690,22 @@ jobs:
 
       # ---- Install Operator & Create Namespaces ----
 
+      - name: Download Operator Image
+        uses: actions/download-artifact@v2
+        with:
+          name: operator-image
+          path: ./operator
+
+      - name: Download Lurker Image
+        uses: actions/download-artifact@v2
+        with:
+          name: lurker-image
+          path: ./operator
+
+      - name: Import Operator & Lurker Image
+        working-directory: ./operator
+        run: make kind-import
+
       - name: "Install Operator"
         run: |
           # Namespace in which the scans for the tests will be executed
@@ -724,6 +718,8 @@ jobs:
             --set="image.tag=sha-$(git rev-parse --short HEAD)" \
             --set="lurker.image.repository=docker.io/${{ env.DOCKER_NAMESPACE }}/lurker" \
             --set="lurker.image.tag=sha-$(git rev-parse --short HEAD)" \
+            --set="lurker.image.pullPolicy=Never" \
+            --set="image.pullPolicy=Never"
 
       # ---- Operator Health Check ----
 

--- a/operator/Makefile
+++ b/operator/Makefile
@@ -85,9 +85,17 @@ docker-push: ## Push docker image with the manager.
 	docker push $(IMG_NS)/$(LURKER_IMG):$(IMG_TAG)
 
 docker-export:
-	@echo ".: 💾 Export Container Images"
+	$(MAKE) docker-export-operator
+	$(MAKE) docker-export-lurker
+
+docker-export-operator:
+	@echo ".: 💾 Export Operator Image"
 	docker save $(IMG_NS)/$(OPERATOR_IMG):$(IMG_TAG) > $(OPERATOR_IMG).tar
+
+docker-export-lurker:
+	@echo ".: 💾 Export Lurker Image"
 	docker save $(IMG_NS)/$(LURKER_IMG):$(IMG_TAG) > $(LURKER_IMG).tar
+
 
 ##@ Deployment
 


### PR DESCRIPTION
If applied this PR will:
- Add Two Make Targets To Enable Separate Image Builds
- Cache Operator and Lurker Image
