### PR TITLE
Add defaults for cascading inherit fields and disable omitEmpty

### DIFF
--- a/operator/apis/execution/v1/scan_types.go
+++ b/operator/apis/execution/v1/scan_types.go
@@ -16,19 +16,23 @@ import (
 type CascadeSpec struct {
 	// InheritLabels defines whether cascading scans should inherit labels from the parent scan
 	// +optional
-	InheritLabels bool `json:"inheritLabels,omitempty"`
+	// +kubebuilder:default=true
+	InheritLabels bool `json:"inheritLabels"`
 
 	// InheritAnnotations defines whether cascading scans should inherit annotations from the parent scan
 	// +optional
-	InheritAnnotations bool `json:"inheritAnnotations,omitempty"`
+	// +kubebuilder:default=true
+	InheritAnnotations bool `json:"inheritAnnotations"`
 
 	// InheritEnv defines whether cascading scans should inherit environment variables from the parent scan
 	// +optional
-	InheritEnv bool `json:"inheritEnv,omitempty"`
+	// +kubebuilder:default=false
+	InheritEnv bool `json:"inheritEnv"`
 
 	// InheritVolumes defines whether cascading scans should inherit volumes and volume mounts from the parent scan
 	// +optional
-	InheritVolumes bool `json:"inheritVolumes,omitempty"`
+	// +kubebuilder:default=false
+	InheritVolumes bool `json:"inheritVolumes"`
 
 	// matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
 	// map is equivalent to an element of matchExpressions, whose key field is "key", the

--- a/operator/config/crd/bases/cascading.securecodebox.io_cascadingrules.yaml
+++ b/operator/config/crd/bases/cascading.securecodebox.io_cascadingrules.yaml
@@ -105,18 +105,22 @@ spec:
                       should be generated.
                     properties:
                       inheritAnnotations:
+                        default: true
                         description: InheritAnnotations defines whether cascading
                           scans should inherit annotations from the parent scan
                         type: boolean
                       inheritEnv:
+                        default: false
                         description: InheritEnv defines whether cascading scans should
                           inherit environment variables from the parent scan
                         type: boolean
                       inheritLabels:
+                        default: true
                         description: InheritLabels defines whether cascading scans
                           should inherit labels from the parent scan
                         type: boolean
                       inheritVolumes:
+                        default: false
                         description: InheritVolumes defines whether cascading scans
                           should inherit volumes and volume mounts from the parent
                           scan

--- a/operator/config/crd/bases/execution.securecodebox.io_scans.yaml
+++ b/operator/config/crd/bases/execution.securecodebox.io_scans.yaml
@@ -67,18 +67,22 @@ spec:
                   be generated.
                 properties:
                   inheritAnnotations:
+                    default: true
                     description: InheritAnnotations defines whether cascading scans
                       should inherit annotations from the parent scan
                     type: boolean
                   inheritEnv:
+                    default: false
                     description: InheritEnv defines whether cascading scans should
                       inherit environment variables from the parent scan
                     type: boolean
                   inheritLabels:
+                    default: true
                     description: InheritLabels defines whether cascading scans should
                       inherit labels from the parent scan
                     type: boolean
                   inheritVolumes:
+                    default: false
                     description: InheritVolumes defines whether cascading scans should
                       inherit volumes and volume mounts from the parent scan
                     type: boolean

--- a/operator/config/crd/bases/execution.securecodebox.io_scheduledscans.yaml
+++ b/operator/config/crd/bases/execution.securecodebox.io_scheduledscans.yaml
@@ -81,18 +81,22 @@ spec:
                       should be generated.
                     properties:
                       inheritAnnotations:
+                        default: true
                         description: InheritAnnotations defines whether cascading
                           scans should inherit annotations from the parent scan
                         type: boolean
                       inheritEnv:
+                        default: false
                         description: InheritEnv defines whether cascading scans should
                           inherit environment variables from the parent scan
                         type: boolean
                       inheritLabels:
+                        default: true
                         description: InheritLabels defines whether cascading scans
                           should inherit labels from the parent scan
                         type: boolean
                       inheritVolumes:
+                        default: false
                         description: InheritVolumes defines whether cascading scans
                           should inherit volumes and volume mounts from the parent
                           scan

--- a/operator/crds/cascading.securecodebox.io_cascadingrules.yaml
+++ b/operator/crds/cascading.securecodebox.io_cascadingrules.yaml
@@ -105,18 +105,22 @@ spec:
                       should be generated.
                     properties:
                       inheritAnnotations:
+                        default: true
                         description: InheritAnnotations defines whether cascading
                           scans should inherit annotations from the parent scan
                         type: boolean
                       inheritEnv:
+                        default: false
                         description: InheritEnv defines whether cascading scans should
                           inherit environment variables from the parent scan
                         type: boolean
                       inheritLabels:
+                        default: true
                         description: InheritLabels defines whether cascading scans
                           should inherit labels from the parent scan
                         type: boolean
                       inheritVolumes:
+                        default: false
                         description: InheritVolumes defines whether cascading scans
                           should inherit volumes and volume mounts from the parent
                           scan

--- a/operator/crds/execution.securecodebox.io_scans.yaml
+++ b/operator/crds/execution.securecodebox.io_scans.yaml
@@ -67,18 +67,22 @@ spec:
                   be generated.
                 properties:
                   inheritAnnotations:
+                    default: true
                     description: InheritAnnotations defines whether cascading scans
                       should inherit annotations from the parent scan
                     type: boolean
                   inheritEnv:
+                    default: false
                     description: InheritEnv defines whether cascading scans should
                       inherit environment variables from the parent scan
                     type: boolean
                   inheritLabels:
+                    default: true
                     description: InheritLabels defines whether cascading scans should
                       inherit labels from the parent scan
                     type: boolean
                   inheritVolumes:
+                    default: false
                     description: InheritVolumes defines whether cascading scans should
                       inherit volumes and volume mounts from the parent scan
                     type: boolean

--- a/operator/crds/execution.securecodebox.io_scheduledscans.yaml
+++ b/operator/crds/execution.securecodebox.io_scheduledscans.yaml
@@ -81,18 +81,22 @@ spec:
                       should be generated.
                     properties:
                       inheritAnnotations:
+                        default: true
                         description: InheritAnnotations defines whether cascading
                           scans should inherit annotations from the parent scan
                         type: boolean
                       inheritEnv:
+                        default: false
                         description: InheritEnv defines whether cascading scans should
                           inherit environment variables from the parent scan
                         type: boolean
                       inheritLabels:
+                        default: true
                         description: InheritLabels defines whether cascading scans
                           should inherit labels from the parent scan
                         type: boolean
                       inheritVolumes:
+                        default: false
                         description: InheritVolumes defines whether cascading scans
                           should inherit volumes and volume mounts from the parent
                           scan


### PR DESCRIPTION
Closes #683 

## Description
This PR, if applied, adds default values to the cascading inherit fields. Using `omitEmpty` on booleans has an implicit default of omitting `false` values completely https://github.com/golang/go/issues/13284. Since the cascading hook regards `inheritLabels` and `inheritAnnotations` undefined field as `true`, it was impossible to set those fields to `false`.

https://github.com/secureCodeBox/secureCodeBox/blob/79a279a8967e0e991b4674e5969da09fed22b7d6/hooks/cascading-scans/hook/hook.ts#L161-L165

https://github.com/secureCodeBox/secureCodeBox/blob/79a279a8967e0e991b4674e5969da09fed22b7d6/hooks/cascading-scans/hook/scan-helpers.ts#L73-L81

Fixed by setting the default at CRD level with kubebuilders default annotation and deleting the `omitEmpty` tag.

Results in all cascading scans to have the following fields by default:

```yaml
  cascades:
    inheritAnnotations: true
    inheritEnv: false
    inheritLabels: true
    inheritVolumes: false
    matchExpressions:
    - key: securecodebox.io/intensive
      operator: In
      values:
      - light
      - medium
      - high
    - key: securecodebox.io/invasive
      operator: In
      values:
      - non-invasive
      - invasive
```

`inheritLabels` and `inheritAnnotations` `true` by default #334
`inheritEnv` and `inheritVolumes` `false` by default https://github.com/secureCodeBox/secureCodeBox/pull/538#issuecomment-877180198

### Checklist

* [x] Test your changes as thoroughly as possible before you commit them. Preferably, automate your test by unit/integration tests.
* [x] Make sure `npm test` runs for the whole project.
* [x] Make codeclimate checks happy
