### PR TITLE
fix: change indent for .mk files to tab

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -24,5 +24,5 @@ indent_style = space
 indent_size = 4
 
 # Tab indentation (no size specified)
-[Makefile]
+[{Makefile,*.mk}]
 indent_style = tab


### PR DESCRIPTION
The editor config uses spaces as standard indent.
That was causing issues working on Makefiles with .mk file extension
because Makefiles enforce tabs.
To fix this issue I added .mk files to the list of tab indented files

Signed-off-by: Yannik Fuhrmeister <yannik.fuhrmeister@iteratec.com>
