### PR TITLE
Add Targets To Build README and Docs

### DIFF
--- a/.github/workflows/helm-docs.yaml
+++ b/.github/workflows/helm-docs.yaml
@@ -67,31 +67,7 @@ jobs:
         run: make hook-docs
 
       - name: Generate Docker Scanner Docs
-        run: |
-          # Start in the scanners folder
-          cd scanners
-          # https://github.com/koalaman/shellcheck/wiki/SC2044
-          find . -type f -name Chart.yaml -print0 | while IFS= read -r -d '' chart; do
-          (
-            dir="$(dirname "${chart}")"
-            echo "Processing Helm Chart in $dir"
-            cd "${dir}" || exit
-            if [ -d "docs" ]; then
-              echo "Docs Folder found at: ${dir}/docs"
-              if [ -d "parser" ]; then
-                echo "Parser found at: ${dir}/parser"
-                helm-docs --template-files=./../../.helm-docs/templates.gotmpl --template-files=.helm-docs.gotmpl --template-files=./../../.helm-docs/README.DockerHub-Parser.md.gotmpl --output-file=docs/README.DockerHub-Parser.md
-              fi
-              if [ -d "scanner" ]; then
-                echo "Scanner found at: ${dir}/parser"
-                helm-docs --template-files=./../../.helm-docs/templates.gotmpl --template-files=.helm-docs.gotmpl --template-files=./../../.helm-docs/README.DockerHub-Scanner.md.gotmpl --output-file=docs/README.DockerHub-Scanner.md
-              fi
-              helm-docs --template-files=./../../.helm-docs/templates.gotmpl --template-files=.helm-docs.gotmpl --template-files=./../../.helm-docs/README.ArtifactHub.md.gotmpl --output-file=docs/README.ArtifactHub.md
-            else
-              echo "Ignoring Docs creation process for Chart $dir, because no `docs` folder found at: ${dir}/docs"
-            fi
-          )
-          done
+        run: make scanner-docs
 
       - name: Generate Core (Operator) Docs
         run: |

--- a/.github/workflows/helm-docs.yaml
+++ b/.github/workflows/helm-docs.yaml
@@ -44,24 +44,7 @@ jobs:
           # Generate README.md based on Chart.yaml and template
           make readme
       - name: Generate Demo-Apps Docs
-        run: |
-          # Start in the hooks folder
-          cd demo-targets
-          # https://github.com/koalaman/shellcheck/wiki/SC2044
-          find . -type f -name Chart.yaml -print0 | while IFS= read -r -d '' chart; do
-          (
-            dir="$(dirname "${chart}")"
-            echo "Processing Helm Chart in $dir"
-            cd "${dir}" || exit
-            if [ -d "docs" ]; then
-              echo "Docs Folder found at: ${dir}/docs"
-              helm-docs --template-files=./../../.helm-docs/templates.gotmpl --template-files=.helm-docs.gotmpl --template-files=./../../.helm-docs/README.DockerHub-Target.md.gotmpl --output-file=docs/README.DockerHub-Target.md
-              helm-docs --template-files=./../../.helm-docs/templates.gotmpl --template-files=.helm-docs.gotmpl --template-files=./../../.helm-docs/README.ArtifactHub.md.gotmpl --output-file=docs/README.ArtifactHub.md
-            else
-              echo "Ignoring Docs creation process for Chart $dir, because no `docs` folder found at: ${dir}/docs"
-            fi
-          )
-          done
+        run: make demo-apps-docs
 
       - name: Generate Docker Hooks Docs
         run: make hook-docs

--- a/.github/workflows/helm-docs.yaml
+++ b/.github/workflows/helm-docs.yaml
@@ -39,11 +39,10 @@ jobs:
 
           sudo mv helm-docs /usr/local/bin/helm-docs
 
-      - name: Generate Helm Docs
+      - name: Generate README
         run: |
           # Generate README.md based on Chart.yaml and template
-          helm-docs --template-files=./.helm-docs/templates.gotmpl --template-files=.helm-docs.gotmpl --template-files=./.helm-docs/README.md.gotmpl
-
+          make readme
       - name: Generate Demo-Apps Docs
         run: |
           # Start in the hooks folder

--- a/.github/workflows/helm-docs.yaml
+++ b/.github/workflows/helm-docs.yaml
@@ -72,16 +72,8 @@ jobs:
       - name: Generate Operator Docs
         run: make operator-docs
 
-      - name: Generate Core (AutoDiscovery Kubernetes) Docs
-        run: |
-          cd auto-discovery/kubernetes
-          if [ -d "docs" ]; then
-            echo "Docs Folder found at: auto-discovery/kubernetes/docs"
-            helm-docs --template-files=./../../.helm-docs/templates.gotmpl --template-files=.helm-docs.gotmpl --template-files=./../../.helm-docs/README.DockerHub-Core.md.gotmpl --output-file=docs/README.DockerHub-Core.md
-            helm-docs --template-files=./../../.helm-docs/templates.gotmpl --template-files=.helm-docs.gotmpl --template-files=./../../.helm-docs/README.ArtifactHub.md.gotmpl --output-file=docs/README.ArtifactHub.md
-          else
-            echo "Ignoring Docs creation process for Chart $dir, because no `docs` folder found at: auto-discovery/kubernetes/docs"
-          fi
+      - name: Generate AutoDiscovery Docs
+        run: make auto-discovery-docs
 
       - name: Remove Helm Docs Files
         run: |

--- a/.github/workflows/helm-docs.yaml
+++ b/.github/workflows/helm-docs.yaml
@@ -69,17 +69,9 @@ jobs:
       - name: Generate Docker Scanner Docs
         run: make scanner-docs
 
-      - name: Generate Core (Operator) Docs
-        run: |
-          # Start in the operator folder
-          cd operator
-          if [ -d "docs" ]; then
-            echo "Docs Folder found at: operator/docs"
-            helm-docs --template-files=./../.helm-docs/templates.gotmpl --template-files=.helm-docs.gotmpl --template-files=./../.helm-docs/README.DockerHub-Core.md.gotmpl --output-file=docs/README.DockerHub-Core.md
-            helm-docs --template-files=./../.helm-docs/templates.gotmpl --template-files=.helm-docs.gotmpl --template-files=./../.helm-docs/README.ArtifactHub.md.gotmpl --output-file=docs/README.ArtifactHub.md
-          else
-            echo "Ignoring Docs creation process for Chart $dir, because no `docs` folder found at: operator/docs"
-          fi
+      - name: Generate Operator Docs
+        run: make operator-docs
+
       - name: Generate Core (AutoDiscovery Kubernetes) Docs
         run: |
           cd auto-discovery/kubernetes

--- a/.github/workflows/helm-docs.yaml
+++ b/.github/workflows/helm-docs.yaml
@@ -64,24 +64,7 @@ jobs:
           done
 
       - name: Generate Docker Hooks Docs
-        run: |
-          # Start in the hooks folder
-          cd hooks
-          # https://github.com/koalaman/shellcheck/wiki/SC2044
-          find . -type f -name Chart.yaml -print0 | while IFS= read -r -d '' chart; do
-          (
-            dir="$(dirname "${chart}")"
-            echo "Processing Helm Chart in $dir"
-            cd "${dir}" || exit
-            if [ -d "docs" ]; then
-              echo "Docs Folder found at: ${dir}/docs"
-              helm-docs --template-files=./../../.helm-docs/templates.gotmpl --template-files=.helm-docs.gotmpl --template-files=./../../.helm-docs/README.DockerHub-Hook.md.gotmpl --output-file=docs/README.DockerHub-Hook.md
-              helm-docs --template-files=./../../.helm-docs/templates.gotmpl --template-files=.helm-docs.gotmpl --template-files=./../../.helm-docs/README.ArtifactHub.md.gotmpl --output-file=docs/README.ArtifactHub.md
-            else
-              echo "Ignoring Docs creation process for Chart $dir, because no `docs` folder found at: ${dir}/docs"
-            fi
-          )
-          done
+        run: make hook-docs
 
       - name: Generate Docker Scanner Docs
         run: |

--- a/.github/workflows/helm-docs.yaml
+++ b/.github/workflows/helm-docs.yaml
@@ -41,15 +41,14 @@ jobs:
 
       - name: Generate README
         run: |
-          # Generate README.md based on Chart.yaml and template
           make readme
       - name: Generate Demo-Apps Docs
         run: make demo-apps-docs
 
-      - name: Generate Docker Hooks Docs
+      - name: Generate Hooks Docs
         run: make hook-docs
 
-      - name: Generate Docker Scanner Docs
+      - name: Generate Scanner Docs
         run: make scanner-docs
 
       - name: Generate Operator Docs

--- a/Makefile
+++ b/Makefile
@@ -47,6 +47,28 @@ readme:
 	@echo ".: ⚙ Generate Helm Docs."
 	helm-docs --template-files=./.helm-docs/templates.gotmpl --template-files=.helm-docs.gotmpl --template-files=./.helm-docs/README.md.gotmpl
 
+.PHONY: hook-docs
+.ONESHELL:
+hook-docs:
+	@echo ".: ⚙ Generate Helm Docs."
+	# Start in the hooks folder
+	cd hooks
+	# https://github.com/koalaman/shellcheck/wiki/SC2044
+	find . -type f -name Chart.yaml -print0 | while IFS= read -r -d '' chart; do
+	(
+		dir="$$(dirname "$${chart}")"
+		echo "Processing Helm Chart in $$dir"
+		cd "$${dir}" || exit
+		if [ -d "docs" ]; then
+			echo "Docs Folder found at: $${dir}/docs"
+			helm-docs --template-files=./../../.helm-docs/templates.gotmpl --template-files=.helm-docs.gotmpl --template-files=./../../.helm-docs/README.DockerHub-Hook.md.gotmpl --output-file=docs/README.DockerHub-Hook.md
+			helm-docs --template-files=./../../.helm-docs/templates.gotmpl --template-files=.helm-docs.gotmpl --template-files=./../../.helm-docs/README.ArtifactHub.md.gotmpl --output-file=docs/README.ArtifactHub.md
+		else
+			echo "Ignoring Docs creation process for Chart $$dir, because no `docs` folder found at: $${dir}/docs"
+		fi
+	)
+	done
+
 .PHONY:
 help: ## Display this help screen.
 	@grep -h -E '^[a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) | \

--- a/Makefile
+++ b/Makefile
@@ -69,6 +69,34 @@ hook-docs:
 	)
 	done
 
+.PHONY: scanner-docs
+.ONESHELL:
+scanner-docs:
+	# Start in the scanners folder
+	cd scanners
+	# https://github.com/koalaman/shellcheck/wiki/SC2044
+	find . -type f -name Chart.yaml -print0 | while IFS= read -r -d '' chart; do
+	(
+		dir="$$(dirname "$${chart}")"
+		echo "Processing Helm Chart in $$dir"
+		cd "$${dir}" || exit
+		if [ -d "docs" ]; then
+			echo "Docs Folder found at: $${dir}/docs"
+			if [ -d "parser" ]; then
+				echo "Parser found at: $${dir}/parser"
+				helm-docs --template-files=./../../.helm-docs/templates.gotmpl --template-files=.helm-docs.gotmpl --template-files=./../../.helm-docs/README.DockerHub-Parser.md.gotmpl --output-file=docs/README.DockerHub-Parser.md
+			fi
+			if [ -d "scanner" ]; then
+				echo "Scanner found at: $${dir}/parser"
+				helm-docs --template-files=./../../.helm-docs/templates.gotmpl --template-files=.helm-docs.gotmpl --template-files=./../../.helm-docs/README.DockerHub-Scanner.md.gotmpl --output-file=docs/README.DockerHub-Scanner.md
+			fi
+			helm-docs --template-files=./../../.helm-docs/templates.gotmpl --template-files=.helm-docs.gotmpl --template-files=./../../.helm-docs/README.ArtifactHub.md.gotmpl --output-file=docs/README.ArtifactHub.md
+		else
+			echo "Ignoring Docs creation process for Chart $$dir, because no `docs` folder found at: $${dir}/docs"
+		fi
+	)
+	done
+
 .PHONY:
 help: ## Display this help screen.
 	@grep -h -E '^[a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) | \

--- a/Makefile
+++ b/Makefile
@@ -110,6 +110,18 @@ operator-docs:
 		echo "Ignoring Docs creation process for Chart $$dir, because no `docs` folder found at: operator/docs"
 	fi
 
+.PHONY: auto-discovery-docs
+.ONESHELL:
+auto-discovery-docs:
+	cd auto-discovery/kubernetes
+	if [ -d "docs" ]; then
+		echo "Docs Folder found at: auto-discovery/kubernetes/docs"
+		helm-docs --template-files=./../../.helm-docs/templates.gotmpl --template-files=.helm-docs.gotmpl --template-files=./../../.helm-docs/README.DockerHub-Core.md.gotmpl --output-file=docs/README.DockerHub-Core.md
+		helm-docs --template-files=./../../.helm-docs/templates.gotmpl --template-files=.helm-docs.gotmpl --template-files=./../../.helm-docs/README.ArtifactHub.md.gotmpl --output-file=docs/README.ArtifactHub.md
+	else
+		echo "Ignoring Docs creation process for Chart $dir, because no `docs` folder found at: auto-discovery/kubernetes/docs"
+	fi
+
 .PHONY:
 help: ## Display this help screen.
 	@grep -h -E '^[a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) | \

--- a/Makefile
+++ b/Makefile
@@ -43,6 +43,11 @@ test-all: ## Runs all makefile based test suites.
 	done;
 
 .PHONY:
+readme:
+	@echo ".: ⚙ Generate Helm Docs."
+	helm-docs --template-files=./.helm-docs/templates.gotmpl --template-files=.helm-docs.gotmpl --template-files=./.helm-docs/README.md.gotmpl
+
+.PHONY:
 help: ## Display this help screen.
 	@grep -h -E '^[a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) | \
 		awk 'BEGIN {FS = ":.*?## "}; {printf "\033[36m%-30s\033[0m %s\n", $$1, $$2}'

--- a/Makefile
+++ b/Makefile
@@ -44,6 +44,7 @@ test-all: ## Runs all makefile based test suites.
 
 .PHONY:
 readme:
+	# Generate README.md based on Chart.yaml and template
 	@echo ".: ⚙ Generate Helm Docs."
 	helm-docs --template-files=./.helm-docs/templates.gotmpl --template-files=.helm-docs.gotmpl --template-files=./.helm-docs/README.md.gotmpl
 

--- a/Makefile
+++ b/Makefile
@@ -144,6 +144,9 @@ demo-apps-docs:
 	)
 	done
 
+.PHONY: docs
+docs: readme hook-docs scanner-docs operator-docs auto-discovery-docs demo-apps-docs
+
 .PHONY:
 help: ## Display this help screen.
 	@grep -h -E '^[a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) | \

--- a/Makefile
+++ b/Makefile
@@ -120,7 +120,7 @@ auto-discovery-docs:
 		helm-docs --template-files=./../../.helm-docs/templates.gotmpl --template-files=.helm-docs.gotmpl --template-files=./../../.helm-docs/README.DockerHub-Core.md.gotmpl --output-file=docs/README.DockerHub-Core.md
 		helm-docs --template-files=./../../.helm-docs/templates.gotmpl --template-files=.helm-docs.gotmpl --template-files=./../../.helm-docs/README.ArtifactHub.md.gotmpl --output-file=docs/README.ArtifactHub.md
 	else
-		echo "Ignoring Docs creation process for Chart $dir, because no `docs` folder found at: auto-discovery/kubernetes/docs"
+		echo "Ignoring Docs creation process for Chart $$dir, because no `docs` folder found at: auto-discovery/kubernetes/docs"
 	fi
 
 .PHONY: demo-apps-docs
@@ -131,15 +131,15 @@ demo-apps-docs:
 	# https://github.com/koalaman/shellcheck/wiki/SC2044
 	find . -type f -name Chart.yaml -print0 | while IFS= read -r -d '' chart; do
 	(
-		dir="$(dirname "${chart}")"
-		echo "Processing Helm Chart in $dir"
-		cd "${dir}" || exit
+		dir="$$(dirname "$${chart}")"
+		echo "Processing Helm Chart in $$dir"
+		cd "$${dir}" || exit
 		if [ -d "docs" ]; then
-				echo "Docs Folder found at: ${dir}/docs"
+				echo "Docs Folder found at: $${dir}/docs"
 				helm-docs --template-files=./../../.helm-docs/templates.gotmpl --template-files=.helm-docs.gotmpl --template-files=./../../.helm-docs/README.DockerHub-Target.md.gotmpl --output-file=docs/README.DockerHub-Target.md
 				helm-docs --template-files=./../../.helm-docs/templates.gotmpl --template-files=.helm-docs.gotmpl --template-files=./../../.helm-docs/README.ArtifactHub.md.gotmpl --output-file=docs/README.ArtifactHub.md
 		else
-				echo "Ignoring Docs creation process for Chart $dir, because no `docs` folder found at: ${dir}/docs"
+				echo "Ignoring Docs creation process for Chart $$dir, because no `docs` folder found at: $${dir}/docs"
 		fi
 	)
 	done

--- a/Makefile
+++ b/Makefile
@@ -97,6 +97,19 @@ scanner-docs:
 	)
 	done
 
+.PHONY: operator-docs
+.ONESHELL:
+operator-docs:
+	# Start in the operator folder
+	cd operator
+	if [ -d "docs" ]; then
+		echo "Docs Folder found at: operator/docs"
+		helm-docs --template-files=./../.helm-docs/templates.gotmpl --template-files=.helm-docs.gotmpl --template-files=./../.helm-docs/README.DockerHub-Core.md.gotmpl --output-file=docs/README.DockerHub-Core.md
+		helm-docs --template-files=./../.helm-docs/templates.gotmpl --template-files=.helm-docs.gotmpl --template-files=./../.helm-docs/README.ArtifactHub.md.gotmpl --output-file=docs/README.ArtifactHub.md
+	else
+		echo "Ignoring Docs creation process for Chart $$dir, because no `docs` folder found at: operator/docs"
+	fi
+
 .PHONY:
 help: ## Display this help screen.
 	@grep -h -E '^[a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) | \

--- a/Makefile
+++ b/Makefile
@@ -122,6 +122,27 @@ auto-discovery-docs:
 		echo "Ignoring Docs creation process for Chart $dir, because no `docs` folder found at: auto-discovery/kubernetes/docs"
 	fi
 
+.PHONY: demo-apps-docs
+.ONESHELL:
+demo-apps-docs:
+	# Start in the hooks folder
+	cd demo-targets
+	# https://github.com/koalaman/shellcheck/wiki/SC2044
+	find . -type f -name Chart.yaml -print0 | while IFS= read -r -d '' chart; do
+	(
+		dir="$(dirname "${chart}")"
+		echo "Processing Helm Chart in $dir"
+		cd "${dir}" || exit
+		if [ -d "docs" ]; then
+				echo "Docs Folder found at: ${dir}/docs"
+				helm-docs --template-files=./../../.helm-docs/templates.gotmpl --template-files=.helm-docs.gotmpl --template-files=./../../.helm-docs/README.DockerHub-Target.md.gotmpl --output-file=docs/README.DockerHub-Target.md
+				helm-docs --template-files=./../../.helm-docs/templates.gotmpl --template-files=.helm-docs.gotmpl --template-files=./../../.helm-docs/README.ArtifactHub.md.gotmpl --output-file=docs/README.ArtifactHub.md
+		else
+				echo "Ignoring Docs creation process for Chart $dir, because no `docs` folder found at: ${dir}/docs"
+		fi
+	)
+	done
+
 .PHONY:
 help: ## Display this help screen.
 	@grep -h -E '^[a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) | \


### PR DESCRIPTION
If applied this PR will
- add make targets to build
	- readme
	- hook docs
	- scanner docs
	- operator docs
	- auto-discovery docs
	- demo-apps docs
	- all the above
- use make target in ci for
	- readme
	- hook docs
	- scanner docs
	- operator docs
	- auto-discovery docs
	- demo-apps docs 	

Signed-off-by: Yannik Fuhrmeister <yannik.fuhrmeister@iteratec.com>
