### PR TITLE
fix(scanner): fix scantype for nuclei

### DIFF
--- a/scanners/nuclei/templates/nuclei-scan-type.yaml
+++ b/scanners/nuclei/templates/nuclei-scan-type.yaml
@@ -39,6 +39,8 @@ spec:
                 {{- toYaml .Values.scanner.securityContext | nindent 16 }}
               env:
                 {{- toYaml .Values.scanner.env | nindent 16 }}
+              {{ $length := len .Values.scanner.extraVolumes }}
+              {{ if or .Values.nucleiTemplateCache.enabled  (gt $length 0 ) }}
               volumeMounts:
                 {{ if .Values.nucleiTemplateCache.enabled }}
                 - name: nuclei-content
@@ -48,9 +50,13 @@ spec:
                 {{- if .Values.scanner.extraVolumeMounts }}
                 {{- toYaml .Values.scanner.extraVolumeMounts | nindent 16 }}
                 {{- end }}
+              {{ end }}
             {{- if .Values.scanner.extraContainers }}
             {{- toYaml .Values.scanner.extraContainers | nindent 12 }}
             {{- end }}
+
+          {{ $length := len .Values.scanner.extraVolumes }}
+          {{ if or .Values.nucleiTemplateCache.enabled  (gt $length 0 ) }}
           volumes:
             {{ if .Values.nucleiTemplateCache.enabled }}
             - name: nuclei-content
@@ -61,3 +67,4 @@ spec:
             {{- if .Values.scanner.extraVolumes }}
             {{- toYaml .Values.scanner.extraVolumes | nindent 12 }}
             {{- end }}
+         {{ end }}


### PR DESCRIPTION
Trying to install nuclei with `nucleiTemplateCache.enabled: false`
resulted in an invalid template because volumes and volumeMounts are not
allowed to be empty.

To fix this I added another condition checking if extraMounts has mounts
or `nucleiTemplateCache.enabled` is true

closes #699

Signed-off-by: Yannik Fuhrmeister <yannik.fuhrmeister@iteratec.com>
