### PR TITLE
Fixed incompatibility with BSD Unix sed in makefile (closes #749)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -151,7 +151,9 @@ docs: readme hook-docs scanner-docs operator-docs auto-discovery-docs demo-apps-
 create-new-scanner: ## Creates templates for a new scanner, pass NAME=NEW-SCANNER
 ifdef NAME
 	cp -r ./.templates/new-scanner ./scanners/$(NAME)
-	find ./scanners/$(NAME) -type f -exec sed -i '' 's/new-scanner/$(NAME)/g' {} +
+	find ./scanners/$(NAME) -type f ! -name 'tmp' \
+		-exec sed -n 's/new-scanner/$(NAME)/g;w ./scanners/$(NAME)/tmp' {} \; \
+		-exec mv ./scanners/$(NAME)/tmp {} \;
 	mv ./scanners/$(NAME)/templates/new-scanner-parse-definition.yaml ./scanners/$(NAME)/templates/$(NAME)-parse-definition.yaml
 	mv ./scanners/$(NAME)/templates/new-scanner-scan-type.yaml ./scanners/$(NAME)/templates/$(NAME)-scan-type.yaml
 else


### PR DESCRIPTION
## Description

This fixes #749 incompatibility with BSD Unix sed.

### Checklist

* [x] Test your changes as thoroughly as possible before you commit them. Preferably, automate your test by unit/integration tests.
* [x] Make sure `npm test` runs for the whole project.
* [x] Make codeclimate checks happy
