### PR TITLE
Consistency/scan types

### DIFF
--- a/scanners/amass/templates/amass-scan-type.yaml
+++ b/scanners/amass/templates/amass-scan-type.yaml
@@ -1,14 +1,13 @@
 # SPDX-FileCopyrightText: 2021 iteratec GmbH
 #
 # SPDX-License-Identifier: Apache-2.0
+
 apiVersion: "execution.securecodebox.io/v1"
 kind: ScanType
 metadata:
   name: "amass{{ .Values.scanner.nameAppend | default ""}}"
 spec:
   extractResults:
-    # amass saves it's result now in json but in "json lines" format
-    # http://jsonlines.org/
     type: amass-jsonl
     location: "/home/securecodebox/amass-results.jsonl"
   jobTemplate:

--- a/scanners/git-repo-scanner/templates/git-repo-scanner-scan-type.yaml
+++ b/scanners/git-repo-scanner/templates/git-repo-scanner-scan-type.yaml
@@ -24,7 +24,7 @@ spec:
           restartPolicy: OnFailure
           containers:
             - name: git-repo-scanner
-              image: "{{ .Values.scanner.image.repository }}:{{ .Values.scanner.image.tag | default .Chart.Version }}"
+              image: "{{ .Values.scanner.image.repository }}:{{ .Values.scanner.image.tag | default .Chart.AppVersion }}"
               imagePullPolicy: {{ .Values.scanner.image.pullPolicy }}
               command:
                 - "python"

--- a/scanners/kube-hunter/templates/kubehunter-scan-type.yaml
+++ b/scanners/kube-hunter/templates/kubehunter-scan-type.yaml
@@ -2,14 +2,14 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-apiVersion: 'execution.securecodebox.io/v1'
+apiVersion: "execution.securecodebox.io/v1"
 kind: ScanType
 metadata:
-  name: 'kube-hunter{{ .Values.scanner.nameAppend | default ""}}'
+  name: "kube-hunter{{ .Values.scanner.nameAppend | default ""}}"
 spec:
   extractResults:
     type: kube-hunter-json
-    location: '/home/securecodebox/kube-hunter-results.json'
+    location: "/home/securecodebox/kube-hunter-results.json"
   jobTemplate:
     spec:
       {{- if .Values.scanner.ttlSecondsAfterFinished }}
@@ -27,10 +27,10 @@ spec:
               image: "{{ .Values.scanner.image.repository }}:{{ .Values.scanner.image.tag | default .Chart.AppVersion }}"
               imagePullPolicy: {{ .Values.scanner.image.pullPolicy }}
               command:
-                - 'sh'
-                - '/wrapper.sh'
-                - '--report'
-                - 'json'
+                - "sh"
+                - "/wrapper.sh"
+                - "--report"
+                - "json"
               resources:
                 {{- toYaml .Values.scanner.resources | nindent 16 }}
               securityContext:

--- a/scanners/kubeaudit/templates/kubeaudit-scan-type.yaml
+++ b/scanners/kubeaudit/templates/kubeaudit-scan-type.yaml
@@ -46,5 +46,5 @@ spec:
             {{- toYaml .Values.scanner.extraContainers | nindent 12 }}
             {{- end }}
           volumes:
-            {{- toYaml .Values.scanner.extraVolumeMounts | nindent 12 }}
+            {{- toYaml .Values.scanner.extraVolumes | nindent 12 }}
           serviceAccountName: kubeaudit

--- a/scanners/ncrack/templates/ncrack-scan-type.yaml
+++ b/scanners/ncrack/templates/ncrack-scan-type.yaml
@@ -26,7 +26,10 @@ spec:
             - name: ncrack
               image: "{{ .Values.scanner.image.repository }}:{{ .Values.scanner.image.tag | default .Chart.AppVersion }}"
               imagePullPolicy: {{ .Values.scanner.image.pullPolicy }}
-              command: ["ncrack", "-oX", "/home/securecodebox/ncrack-results.xml"]
+              command:
+                - "ncrack"
+                - "-oX"
+                - "/home/securecodebox/ncrack-results.xml"
               resources:
                 {{- toYaml .Values.scanner.resources | nindent 16 }}
               securityContext:

--- a/scanners/nikto/templates/nikto-scan-type.yaml
+++ b/scanners/nikto/templates/nikto-scan-type.yaml
@@ -2,14 +2,14 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-apiVersion: 'execution.securecodebox.io/v1'
+apiVersion: "execution.securecodebox.io/v1"
 kind: ScanType
 metadata:
-  name: 'nikto{{ .Values.scanner.nameAppend | default ""}}'
+  name: "nikto{{ .Values.scanner.nameAppend | default ""}}"
 spec:
   extractResults:
     type: nikto-json
-    location: '/home/securecodebox/nikto-results.json'
+    location: "/home/securecodebox/nikto-results.json"
   jobTemplate:
     spec:
       {{- if .Values.scanner.ttlSecondsAfterFinished }}
@@ -27,12 +27,10 @@ spec:
               image: "{{ .Values.scanner.image.repository }}:{{ .Values.scanner.image.tag | default .Chart.AppVersion }}"
               imagePullPolicy: {{ .Values.scanner.image.pullPolicy }}
               command:
-                # Nikto Entrypoint Script to avoid problems nikto exiting with a non zero exit code
-                # This would cause the kubernetes job to fail no matter what
-                - 'sh'
-                - '/wrapper.sh'
-                - '-o'
-                - '/home/securecodebox/nikto-results.json'
+                - "sh"
+                - "/wrapper.sh"
+                - "-o"
+                - "/home/securecodebox/nikto-results.json"
               resources:
                 {{- toYaml .Values.scanner.resources | nindent 16 }}
               securityContext:

--- a/scanners/nmap/templates/nmap-scan-type.yaml
+++ b/scanners/nmap/templates/nmap-scan-type.yaml
@@ -26,7 +26,10 @@ spec:
             - name: nmap
               image: "{{ .Values.scanner.image.repository }}:{{ .Values.scanner.image.tag | default .Chart.AppVersion }}"
               imagePullPolicy: {{ .Values.scanner.image.pullPolicy }}
-              command: ["nmap", "-oX", "/home/securecodebox/nmap-results.xml"]
+              command:
+                - "nmap"
+                - "-oX"
+                - "/home/securecodebox/nmap-results.xml"
               resources:
                 {{- toYaml .Values.scanner.resources | nindent 16 }}
               securityContext:

--- a/scanners/nuclei/templates/nuclei-scan-type.yaml
+++ b/scanners/nuclei/templates/nuclei-scan-type.yaml
@@ -2,14 +2,14 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-apiVersion: 'execution.securecodebox.io/v1'
+apiVersion: "execution.securecodebox.io/v1"
 kind: ScanType
 metadata:
-  name: 'nuclei{{ .Values.scanner.nameAppend | default ""}}'
+  name: "nuclei{{ .Values.scanner.nameAppend | default ""}}"
 spec:
   extractResults:
     type: nuclei-json
-    location: '/home/securecodebox/nuclei-results.jsonl'
+    location: "/home/securecodebox/nuclei-results.jsonl"
   jobTemplate:
     spec:
       {{- if .Values.scanner.ttlSecondsAfterFinished }}
@@ -27,12 +27,11 @@ spec:
               image: "{{ .Values.scanner.image.repository }}:{{ .Values.scanner.image.tag | default .Chart.AppVersion }}"
               imagePullPolicy: {{ .Values.scanner.image.pullPolicy }}
               command:
-                - 'nuclei'
-                - '-no-update-templates'
-                - '-json'
-                # nuclei writes json lines: https://jsonlines.org/
-                - '-output'
-                - '/home/securecodebox/nuclei-results.jsonl'
+                - "nuclei"
+                - "-no-update-templates"
+                - "-json"
+                - "-output"
+                - "/home/securecodebox/nuclei-results.jsonl"
               resources:
                 {{- toYaml .Values.scanner.resources | nindent 16 }}
               securityContext:

--- a/scanners/screenshooter/templates/screenshooter-scan-type.yaml
+++ b/scanners/screenshooter/templates/screenshooter-scan-type.yaml
@@ -27,8 +27,8 @@ spec:
               image: "{{ .Values.scanner.image.repository }}:{{ .Values.scanner.image.tag | default .Chart.Version }}"
               imagePullPolicy: {{ .Values.scanner.image.pullPolicy }}
               command:
-                - 'sh'
-                - '/wrapper.sh'
+                - "sh"
+                - "/wrapper.sh"
                 - "-screenshot"
                 - "/home/securecodebox/screenshot.png"
               resources:

--- a/scanners/sslyze/templates/sslyze-scan-type.yaml
+++ b/scanners/sslyze/templates/sslyze-scan-type.yaml
@@ -2,14 +2,14 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-apiVersion: 'execution.securecodebox.io/v1'
+apiVersion: "execution.securecodebox.io/v1"
 kind: ScanType
 metadata:
-  name: 'sslyze{{ .Values.scanner.nameAppend | default ""}}'
+  name: "sslyze{{ .Values.scanner.nameAppend | default ""}}"
 spec:
   extractResults:
     type: sslyze-json
-    location: '/home/securecodebox/sslyze-results.json'
+    location: "/home/securecodebox/sslyze-results.json"
   jobTemplate:
     spec:
       {{- if .Values.scanner.ttlSecondsAfterFinished }}
@@ -27,9 +27,9 @@ spec:
               image: "{{ .Values.scanner.image.repository }}:{{ .Values.scanner.image.tag | default .Chart.AppVersion }}"
               imagePullPolicy: {{ .Values.scanner.image.pullPolicy }}
               command:
-                - 'sslyze'
-                - '--json_out'
-                - '/home/securecodebox/sslyze-results.json'
+                - "sslyze"
+                - "--json_out"
+                - "/home/securecodebox/sslyze-results.json"
               resources:
                 {{- toYaml .Values.scanner.resources | nindent 16 }}
               securityContext:

--- a/scanners/test-scan/templates/test-scan-scan-type.yaml
+++ b/scanners/test-scan/templates/test-scan-scan-type.yaml
@@ -24,9 +24,11 @@ spec:
           restartPolicy: OnFailure
           containers:
             - name: test-scan
-              image: "{{ .Values.scanner.image.repository }}:{{ .Values.scanner.image.tag | default .Chart.Version }}"
-              command: ["touch", "/home/securecodebox/hello-world.txt"]
+              image: "{{ .Values.scanner.image.repository }}:{{ .Values.scanner.image.tag | default .Chart.AppVersion }}"
               imagePullPolicy: {{ .Values.scanner.image.pullPolicy }}
+              command:
+                - "touch"
+                - "/home/securecodebox/hello-world.txt"
               resources:
                 {{- toYaml .Values.scanner.resources | nindent 16 }}
               securityContext:

--- a/scanners/typo3scan/templates/typo3scan-scan-type.yaml
+++ b/scanners/typo3scan/templates/typo3scan-scan-type.yaml
@@ -1,6 +1,7 @@
 # SPDX-FileCopyrightText: 2021 iteratec GmbH
 #
 # SPDX-License-Identifier: Apache-2.0
+
 apiVersion: "execution.securecodebox.io/v1"
 kind: ScanType
 metadata:
@@ -24,6 +25,7 @@ spec:
           containers:
             - name: typo3scan
               image: "{{ .Values.scanner.image.repository }}:{{ .Values.scanner.image.tag | default .Chart.AppVersion }}"
+              imagePullPolicy: {{ .Values.scanner.image.pullPolicy }}
               command:
                 - "python3"
                 - "/home/typo3scan/typo3scan.py"

--- a/scanners/whatweb/templates/whatweb-scan-type.yaml
+++ b/scanners/whatweb/templates/whatweb-scan-type.yaml
@@ -26,7 +26,9 @@ spec:
             - name: whatweb
               image: "{{ .Values.scanner.image.repository }}:{{ .Values.scanner.image.tag | default .Chart.AppVersion }}"
               imagePullPolicy: {{ .Values.scanner.image.pullPolicy }}
-              command: ["whatweb", "--log-json=/home/securecodebox/whatweb-results.json"]
+              command:
+                - "whatweb"
+                - "--log-json=/home/securecodebox/whatweb-results.json"
               resources:
                 {{- toYaml .Values.scanner.resources | nindent 16 }}
               securityContext:

--- a/scanners/zap-advanced/templates/zap-advanced-scan-type.yaml
+++ b/scanners/zap-advanced/templates/zap-advanced-scan-type.yaml
@@ -39,7 +39,7 @@ spec:
           restartPolicy: Never
           containers:
             - name: zap-advanced-scan
-              image: "{{ .Values.scanner.image.repository }}:{{ .Values.scanner.image.tag | default .Chart.Version }}"
+              image: "{{ .Values.scanner.image.repository }}:{{ .Values.scanner.image.tag | default .Chart.AppVersion }}"
               imagePullPolicy: {{ .Values.scanner.image.pullPolicy }}
               command:
                 - "python3"


### PR DESCRIPTION
Closes #689.

Makes all scan-type-yaml files consistent:

1. Replacing all ' with "
2. Replacing incorrect scanner image ".Chart.Version" with ".Chart.AppVersion"
3. Replacing array command for ncrack, nmap, test-scan, whatweb with single lines for each parameter
4. Removing redundant comments
5. Adding missing empty lines
6. Make order of variables consistent for all scanners


### Checklist

* [x] Test your changes as thoroughly as possible before you commit them. Preferably, automate your test by unit/integration tests.
* [ ] Make codeclimate checks happy
