### PR TITLE
Braces around the links causes docusaurus build fail

### DIFF
--- a/docs/adr/adr_0009.md
+++ b/docs/adr/adr_0009.md
@@ -16,7 +16,7 @@ SPDX-License-Identifier: Apache-2.0
 
 SecureCodeBox should be able to run scanners that require access to the source code of the target. This could include secret scanners like [Gitleaks][gitleaks] or SAST tools like [Semgrep][semgrep]. To achieve this and expose the feature to the user, we need to extend the syntax of the scan definitions and implement the pre-loading functionality.
 
-The current scanners do not support dynamically loading data from a Git repository (except Gitleaks) or other sources. Thus, we need a solution for retrieving data from a source and exposing it to the scanner, without modifying the scanners or their images. In our view, the best way to achieve this is using [Kubernetes init containers][initc]. They can be used to retrieve data and place it in a volume they share with the scanner, and they can be trivially attached to any existing scanner container using built-in features of Kubernetes. 
+The current scanners do not support dynamically loading data from a Git repository (except Gitleaks) or other sources. Thus, we need a solution for retrieving data from a source and exposing it to the scanner, without modifying the scanners or their images. In our view, the best way to achieve this is using [Kubernetes init containers][initc]. They can be used to retrieve data and place it in a volume they share with the scanner, and they can be trivially attached to any existing scanner container using built-in features of Kubernetes.
 
 
 ### Question 1: Implementing Different Pre-Population Data Sources
@@ -24,9 +24,9 @@ The current scanners do not support dynamically loading data from a Git reposito
 To be useful, the feature will need to support a number of different data sources. At a minimum, Git repositories and file downloads via curl should be supported, but further data sources may be desireable (e.g., SVN, curl+unzip, en- or decryption of data using openssl CLI, ...). Thus, the extensibility of the pre-populator architecture should be considered.
 
 #### Option 1: Modular design using CRDs
-For scanners, secureCodeBox uses a modular architecture where additional scanners can be added without modifying the controller. This allows people without knowledge of Go to contribute new scanners without worrying about implementation details of the operator, at the price of having to install the scanners individually via helm. 
+For scanners, secureCodeBox uses a modular architecture where additional scanners can be added without modifying the controller. This allows people without knowledge of Go to contribute new scanners without worrying about implementation details of the operator, at the price of having to install the scanners individually via helm.
 
-The pre-populators could be designed in a similar way: A general syntax in the ScanSpec defines which downloader should be started, and parameterizes it using arguments, similar to how the scanners are parameterized. It would use a general-purpose syntax (with the same YAML structure for all downloaders), which can be directly transformed into a Kubernetes specification, like it is done for the scan jobs. Power users can define their own pre-populator jobs, which should be a lot simpler than defining a scanner, as it does not require a parser, sidecar, etc. 
+The pre-populators could be designed in a similar way: A general syntax in the ScanSpec defines which downloader should be started, and parameterizes it using arguments, similar to how the scanners are parameterized. It would use a general-purpose syntax (with the same YAML structure for all downloaders), which can be directly transformed into a Kubernetes specification, like it is done for the scan jobs. Power users can define their own pre-populator jobs, which should be a lot simpler than defining a scanner, as it does not require a parser, sidecar, etc.
 
 A configuration may look something like this, using a fictional [semgrep][semgrep] scanner job (disregard the `mountPoint` for now, it will be discussed later in the ADR):
 
@@ -74,7 +74,7 @@ spec:
 
 #### Option 2: Implementation Inside the Operator
 
-If we want to avoid adding another CRD and dealing with the overhead of managing the scanners that way (including the overhead of installing the preloaders etc.), the feature can also be implemented directly inside the operator. For this, the ScanSpec could be extended with specific fields for the different pre-populators (i.e., the Git downloader could explicitly ask for the repository, access key, etc., while the curl downloader would have other flags and options). The controller would then translate the spec into a Kubernetes job with the correct parameters and add it as an init container. Optionally, we could also let users specify their own custom jobs that use a container and script of their choice. This would allow them to run special scripts that are specific to their deployment and that would not be useful to send upstream to the project. 
+If we want to avoid adding another CRD and dealing with the overhead of managing the scanners that way (including the overhead of installing the preloaders etc.), the feature can also be implemented directly inside the operator. For this, the ScanSpec could be extended with specific fields for the different pre-populators (i.e., the Git downloader could explicitly ask for the repository, access key, etc., while the curl downloader would have other flags and options). The controller would then translate the spec into a Kubernetes job with the correct parameters and add it as an init container. Optionally, we could also let users specify their own custom jobs that use a container and script of their choice. This would allow them to run special scripts that are specific to their deployment and that would not be useful to send upstream to the project.
 
 An example configuration could look like this:
 
@@ -92,12 +92,12 @@ spec:
     - "/etc/rules/semgrep-rules.yaml"
     - "/etc/repo"
   prepopulateFilesystemFrom:
-    - mountPoint: /etc/repo 
+    - mountPoint: /etc/repo
       git:
         url: "https://github.com/bkimminich/juice-shop.git"
         accessToken: "ABC123..."
         recurseSubmodules: true
-    - mountPoint: /etc/rules 
+    - mountPoint: /etc/rules
       http:
         url: "https://example.com/semgrep-rules.yaml"
     - mountPoint: /etc/repo
@@ -235,7 +235,7 @@ We decided to utilize the built-in `initContainer` functionality of Kubernetes a
 
 The possibility of using init containers adds a large number of new possible features to the secureCodeBox, and lays the groundwork for adding new types of scanners. We will gather experience with how the feature is used, and may come back to the architecture and make changes if a simpler interface is desired.
 
-[initc]: (https://kubernetes.io/docs/concepts/workloads/pods/init-containers/)
-[initcvolumes]: (https://kubernetes.io/docs/tasks/configure-pod-container/configure-pod-initialization/#create-a-pod-that-has-an-init-container)
-[gitleaks]: (https://docs.securecodebox.io/docs/scanners/gitleaks)
-[semgrep]: (https://github.com/returntocorp/semgrep)
+[initc]:        https://kubernetes.io/docs/concepts/workloads/pods/init-containers/
+[initcvolumes]: https://kubernetes.io/docs/tasks/configure-pod-container/configure-pod-initialization/#create-a-pod-that-has-an-init-container
+[gitleaks]:     https://docs.securecodebox.io/docs/scanners/gitleaks/
+[semgrep]:      https://github.com/returntocorp/semgrep


### PR DESCRIPTION
The ADRs from this repo are copied during the documentation build
over to that repo and will be rendered in its ADR section.

Docusaurus fails the build if there are unresolvable links in
the sources.

In Markdown typically links are written as `[text](url)`. If the
links are written in the footer of the document with references
the syntax must be:

```Markdown
[text]: uri
```

The braces around the URI resulted into unresolvable URIs which
caused the failing build.