### PR TITLE
Add presigned head url to scan object

### DIFF
--- a/operator/apis/execution/v1/scan_types.go
+++ b/operator/apis/execution/v1/scan_types.go
@@ -83,7 +83,7 @@ type ScanStatus struct {
 
 	// FindingHeadLink link to send HEAD request to the finding json file. Valid for 7 days
 	FindingHeadLink string `json:"findingHeadLink,omitempty"`
-	// RawResultHeadLink link to send HEAD request to raw result file from. Valid for 7 days
+	// RawResultHeadLink link to send HEAD request to raw result file. Valid for 7 days
 	RawResultHeadLink string `json:"rawResultHeadLink,omitempty"`
 
 	Findings FindingStats `json:"findings,omitempty"`

--- a/operator/apis/execution/v1/scan_types.go
+++ b/operator/apis/execution/v1/scan_types.go
@@ -81,6 +81,11 @@ type ScanStatus struct {
 	// RawResultDownloadLink link to download the raw result file from. Valid for 7 days
 	RawResultDownloadLink string `json:"rawResultDownloadLink,omitempty"`
 
+	// FindingHeadLink link to send HEAD request to the finding json file. Valid for 7 days
+	FindingHeadLink string `json:"findingHeadLink,omitempty"`
+	// RawResultHeadLink link to send HEAD request to raw result file from. Valid for 7 days
+	RawResultHeadLink string `json:"rawResultHeadLink,omitempty"`
+
 	Findings FindingStats `json:"findings,omitempty"`
 
 	ReadAndWriteHookStatus []HookStatus `json:"readAndWriteHookStatus,omitempty"`

--- a/operator/config/crd/bases/execution.securecodebox.io_scans.yaml
+++ b/operator/config/crd/bases/execution.securecodebox.io_scans.yaml
@@ -1770,7 +1770,7 @@ spec:
                 type: string
               rawResultHeadLink:
                 description: RawResultHeadLink link to send HEAD request to raw result
-                  file from. Valid for 7 days
+                  file. Valid for 7 days
                 type: string
               rawResultType:
                 description: RawResultType determines which kind of ParseDefinition

--- a/operator/config/crd/bases/execution.securecodebox.io_scans.yaml
+++ b/operator/config/crd/bases/execution.securecodebox.io_scans.yaml
@@ -1717,6 +1717,10 @@ spec:
                 description: FindingDownloadLink link to download the finding json
                   file from. Valid for 7 days
                 type: string
+              findingHeadLink:
+                description: FindingHeadLink link to send HEAD request to the finding
+                  json file. Valid for 7 days
+                type: string
               findings:
                 description: FindingStats contains the general stats about the results
                   of the scan
@@ -1763,6 +1767,10 @@ spec:
               rawResultFile:
                 description: RawResultFile Filename of the result file of the scanner.
                   e.g. `nmap-result.xml`
+                type: string
+              rawResultHeadLink:
+                description: RawResultHeadLink link to send HEAD request to raw result
+                  file from. Valid for 7 days
                 type: string
               rawResultType:
                 description: RawResultType determines which kind of ParseDefinition

--- a/operator/controllers/execution/scans/scan_controller.go
+++ b/operator/controllers/execution/scans/scan_controller.go
@@ -162,6 +162,18 @@ func (r *ScanReconciler) PresignedPutURL(scanID types.UID, filename string, dura
 	return rawResultDownloadURL.String(), nil
 }
 
+// PresignedHeadURL returns a presigned URL from the s3 (or compatible) serice.
+func (r *ScanReconciler) PresignedHeadURL(scanID types.UID, filename string, duration time.Duration) (string, error) {
+	bucketName := os.Getenv("S3_BUCKET")
+
+	rawResultHeadURL, err := r.MinioClient.PresignedHeadObject(context.Background(), bucketName, fmt.Sprintf("scan-%s/%s", string(scanID), filename), duration, nil)
+	if err != nil {
+		r.Log.Error(err, "Could not get presigned url from s3 or compatible storage provider")
+		return "", err
+	}
+	return rawResultHeadURL.String(), nil
+}
+
 func (r *ScanReconciler) initS3Connection() *minio.Client {
 	endpoint := os.Getenv("S3_ENDPOINT")
 	if os.Getenv("S3_PORT") != "" {

--- a/operator/controllers/execution/scans/scan_reconciler.go
+++ b/operator/controllers/execution/scans/scan_reconciler.go
@@ -107,6 +107,20 @@ func (r *ScanReconciler) startScan(scan *executionv1.Scan) error {
 	}
 	scan.Status.RawResultDownloadLink = rawResultDownloadURL
 
+	findingsHeadURL, err := r.PresignedHeadURL(scan.UID, "findings.json", 7*24*time.Hour)
+	if err != nil {
+		r.Log.Error(err, "Could not get presigned head url from s3 or compatible storage provider")
+		return err
+	}
+	scan.Status.FindingHeadLink = findingsHeadURL
+
+	rawResultsHeadURL, err := r.PresignedHeadURL(scan.UID, scan.Status.RawResultFile, 7*24*time.Hour)
+	if err != nil {
+		r.Log.Error(err, "Could not get presigned head url from s3 or compatible storage provider")
+		return err
+	}
+	scan.Status.RawResultHeadLink = rawResultsHeadURL
+
 	if err := r.Status().Update(ctx, scan); err != nil {
 		log.Error(err, "unable to update Scan status")
 		return err

--- a/operator/crds/execution.securecodebox.io_scans.yaml
+++ b/operator/crds/execution.securecodebox.io_scans.yaml
@@ -1777,7 +1777,7 @@ spec:
                 type: string
               rawResultHeadLink:
                 description: RawResultHeadLink link to send HEAD request to raw result
-                  file from. Valid for 7 days
+                  file. Valid for 7 days
                 type: string
               rawResultType:
                 description: RawResultType determines which kind of ParseDefinition

--- a/operator/crds/execution.securecodebox.io_scans.yaml
+++ b/operator/crds/execution.securecodebox.io_scans.yaml
@@ -1724,6 +1724,10 @@ spec:
                 description: FindingDownloadLink link to download the finding json
                   file from. Valid for 7 days
                 type: string
+              findingHeadLink:
+                description: FindingHeadLink link to send HEAD request to the finding
+                  json file. Valid for 7 days
+                type: string
               findings:
                 description: FindingStats contains the general stats about the results
                   of the scan
@@ -1770,6 +1774,10 @@ spec:
               rawResultFile:
                 description: RawResultFile Filename of the result file of the scanner.
                   e.g. `nmap-result.xml`
+                type: string
+              rawResultHeadLink:
+                description: RawResultHeadLink link to send HEAD request to raw result
+                  file from. Valid for 7 days
                 type: string
               rawResultType:
                 description: RawResultType determines which kind of ParseDefinition


### PR DESCRIPTION
## Description
This PR, if applied, adds `findingHeadLink` and `rawResultHeadLink` to the scan's status. These links are useful in optimization of external services (or hooks) querying the file. It is especially useful when you would like to use something like a [streaming response](https://docs.djangoproject.com/en/3.2/ref/request-response/#django.http.StreamingHttpResponse) while retaining original headers (obtained through head link).

### Checklist

* [x] Test your changes as thoroughly as possible before you commit them. Preferably, automate your test by unit/integration tests.
* [x] Make sure `npm test` runs for the whole project.
* [x] Make codeclimate checks happy
