### PR TITLE
Fix Defectdojo Hook Issue Causing It to Not Run on Openshift Clusters

### DIFF
--- a/hooks/persistence-defectdojo/hook/Dockerfile
+++ b/hooks/persistence-defectdojo/hook/Dockerfile
@@ -9,5 +9,6 @@ RUN ./gradlew build -x test
 
 FROM gcr.io/distroless/java:11-nonroot
 COPY --from=build --chown=nonroot:nonroot /home/gradle/src/build/libs /app
+WORKDIR /app
 # TLS Config works around an issue in OpenJDK... See: https://github.com/kubernetes-client/java/issues/854
 ENTRYPOINT ["java", "-Djdk.tls.client.protocols=TLSv1.2", "-jar", "/app/defectdojo-persistenceprovider-0.1.0-SNAPSHOT.jar"]


### PR DESCRIPTION
This sets the workdir beforehand so that it doesn't have to be changed on runtime.