### PR TITLE
Helm Chart: Juice-Shop - Ingress installation failed because of 'apiVersion not set'

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -30,3 +30,4 @@ Committing with `git commit -s` will add the sign-off at the end of the commit m
 - Jannik Hollenbach <jannik.hollenbach@iteratec.com>
 - Johannes Zahn <johannes.zahn@iteratec.com>
 - Jop Zitman <jop.zitman@secura.com>
+- Florian Buchmeier <florian.buchmeier@audi.de>

--- a/demo-targets/juice-shop/Chart.yaml
+++ b/demo-targets/juice-shop/Chart.yaml
@@ -3,7 +3,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 apiVersion: v2
-version: v3.1.0-alpha1
+version: v3.1.0-alpha2
 appVersion: "v12.7.0"
 name: juice-shop
 description: "OWASP Juice Shop: Probably the most modern and sophisticated insecure web application"

--- a/demo-targets/juice-shop/templates/ingress.yaml
+++ b/demo-targets/juice-shop/templates/ingress.yaml
@@ -2,7 +2,7 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-{{- if .Values.ingress.enabled -}}
+{{ if .Values.ingress.enabled -}}
 {{- $fullName := include "juice-shop.fullname" . -}}
 {{- $svcPort := .Values.service.port -}}
 {{- if semverCompare ">=1.14-0" .Capabilities.KubeVersion.GitVersion -}}


### PR DESCRIPTION
<!-- 
Thank you for your contribution to our Project 🙌 

Before submitting your Pull Request, please take the time to check the points below and provide some descriptive information.
* [x] If this PR comes from a fork, please [Allow edits from maintainers](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork)
* [x] Set a meaningful title. Format: {task_name} (closes #{issue_number}). For example: Use logger (closes #41)
* [NA] [Link your Pull Request to an issue](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) (if applicable)
* [NA] Create Draft pull requests if you need clarification or an explicit review before you can continue your work item.
* [x] Make sure that your PR is not introducing _unnecessary_ reformatting (e.g., introduced by on-save hooks in your IDE)
* [x] Make sure each new source file you add has a correct license header.
-->

## Description

- fixed 'error validating : error validating data: apiVersion not set' when installing with 'ingress.enabled=true'

When enabling the ingress resource, the first `{-` template block would remove the line feeds between the `apiVersion` and the comments at the beginning of the file, causing the `apiVersion` to be omitted and the resource from failing to install.

### Checklist

* [x] Test your changes as thoroughly as possible before you commit them. Preferably, automate your test by unit/integration tests.
* [NA] Make sure `npm test` runs for the whole project.
* [NA] Make codeclimate checks happy
