### PR TITLE
Add `ftp-anon` and `ftp-banner` nmap scripts and support for portrule scripts

### DIFF
--- a/scanners/nmap/.helm-docs.gotmpl
+++ b/scanners/nmap/.helm-docs.gotmpl
@@ -29,6 +29,22 @@ usecase: "Network discovery and security auditing"
 Nmap ("Network Mapper") is a free and open source (license) utility for network discovery and security auditing. Many systems and network administrators also find it useful for tasks such as network inventory, managing service upgrade schedules, and monitoring host or service uptime.
 
 To learn more about the Nmap scanner itself visit [nmap.org].
+
+## NSE scripts
+
+Currently, the secureCodeBox Nmap parser supports the `smb-protocols`, `ftp-anon`, and `ftp-banner` script with compatibility for hostrules and portrules. If you want custom scripts to be parsed by secureCodeBox, you may contribute your script parser in `parser/parser.js` under `const scriptParser`
+
+```javascript
+const scriptParser = {
+  "ftp-anon": parseFtpAnon,
+  "banner": parseBanner,
+  "smb-protocols": parseSmbProtocols,
+  [...] // Contributed custom parsers
+}
+```
+
+Scripts without an existing parser will only generate an open port finding. Scripts with parsers will add a script output finding.
+
 {{- end }}
 
 {{- define "extra.scannerConfigurationSection" -}}

--- a/scanners/nmap/README.md
+++ b/scanners/nmap/README.md
@@ -40,6 +40,21 @@ Nmap ("Network Mapper") is a free and open source (license) utility for network 
 
 To learn more about the Nmap scanner itself visit [nmap.org].
 
+## NSE scripts
+
+Currently, the secureCodeBox Nmap parser supports the `smb-protocols`, `ftp-anon`, and `ftp-banner` script with compatibility for hostrules and portrules. If you want custom scripts to be parsed by secureCodeBox, you may contribute your script parser in `parser/parser.js` under `const scriptParser`
+
+```javascript
+const scriptParser = {
+  "ftp-anon": parseFtpAnon,
+  "banner": parseBanner,
+  "smb-protocols": parseSmbProtocols,
+  [...] // Contributed custom parsers
+}
+```
+
+Scripts without an existing parser will only generate an open port finding. Scripts with parsers will add a script output finding.
+
 ## Deployment
 The nmap chart can be deployed via helm:
 

--- a/scanners/nmap/parser/__testFiles__/ftp.xml
+++ b/scanners/nmap/parser/__testFiles__/ftp.xml
@@ -1,0 +1,25 @@
+<!--
+SPDX-FileCopyrightText: 2021 Secura
+
+SPDX-License-Identifier: NOASSERTION
+-->
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE nmaprun>
+<?xml-stylesheet href="file:///usr/bin/../share/nmap/nmap.xsl" type="text/xsl"?>
+<!-- Nmap 7.91 scan initiated Mon Sep 20 09:23:51 2021 as: nmap -oX /home/securecodebox/nmap-results.xml -Pn -p21 -&#45;script banner -&#45;script ftp-anon 10.103.42.74 -->
+<nmaprun scanner="nmap" args="nmap -oX /home/securecodebox/nmap-results.xml -Pn -p21 -&#45;script banner -&#45;script ftp-anon 10.103.42.74" start="1632129831" startstr="Mon Sep 20 09:23:51 2021" version="7.91" xmloutputversion="1.05">
+<scaninfo type="connect" protocol="tcp" numservices="1" services="21"/>
+<verbose level="0"/>
+<debugging level="0"/>
+<host starttime="1632129831" endtime="1632129831"><status state="up" reason="user-set" reason_ttl="0"/>
+<address addr="10.103.42.74" addrtype="ipv4"/>
+<hostnames>
+<hostname name="dummy-ftp.demo-targets.svc.cluster.local" type="PTR"/>
+</hostnames>
+<ports><port protocol="tcp" portid="21"><state state="open" reason="syn-ack" reason_ttl="0"/><service name="ftp" method="table" conf="3"/><script id="banner" output="220-&#45;&#45;&#45;&#45;&#45;&#45;&#45;&#45;&#45; Welcome to Pure-FTPd [privsep] [TLS] -&#45;&#45;&#45;&#45;&#45;&#45;&#45;&#45;&#45;\x&#xa;0D\x0A220-You are user number 2 of 30 allowed.\x0D\x0A220-Local time...&#xa;"/><script id="ftp-anon" output="Anonymous FTP login allowed (FTP code 230)&#xa;Can&apos;t get directory listing: PASV IP 127.0.0.1 is not the same as 10.103.42.74"/></port>
+</ports>
+<times srtt="105" rttvar="5000" to="100000"/>
+</host>
+<runstats><finished time="1632129831" timestr="Mon Sep 20 09:23:51 2021" summary="Nmap done at Mon Sep 20 09:23:51 2021; 1 IP address (1 host up) scanned in 0.32 seconds" elapsed="0.32" exit="success"/><hosts up="1" down="0" total="1"/>
+</runstats>
+</nmaprun>

--- a/scanners/nmap/parser/parser.test.js
+++ b/scanners/nmap/parser/parser.test.js
@@ -411,3 +411,82 @@ Array [
 ]
 `);
 });
+
+test("should properly parse a script finding for ftp in an xml file", async () => {
+  const xmlContent = await readFile(__dirname + "/__testFiles__/ftp.xml", {
+    encoding: "utf8",
+  });
+  const findings = await parse(xmlContent);
+  await expect(validateParser(findings)).resolves.toBeUndefined();
+  expect(await parse(xmlContent)).toMatchInlineSnapshot(`
+Array [
+  Object {
+    "attributes": Object {
+      "hostname": "dummy-ftp.demo-targets.svc.cluster.local",
+      "ip_address": "10.103.42.74",
+      "mac_address": null,
+      "method": "table",
+      "operating_system": null,
+      "port": 21,
+      "protocol": "tcp",
+      "scripts": Object {
+        "banner": "220---------- Welcome to Pure-FTPd [privsep] [TLS] ----------\\\\x
+0D\\\\x0A220-You are user number 2 of 30 allowed.\\\\x0D\\\\x0A220-Local time...
+",
+        "ftp-anon": "Anonymous FTP login allowed (FTP code 230)
+Can't get directory listing: PASV IP 127.0.0.1 is not the same as 10.103.42.74",
+      },
+      "service": "ftp",
+      "serviceProduct": null,
+      "serviceVersion": null,
+      "state": "open",
+      "tunnel": null,
+    },
+    "category": "Open Port",
+    "description": "Port 21 is open using tcp protocol.",
+    "location": "tcp://10.103.42.74:21",
+    "name": "Open Port: 21 (ftp)",
+    "osi_layer": "NETWORK",
+    "severity": "INFORMATIONAL",
+  },
+  Object {
+    "attributes": Object {
+      "hostname": "dummy-ftp.demo-targets.svc.cluster.local",
+      "ip_address": "10.103.42.74",
+      "operating_system": null,
+    },
+    "category": "Host",
+    "description": "Found a host",
+    "location": "dummy-ftp.demo-targets.svc.cluster.local",
+    "name": "Host: dummy-ftp.demo-targets.svc.cluster.local",
+    "osi_layer": "NETWORK",
+    "severity": "INFORMATIONAL",
+  },
+  Object {
+    "attributes": Object {
+      "banner": "220---------- Welcome to Pure-FTPd [privsep] [TLS] ----------\\\\x
+0D\\\\x0A220-You are user number 2 of 30 allowed.\\\\x0D\\\\x0A220-Local time...
+",
+      "script": "banner",
+    },
+    "category": "FTP",
+    "description": "Port 21 displays banner",
+    "location": "ftp://10.103.42.74:21",
+    "name": "Server banner found",
+    "osi_layer": "NETWORK",
+    "severity": "INFORMATIONAL",
+  },
+  Object {
+    "attributes": Object {
+      "script": "ftp-anon",
+    },
+    "category": "FTP",
+    "description": "Port 21 allows anonymous FTP login",
+    "location": "ftp://10.103.42.74:21",
+    "name": "Anonymous FTP Login possible",
+    "osi_layer": "NETWORK",
+    "severity": "MEDIUM",
+  },
+]
+`);
+});


### PR DESCRIPTION
## Description

This PR, if applied, adds Nmap script support for `ftp-anon` and `ftp-banner`. To achieve this, parser support has been added for portrule scripts. This PR also introduced a generic way for maintainers to add more parsers.

### Context

Nmap has prerule, postrule, hostrule, and portrule [scripts](https://nmap.org/book/nse-script-format.html). Each of these script types output the script result under a different XML field.

For example, the smb-protocols script is a hostrule script and outputs the script results under the `<hostscript>` field within `<hosts>`. However, the ftp-anon scan is a portrule script and will output the script results under the `<port>`  field within <ports>. When parsing and extracting script results, this will need to be taken into account in order to detect whether or not a script was successful and did indeed produce output.

Originally in the SecureCodeBox parser, only the parsing function for one example script was present. This was a hostrule script, and thus got its script results from the <hostscript> subtitle. This caused some confusion when implementing an additional script parsing function, as that script happened to be a portrule script and thus never produced output within <hostscript>, meaning it did not get picked up by the parser as script output.

Pre-rule scripts and post-rule scripts can also have their seperate XML field, namely <prescript> and <postscript> respectively, but these are rarely, if ever, relevant to the creation of a finding for a target host, that special support for these has not been implemented. Note: post-rule scripts often edit output in port-rule or host-rule script fields, which is supported by this merge.

Example host-rule script output
``` xml
<hostscript>
    <script id="smb-protocols" output="&#xa;  dialects: &#xa;    NT LM 0.12 (SMBv1) [dangerous, but default]&#xa;    2.02&#xa;    2.10&#xa;    3.00&#xa;    3.02&#xa;    3.11">
        <table key="dialects">
            <elem>NT LM 0.12 (SMBv1) [dangerous, but default]</elem>
            <elem>2.02</elem>
            <elem>2.10</elem>
            <elem>3.00</elem>
            <elem>3.02</elem>
            <elem>3.11</elem>
        </table>
    </script>
</hostscript>
```

Example port-rule script output
``` xml
<port protocol="tcp" portid="21">
    <state state="open" reason="syn-ack" reason_ttl="0"/>
    <service name="ftp" method="table" conf="3"/>
    <script id="ftp-anon" output="Anonymous FTP login allowed (FTP code 230)"/>
</port>
```

### Checklist

* [x] Test your changes as thoroughly as possible before you commit them. Preferably, automate your test by unit/integration tests.
* [x] Make sure `npm test` runs for the whole project.
* [x] Make codeclimate checks happy
