### PR TITLE
Add ability to configure which hooks to run per scan

### DIFF
--- a/hooks/cascading-scans/hook/hook.test.js
+++ b/hooks/cascading-scans/hook/hook.test.js
@@ -1307,7 +1307,7 @@ test("Templating should not break special encoding (http://...) when using tripl
   `);
 });
 
-test("should merge hookSelector into cascaded scan", () => {
+test("should merge hookSelector into cascaded scan if inheritHookSelector is enabled", () => {
   parentScan.spec.cascades.inheritHookSelector = true
   const findings = [
     {

--- a/hooks/cascading-scans/hook/hook.ts
+++ b/hooks/cascading-scans/hook/hook.ts
@@ -16,7 +16,8 @@ import {
   getCascadedRuleForScan,
   purgeCascadedRuleFromScan,
   mergeInheritedMap,
-  mergeInheritedArray
+  mergeInheritedArray,
+  mergeInheritedSelector,
 } from "./scan-helpers";
 
 interface HandleArgs {
@@ -110,7 +111,7 @@ function getCascadingScan(
 
   let { scanType, parameters } = cascadingRule.spec.scanSpec;
 
-  let { annotations, labels, env, volumes, volumeMounts, initContainers } = mergeCascadingRuleWithScan(parentScan, cascadingRule);
+  let { annotations, labels, env, volumes, volumeMounts, initContainers, hookSelector } = mergeCascadingRuleWithScan(parentScan, cascadingRule);
 
   let cascadingChain = getScanChain(parentScan);
 
@@ -142,6 +143,7 @@ function getCascadingScan(
       ]
     },
     spec: {
+      hookSelector,
       scanType,
       parameters,
       cascades: parentScan.spec.cascades,
@@ -158,8 +160,8 @@ function mergeCascadingRuleWithScan(
   cascadingRule: CascadingRule
 ) {
   const { scanAnnotations, scanLabels } = cascadingRule.spec;
-  let { env = [], volumes = [], volumeMounts = [], initContainers = [] } = cascadingRule.spec.scanSpec;
-  let { inheritAnnotations, inheritLabels, inheritEnv, inheritVolumes, inheritInitContainers } = scan.spec.cascades;
+  let { env = [], volumes = [], volumeMounts = [], initContainers = [], hookSelector = {} } = cascadingRule.spec.scanSpec;
+  let { inheritAnnotations, inheritLabels, inheritEnv, inheritVolumes, inheritInitContainers, inheritHookSelector } = scan.spec.cascades;
 
   return {
     annotations: mergeInheritedMap(scan.metadata.annotations, scanAnnotations, inheritAnnotations),
@@ -168,6 +170,7 @@ function mergeCascadingRuleWithScan(
     volumes: mergeInheritedArray(scan.spec.volumes, volumes, inheritVolumes),
     volumeMounts: mergeInheritedArray(scan.spec.volumeMounts, volumeMounts, inheritVolumes),
     initContainers: mergeInheritedArray(scan.spec.initContainers, initContainers, inheritInitContainers),
+    hookSelector: mergeInheritedSelector(scan.spec.hookSelector, hookSelector, inheritHookSelector),
   }
 }
 

--- a/hooks/cascading-scans/hook/kubernetes-label-selector.ts
+++ b/hooks/cascading-scans/hook/kubernetes-label-selector.ts
@@ -19,8 +19,8 @@ export interface LabelSelectorRequirement {
 }
 
 export interface LabelSelector {
-  matchExpressions: Array<LabelSelectorRequirement>;
-  matchLabels: Map<string, string>;
+  matchExpressions?: Array<LabelSelectorRequirement>;
+  matchLabels?: Map<string, string>;
 }
 
 // generateSelectorString transforms a kubernetes labelSelector object in to the string representation

--- a/hooks/cascading-scans/hook/scan-helpers.ts
+++ b/hooks/cascading-scans/hook/scan-helpers.ts
@@ -91,7 +91,7 @@ export function mergeInheritedArray(parentArray, ruleArray, inherit: boolean = f
   return (parentArray || []).concat(ruleArray)  // CascadingRule's env overwrites scan's env
 }
 
-export function mergeInheritedSelector(parentSelector: LabelSelector = {}, ruleSelector: LabelSelector = {}, inherit: boolean = true): LabelSelector {
+export function mergeInheritedSelector(parentSelector: LabelSelector = {}, ruleSelector: LabelSelector = {}, inherit: boolean = false): LabelSelector {
   let labelSelector: LabelSelector = {};
   if (parentSelector.matchExpressions || ruleSelector.matchExpressions) {
     labelSelector.matchExpressions = mergeInheritedArray(parentSelector.matchExpressions, ruleSelector.matchExpressions, inherit);

--- a/hooks/cascading-scans/hook/scan-helpers.ts
+++ b/hooks/cascading-scans/hook/scan-helpers.ts
@@ -84,7 +84,7 @@ export function mergeInheritedMap(parentProps, ruleProps, inherit: boolean = tru
   }
 }
 
-export function mergeInheritedArray(parentArray, ruleArray, inherit: boolean = false) {
+export function mergeInheritedArray(parentArray = [], ruleArray = [], inherit: boolean = false) {
   if (!inherit) {
     parentArray = [];
   }
@@ -176,6 +176,19 @@ export function purgeCascadedRuleFromScan(scan: Scan, cascadedRuleUsedForParentS
     scan.spec.volumeMounts = scan.spec.volumeMounts.filter(scanVolumeMount =>
       !cascadedRuleUsedForParentScan.spec.scanSpec.volumeMounts.some(ruleVolumeMount => isEqual(scanVolumeMount, ruleVolumeMount))
     );
+  }
+
+  if (scan.spec.hookSelector !== undefined && cascadedRuleUsedForParentScan.spec.scanSpec.hookSelector !== undefined) {
+    if (scan.spec.hookSelector.matchExpressions !== undefined && cascadedRuleUsedForParentScan.spec.scanSpec.hookSelector.matchExpressions !== undefined) {
+      scan.spec.hookSelector.matchExpressions = scan.spec.hookSelector.matchExpressions.filter(scanHookSelector =>
+        !cascadedRuleUsedForParentScan.spec.scanSpec.hookSelector.matchExpressions.some(ruleHookSelector => isEqual(scanHookSelector, ruleHookSelector))
+      );
+    }
+    if (scan.spec.hookSelector.matchLabels !== undefined && cascadedRuleUsedForParentScan.spec.scanSpec.hookSelector.matchLabels !== undefined) {
+      for (const label in cascadedRuleUsedForParentScan.spec.scanSpec.hookSelector.matchLabels) {
+        delete scan.spec.hookSelector.matchLabels[label]
+      }
+    }
   }
 
   return scan

--- a/hooks/cascading-scans/hook/scan-helpers.ts
+++ b/hooks/cascading-scans/hook/scan-helpers.ts
@@ -62,6 +62,7 @@ export interface ScanSpec {
   volumes?: Array<k8s.V1Volume>;
   volumeMounts?: Array<k8s.V1VolumeMount>;
   initContainers?: Array<k8s.V1Container>;
+  hookSelector?: LabelSelector;
 }
 
 export interface CascadingInheritance {
@@ -70,6 +71,7 @@ export interface CascadingInheritance {
   inheritEnv: boolean,
   inheritVolumes: boolean,
   inheritInitContainers: boolean,
+  inheritHookSelector: boolean,
 }
 
 export function mergeInheritedMap(parentProps, ruleProps, inherit: boolean = true) {
@@ -87,6 +89,17 @@ export function mergeInheritedArray(parentArray, ruleArray, inherit: boolean = f
     parentArray = [];
   }
   return (parentArray || []).concat(ruleArray)  // CascadingRule's env overwrites scan's env
+}
+
+export function mergeInheritedSelector(parentSelector: LabelSelector = {}, ruleSelector: LabelSelector = {}, inherit: boolean = true): LabelSelector {
+  let labelSelector: LabelSelector = {};
+  if (parentSelector.matchExpressions || ruleSelector.matchExpressions) {
+    labelSelector.matchExpressions = mergeInheritedArray(parentSelector.matchExpressions, ruleSelector.matchExpressions, inherit);
+  }
+  if (parentSelector.matchLabels || ruleSelector.matchLabels) {
+    labelSelector.matchLabels = mergeInheritedMap(parentSelector.matchLabels, ruleSelector.matchLabels, inherit);
+  }
+  return labelSelector
 }
 
 export async function startSubsequentSecureCodeBoxScan(scan: Scan) {

--- a/hooks/cascading-scans/templates/cascading-scans-hook.yaml
+++ b/hooks/cascading-scans/templates/cascading-scans-hook.yaml
@@ -8,6 +8,9 @@ metadata:
   name: {{ include "cascading-scans.fullname" . }}
   labels:
     {{- include "cascading-scans.labels" . | nindent 4 }}
+    {{- with .Values.hook.labels }}
+    {{ toYaml . }}
+    {{- end }}
 spec:
   type: ReadOnly
   image: "{{ .Values.hook.image.repository }}:{{ .Values.hook.image.tag | default .Chart.Version }}"

--- a/hooks/cascading-scans/templates/cascading-scans-hook.yaml
+++ b/hooks/cascading-scans/templates/cascading-scans-hook.yaml
@@ -8,6 +8,7 @@ metadata:
   name: {{ include "cascading-scans.fullname" . }}
   labels:
     {{- include "cascading-scans.labels" . | nindent 4 }}
+    securecodebox.io/internal: "true"
     {{- with .Values.hook.labels }}
     {{ toYaml . }}
     {{- end }}

--- a/hooks/cascading-scans/values.yaml
+++ b/hooks/cascading-scans/values.yaml
@@ -14,5 +14,8 @@ hook:
     # @default -- defaults to the charts version
     tag: null
 
+  # hook.labels -- Add Kubernetes Labels to the hook definition
+  labels: {}
+
   # hook.ttlSecondsAfterFinished -- Seconds after which the kubernetes job for the hook will be deleted. Requires the Kubernetes TTLAfterFinished controller: https://kubernetes.io/docs/concepts/workloads/controllers/ttlafterfinished/
   ttlSecondsAfterFinished: null

--- a/hooks/finding-post-processing/templates/finding-post-processing-hook.yaml
+++ b/hooks/finding-post-processing/templates/finding-post-processing-hook.yaml
@@ -8,6 +8,9 @@ metadata:
   name: {{ include "finding-post-processing.fullname" . }}
   labels:
     {{- include "finding-post-processing.labels" . | nindent 4 }}
+    {{- with .Values.hook.labels }}
+    {{ toYaml . }}
+    {{- end }}
 spec:
   type: ReadAndWrite
   image: "{{ .Values.hook.image.repository }}:{{ .Values.hook.image.tag | default .Chart.Version }}"

--- a/hooks/finding-post-processing/values.yaml
+++ b/hooks/finding-post-processing/values.yaml
@@ -30,5 +30,8 @@ hook:
     # @default -- defaults to the charts version
     tag: null
 
+  # hook.labels -- Add Kubernetes Labels to the hook definition
+  labels: {}
+
   # hook.ttlSecondsAfterFinished -- Seconds after which the kubernetes job for the hook will be deleted. Requires the Kubernetes TTLAfterFinished controller: https://kubernetes.io/docs/concepts/workloads/controllers/ttlafterfinished/
   ttlSecondsAfterFinished: null

--- a/hooks/generic-webhook/templates/webhook-hook.yaml
+++ b/hooks/generic-webhook/templates/webhook-hook.yaml
@@ -8,6 +8,9 @@ metadata:
   name: {{ include "generic-webhook.fullname" . }}
   labels:
     {{- include "generic-webhook.labels" . | nindent 4 }}
+    {{- with .Values.hook.labels }}
+    {{ toYaml . }}
+    {{- end }}
 spec:
   type: ReadOnly
   image: "{{ .Values.hook.image.repository }}:{{ .Values.hook.image.tag | default .Chart.Version }}"

--- a/hooks/generic-webhook/values.yaml
+++ b/hooks/generic-webhook/values.yaml
@@ -17,5 +17,8 @@ hook:
     # @default -- defaults to the charts version
     tag: null
 
+  # hook.labels -- Add Kubernetes Labels to the hook definition
+  labels: {}
+
   # hook.ttlSecondsAfterFinished -- Seconds after which the kubernetes job for the hook will be deleted. Requires the Kubernetes TTLAfterFinished controller: https://kubernetes.io/docs/concepts/workloads/controllers/ttlafterfinished/
   ttlSecondsAfterFinished: null

--- a/hooks/notification/templates/notification-hook.yaml
+++ b/hooks/notification/templates/notification-hook.yaml
@@ -6,6 +6,11 @@ apiVersion: "execution.securecodebox.io/v1"
 kind: ScanCompletionHook
 metadata:
   name: {{ include "notification-hook.fullname" . }}
+  labels:
+    {{- include "notification-hook.labels" . | nindent 4 }}
+    {{- with .Values.hook.labels }}
+    {{ toYaml . }}
+    {{- end }}
 spec:
   type: ReadOnly
   imagePullPolicy: "{{ .Values.hook.image.pullPolicy }}"

--- a/hooks/notification/values.yaml
+++ b/hooks/notification/values.yaml
@@ -16,6 +16,9 @@ hook:
     # -- Image pull policy. One of Always, Never, IfNotPresent. Defaults to Always if :latest tag is specified, or IfNotPresent otherwise. More info: https://kubernetes.io/docs/concepts/containers/images#updating-images
     pullPolicy: IfNotPresent
 
+  # hook.labels -- Add Kubernetes Labels to the hook definition
+  labels: {}
+
   # hook.ttlSecondsAfterFinished -- seconds after which the kubernetes job for the hook will be deleted. Requires the Kubernetes TTLAfterFinished controller: https://kubernetes.io/docs/concepts/workloads/controllers/ttlafterfinished/
   ttlSecondsAfterFinished: null
 

--- a/hooks/persistence-defectdojo/templates/persistence-provider.yaml
+++ b/hooks/persistence-defectdojo/templates/persistence-provider.yaml
@@ -9,6 +9,9 @@ metadata:
   labels:
     {{- include "persistence-defectdojo.labels" . | nindent 4 }}
     type: Unstructured
+    {{- with .Values.hook.labels }}
+    {{ toYaml . }}
+    {{- end }}
 spec:
   {{- if .Values.defectdojo.syncFindingsBack }}
   type: ReadAndWrite

--- a/hooks/persistence-defectdojo/values.yaml
+++ b/hooks/persistence-defectdojo/values.yaml
@@ -16,6 +16,9 @@ hook:
     # -- Image pull policy. One of Always, Never, IfNotPresent. Defaults to Always if :latest tag is specified, or IfNotPresent otherwise. More info: https://kubernetes.io/docs/concepts/containers/images#updating-images
     pullPolicy: IfNotPresent
 
+  # hook.labels -- Add Kubernetes Labels to the hook definition
+  labels: {}
+
 defectdojo:
   # -- Syncs back (two way sync) all imported findings from DefectDojo to SCB Findings Store. When set to false the hook will only import the findings to DefectDojo (one way sync).
   syncFindingsBack: true

--- a/hooks/persistence-elastic/templates/persistence-provider.yaml
+++ b/hooks/persistence-elastic/templates/persistence-provider.yaml
@@ -9,6 +9,9 @@ metadata:
   labels:
     {{- include "persistence-elastic.labels" . | nindent 4 }}
     type: Structured
+    {{- with .Values.hook.labels }}
+    {{ toYaml . }}
+    {{- end }}
 spec:
   type: ReadOnly
   image: "{{ .Values.hook.image.repository }}:{{ .Values.hook.image.tag | default .Chart.Version }}"

--- a/hooks/persistence-elastic/values.yaml
+++ b/hooks/persistence-elastic/values.yaml
@@ -86,5 +86,8 @@ hook:
     # @default -- defaults to the charts version
     tag: null
 
+  # hook.labels -- Add Kubernetes Labels to the hook definition
+  labels: {}
+
   # hook.ttlSecondsAfterFinished -- Seconds after which the kubernetes job for the hook will be deleted. Requires the Kubernetes TTLAfterFinished controller: https://kubernetes.io/docs/concepts/workloads/controllers/ttlafterfinished/
   ttlSecondsAfterFinished: null

--- a/hooks/update-field/templates/update-field-hook.yaml
+++ b/hooks/update-field/templates/update-field-hook.yaml
@@ -8,6 +8,9 @@ metadata:
   name: {{ include "update-field.fullname" . }}
   labels:
     {{- include "update-field.labels" . | nindent 4 }}
+    {{- with .Values.hook.labels }}
+    {{ toYaml . }}
+    {{- end }}
 spec:
   type: ReadAndWrite
   image: "{{ .Values.hook.image.repository }}:{{ .Values.hook.image.tag | default .Chart.Version }}"

--- a/hooks/update-field/values.yaml
+++ b/hooks/update-field/values.yaml
@@ -20,5 +20,8 @@ hook:
     # @default -- defaults to the charts version
     tag: null
 
+  # hook.labels -- Add Kubernetes Labels to the hook definition
+  labels: {}
+
   # hook.ttlSecondsAfterFinished -- Seconds after which the kubernetes job for the hook will be deleted. Requires the Kubernetes TTLAfterFinished controller: https://kubernetes.io/docs/concepts/workloads/controllers/ttlafterfinished/
   ttlSecondsAfterFinished: null

--- a/operator/apis/execution/v1/scan_types.go
+++ b/operator/apis/execution/v1/scan_types.go
@@ -62,6 +62,9 @@ type ScanSpec struct {
 	// +kubebuilder:validation:Required
 	Parameters []string `json:"parameters,omitempty"`
 
+	// HookSelector allows to specify a LabelSelector with which the hooks are selected.
+	HookSelector *metav1.LabelSelector `json:"hookSelector,omitempty"`
+
 	// Env allows to specify environment vars for the scanner container. These will be merged will the env vars specified for the first container of the pod defined in the ScanType
 	Env []corev1.EnvVar `json:"env,omitempty"`
 	// Volumes allows to specify volumes for the scan container.

--- a/operator/apis/execution/v1/scan_types.go
+++ b/operator/apis/execution/v1/scan_types.go
@@ -41,7 +41,7 @@ type CascadeSpec struct {
 
 	// InheritHookSelector defines whether cascading scans should inherit hookSelector from the parent scan.
 	// +optional
-	// +kubebuilder:default=true
+	// +kubebuilder:default=false
 	InheritHookSelector bool `json:"inheritHookSelector"`
 
 	// matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels

--- a/operator/apis/execution/v1/scan_types.go
+++ b/operator/apis/execution/v1/scan_types.go
@@ -39,6 +39,11 @@ type CascadeSpec struct {
 	// +kubebuilder:default=false
 	InheritInitContainers bool `json:"inheritInitContainers"`
 
+	// InheritHookSelector defines whether cascading scans should inherit hookSelector from the parent scan.
+	// +optional
+	// +kubebuilder:default=true
+	InheritHookSelector bool `json:"inheritHookSelector"`
+
 	// matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
 	// map is equivalent to an element of matchExpressions, whose key field is "key", the
 	// operator is "In", and the values array contains only "value". The requirements are ANDed.

--- a/operator/apis/execution/v1/zz_generated.deepcopy.go
+++ b/operator/apis/execution/v1/zz_generated.deepcopy.go
@@ -424,6 +424,11 @@ func (in *ScanSpec) DeepCopyInto(out *ScanSpec) {
 		*out = make([]string, len(*in))
 		copy(*out, *in)
 	}
+	if in.HookSelector != nil {
+		in, out := &in.HookSelector, &out.HookSelector
+		*out = new(metav1.LabelSelector)
+		(*in).DeepCopyInto(*out)
+	}
 	if in.Env != nil {
 		in, out := &in.Env, &out.Env
 		*out = make([]corev1.EnvVar, len(*in))

--- a/operator/config/crd/bases/cascading.securecodebox.io_cascadingrules.yaml
+++ b/operator/config/crd/bases/cascading.securecodebox.io_cascadingrules.yaml
@@ -283,6 +283,51 @@ spec:
                       - name
                       type: object
                     type: array
+                  hookSelector:
+                    description: HookSelector allows to specify a LabelSelector with
+                      which the hooks are selected.
+                    properties:
+                      matchExpressions:
+                        description: matchExpressions is a list of label selector
+                          requirements. The requirements are ANDed.
+                        items:
+                          description: A label selector requirement is a selector
+                            that contains values, a key, and an operator that relates
+                            the key and values.
+                          properties:
+                            key:
+                              description: key is the label key that the selector
+                                applies to.
+                              type: string
+                            operator:
+                              description: operator represents a key's relationship
+                                to a set of values. Valid operators are In, NotIn,
+                                Exists and DoesNotExist.
+                              type: string
+                            values:
+                              description: values is an array of string values. If
+                                the operator is In or NotIn, the values array must
+                                be non-empty. If the operator is Exists or DoesNotExist,
+                                the values array must be empty. This array is replaced
+                                during a strategic merge patch.
+                              items:
+                                type: string
+                              type: array
+                          required:
+                          - key
+                          - operator
+                          type: object
+                        type: array
+                      matchLabels:
+                        additionalProperties:
+                          type: string
+                        description: matchLabels is a map of {key,value} pairs. A
+                          single {key,value} in the matchLabels map is equivalent
+                          to an element of matchExpressions, whose key field is "key",
+                          the operator is "In", and the values array contains only
+                          "value". The requirements are ANDed.
+                        type: object
+                    type: object
                   initContainers:
                     description: InitContainers allows to specify init containers
                       for the scan container, to pre-load data into them.

--- a/operator/config/crd/bases/cascading.securecodebox.io_cascadingrules.yaml
+++ b/operator/config/crd/bases/cascading.securecodebox.io_cascadingrules.yaml
@@ -115,7 +115,7 @@ spec:
                           inherit environment variables from the parent scan
                         type: boolean
                       inheritHookSelector:
-                        default: true
+                        default: false
                         description: InheritHookSelector defines whether cascading
                           scans should inherit hookSelector from the parent scan.
                         type: boolean

--- a/operator/config/crd/bases/cascading.securecodebox.io_cascadingrules.yaml
+++ b/operator/config/crd/bases/cascading.securecodebox.io_cascadingrules.yaml
@@ -114,6 +114,11 @@ spec:
                         description: InheritEnv defines whether cascading scans should
                           inherit environment variables from the parent scan
                         type: boolean
+                      inheritHookSelector:
+                        default: true
+                        description: InheritHookSelector defines whether cascading
+                          scans should inherit hookSelector from the parent scan.
+                        type: boolean
                       inheritInitContainers:
                         default: false
                         description: InheritInitContainers defines whether cascading

--- a/operator/config/crd/bases/execution.securecodebox.io_scans.yaml
+++ b/operator/config/crd/bases/execution.securecodebox.io_scans.yaml
@@ -77,7 +77,7 @@ spec:
                       inherit environment variables from the parent scan
                     type: boolean
                   inheritHookSelector:
-                    default: true
+                    default: false
                     description: InheritHookSelector defines whether cascading scans
                       should inherit hookSelector from the parent scan.
                     type: boolean

--- a/operator/config/crd/bases/execution.securecodebox.io_scans.yaml
+++ b/operator/config/crd/bases/execution.securecodebox.io_scans.yaml
@@ -238,6 +238,51 @@ spec:
                   - name
                   type: object
                 type: array
+              hookSelector:
+                description: HookSelector allows to specify a LabelSelector with which
+                  the hooks are selected.
+                properties:
+                  matchExpressions:
+                    description: matchExpressions is a list of label selector requirements.
+                      The requirements are ANDed.
+                    items:
+                      description: A label selector requirement is a selector that
+                        contains values, a key, and an operator that relates the key
+                        and values.
+                      properties:
+                        key:
+                          description: key is the label key that the selector applies
+                            to.
+                          type: string
+                        operator:
+                          description: operator represents a key's relationship to
+                            a set of values. Valid operators are In, NotIn, Exists
+                            and DoesNotExist.
+                          type: string
+                        values:
+                          description: values is an array of string values. If the
+                            operator is In or NotIn, the values array must be non-empty.
+                            If the operator is Exists or DoesNotExist, the values
+                            array must be empty. This array is replaced during a strategic
+                            merge patch.
+                          items:
+                            type: string
+                          type: array
+                      required:
+                      - key
+                      - operator
+                      type: object
+                    type: array
+                  matchLabels:
+                    additionalProperties:
+                      type: string
+                    description: matchLabels is a map of {key,value} pairs. A single
+                      {key,value} in the matchLabels map is equivalent to an element
+                      of matchExpressions, whose key field is "key", the operator
+                      is "In", and the values array contains only "value". The requirements
+                      are ANDed.
+                    type: object
+                type: object
               initContainers:
                 description: InitContainers allows to specify init containers for
                   the scan container, to pre-load data into them.

--- a/operator/config/crd/bases/execution.securecodebox.io_scans.yaml
+++ b/operator/config/crd/bases/execution.securecodebox.io_scans.yaml
@@ -76,6 +76,11 @@ spec:
                     description: InheritEnv defines whether cascading scans should
                       inherit environment variables from the parent scan
                     type: boolean
+                  inheritHookSelector:
+                    default: true
+                    description: InheritHookSelector defines whether cascading scans
+                      should inherit hookSelector from the parent scan.
+                    type: boolean
                   inheritInitContainers:
                     default: false
                     description: InheritInitContainers defines whether cascading scans

--- a/operator/config/crd/bases/execution.securecodebox.io_scheduledscans.yaml
+++ b/operator/config/crd/bases/execution.securecodebox.io_scheduledscans.yaml
@@ -96,6 +96,11 @@ spec:
                         description: InheritEnv defines whether cascading scans should
                           inherit environment variables from the parent scan
                         type: boolean
+                      inheritHookSelector:
+                        default: true
+                        description: InheritHookSelector defines whether cascading
+                          scans should inherit hookSelector from the parent scan.
+                        type: boolean
                       inheritInitContainers:
                         default: false
                         description: InheritInitContainers defines whether cascading

--- a/operator/config/crd/bases/execution.securecodebox.io_scheduledscans.yaml
+++ b/operator/config/crd/bases/execution.securecodebox.io_scheduledscans.yaml
@@ -97,7 +97,7 @@ spec:
                           inherit environment variables from the parent scan
                         type: boolean
                       inheritHookSelector:
-                        default: true
+                        default: false
                         description: InheritHookSelector defines whether cascading
                           scans should inherit hookSelector from the parent scan.
                         type: boolean

--- a/operator/config/crd/bases/execution.securecodebox.io_scheduledscans.yaml
+++ b/operator/config/crd/bases/execution.securecodebox.io_scheduledscans.yaml
@@ -265,6 +265,51 @@ spec:
                       - name
                       type: object
                     type: array
+                  hookSelector:
+                    description: HookSelector allows to specify a LabelSelector with
+                      which the hooks are selected.
+                    properties:
+                      matchExpressions:
+                        description: matchExpressions is a list of label selector
+                          requirements. The requirements are ANDed.
+                        items:
+                          description: A label selector requirement is a selector
+                            that contains values, a key, and an operator that relates
+                            the key and values.
+                          properties:
+                            key:
+                              description: key is the label key that the selector
+                                applies to.
+                              type: string
+                            operator:
+                              description: operator represents a key's relationship
+                                to a set of values. Valid operators are In, NotIn,
+                                Exists and DoesNotExist.
+                              type: string
+                            values:
+                              description: values is an array of string values. If
+                                the operator is In or NotIn, the values array must
+                                be non-empty. If the operator is Exists or DoesNotExist,
+                                the values array must be empty. This array is replaced
+                                during a strategic merge patch.
+                              items:
+                                type: string
+                              type: array
+                          required:
+                          - key
+                          - operator
+                          type: object
+                        type: array
+                      matchLabels:
+                        additionalProperties:
+                          type: string
+                        description: matchLabels is a map of {key,value} pairs. A
+                          single {key,value} in the matchLabels map is equivalent
+                          to an element of matchExpressions, whose key field is "key",
+                          the operator is "In", and the values array contains only
+                          "value". The requirements are ANDed.
+                        type: object
+                    type: object
                   initContainers:
                     description: InitContainers allows to specify init containers
                       for the scan container, to pre-load data into them.

--- a/operator/controllers/execution/scans/hook_reconciler.go
+++ b/operator/controllers/execution/scans/hook_reconciler.go
@@ -23,9 +23,17 @@ import (
 func (r *ScanReconciler) setHookStatus(scan *executionv1.Scan) error {
 	// Set (pending) Hook status on the scan
 	ctx := context.Background()
+	labelSelector, err := metav1.LabelSelectorAsSelector(scan.Spec.HookSelector)
+	if err != nil {
+		return err
+	}
+
 	var scanCompletionHooks executionv1.ScanCompletionHookList
 
-	if err := r.List(ctx, &scanCompletionHooks, client.InNamespace(scan.Namespace)); err != nil {
+	if err := r.List(ctx, &scanCompletionHooks,
+		client.InNamespace(scan.Namespace),
+		client.MatchingLabelsSelector{Selector: labelSelector},
+	); err != nil {
 		r.Log.V(7).Info("Unable to fetch ScanCompletionHooks")
 		return err
 	}
@@ -198,9 +206,17 @@ func containsJobForHook(jobs *batch.JobList, hook executionv1.ScanCompletionHook
 func (r *ScanReconciler) startReadOnlyHooks(scan *executionv1.Scan) error {
 	ctx := context.Background()
 
+	labelSelector, err := metav1.LabelSelectorAsSelector(scan.Spec.HookSelector)
+	if err != nil {
+		return err
+	}
+
 	var scanCompletionHooks executionv1.ScanCompletionHookList
 
-	if err := r.List(ctx, &scanCompletionHooks, client.InNamespace(scan.Namespace)); err != nil {
+	if err := r.List(ctx, &scanCompletionHooks,
+		client.InNamespace(scan.Namespace),
+		client.MatchingLabelsSelector{Selector: labelSelector},
+	); err != nil {
 		r.Log.V(7).Info("Unable to fetch ScanCompletionHooks")
 		return err
 	}

--- a/operator/controllers/execution/scans/hook_reconciler.go
+++ b/operator/controllers/execution/scans/hook_reconciler.go
@@ -7,6 +7,7 @@ package scancontrollers
 import (
 	"context"
 	"fmt"
+	"k8s.io/apimachinery/pkg/labels"
 
 	executionv1 "github.com/secureCodeBox/secureCodeBox/operator/apis/execution/v1"
 	util "github.com/secureCodeBox/secureCodeBox/operator/utils"
@@ -23,7 +24,7 @@ import (
 func (r *ScanReconciler) setHookStatus(scan *executionv1.Scan) error {
 	// Set (pending) Hook status on the scan
 	ctx := context.Background()
-	labelSelector, err := metav1.LabelSelectorAsSelector(scan.Spec.HookSelector)
+	labelSelector, err := r.getLabelSelector(scan)
 	if err != nil {
 		return err
 	}
@@ -206,7 +207,7 @@ func containsJobForHook(jobs *batch.JobList, hook executionv1.ScanCompletionHook
 func (r *ScanReconciler) startReadOnlyHooks(scan *executionv1.Scan) error {
 	ctx := context.Background()
 
-	labelSelector, err := metav1.LabelSelectorAsSelector(scan.Spec.HookSelector)
+	labelSelector, err := r.getLabelSelector(scan)
 	if err != nil {
 		return err
 	}
@@ -481,4 +482,12 @@ func (r *ScanReconciler) updateHookStatus(scan *executionv1.Scan, hookStatus exe
 		return err
 	}
 	return nil
+}
+
+func (r *ScanReconciler) getLabelSelector(scan *executionv1.Scan) (labels.Selector, error) {
+	hookSelector := scan.Spec.HookSelector
+	if hookSelector == nil {
+		hookSelector = &metav1.LabelSelector{}
+	}
+	return metav1.LabelSelectorAsSelector(hookSelector)
 }

--- a/operator/crds/cascading.securecodebox.io_cascadingrules.yaml
+++ b/operator/crds/cascading.securecodebox.io_cascadingrules.yaml
@@ -283,6 +283,51 @@ spec:
                       - name
                       type: object
                     type: array
+                  hookSelector:
+                    description: HookSelector allows to specify a LabelSelector with
+                      which the hooks are selected.
+                    properties:
+                      matchExpressions:
+                        description: matchExpressions is a list of label selector
+                          requirements. The requirements are ANDed.
+                        items:
+                          description: A label selector requirement is a selector
+                            that contains values, a key, and an operator that relates
+                            the key and values.
+                          properties:
+                            key:
+                              description: key is the label key that the selector
+                                applies to.
+                              type: string
+                            operator:
+                              description: operator represents a key's relationship
+                                to a set of values. Valid operators are In, NotIn,
+                                Exists and DoesNotExist.
+                              type: string
+                            values:
+                              description: values is an array of string values. If
+                                the operator is In or NotIn, the values array must
+                                be non-empty. If the operator is Exists or DoesNotExist,
+                                the values array must be empty. This array is replaced
+                                during a strategic merge patch.
+                              items:
+                                type: string
+                              type: array
+                          required:
+                          - key
+                          - operator
+                          type: object
+                        type: array
+                      matchLabels:
+                        additionalProperties:
+                          type: string
+                        description: matchLabels is a map of {key,value} pairs. A
+                          single {key,value} in the matchLabels map is equivalent
+                          to an element of matchExpressions, whose key field is "key",
+                          the operator is "In", and the values array contains only
+                          "value". The requirements are ANDed.
+                        type: object
+                    type: object
                   initContainers:
                     description: InitContainers allows to specify init containers
                       for the scan container, to pre-load data into them.

--- a/operator/crds/cascading.securecodebox.io_cascadingrules.yaml
+++ b/operator/crds/cascading.securecodebox.io_cascadingrules.yaml
@@ -115,7 +115,7 @@ spec:
                           inherit environment variables from the parent scan
                         type: boolean
                       inheritHookSelector:
-                        default: true
+                        default: false
                         description: InheritHookSelector defines whether cascading
                           scans should inherit hookSelector from the parent scan.
                         type: boolean

--- a/operator/crds/cascading.securecodebox.io_cascadingrules.yaml
+++ b/operator/crds/cascading.securecodebox.io_cascadingrules.yaml
@@ -114,6 +114,11 @@ spec:
                         description: InheritEnv defines whether cascading scans should
                           inherit environment variables from the parent scan
                         type: boolean
+                      inheritHookSelector:
+                        default: true
+                        description: InheritHookSelector defines whether cascading
+                          scans should inherit hookSelector from the parent scan.
+                        type: boolean
                       inheritInitContainers:
                         default: false
                         description: InheritInitContainers defines whether cascading

--- a/operator/crds/execution.securecodebox.io_scans.yaml
+++ b/operator/crds/execution.securecodebox.io_scans.yaml
@@ -77,7 +77,7 @@ spec:
                       inherit environment variables from the parent scan
                     type: boolean
                   inheritHookSelector:
-                    default: true
+                    default: false
                     description: InheritHookSelector defines whether cascading scans
                       should inherit hookSelector from the parent scan.
                     type: boolean

--- a/operator/crds/execution.securecodebox.io_scans.yaml
+++ b/operator/crds/execution.securecodebox.io_scans.yaml
@@ -238,6 +238,51 @@ spec:
                   - name
                   type: object
                 type: array
+              hookSelector:
+                description: HookSelector allows to specify a LabelSelector with which
+                  the hooks are selected.
+                properties:
+                  matchExpressions:
+                    description: matchExpressions is a list of label selector requirements.
+                      The requirements are ANDed.
+                    items:
+                      description: A label selector requirement is a selector that
+                        contains values, a key, and an operator that relates the key
+                        and values.
+                      properties:
+                        key:
+                          description: key is the label key that the selector applies
+                            to.
+                          type: string
+                        operator:
+                          description: operator represents a key's relationship to
+                            a set of values. Valid operators are In, NotIn, Exists
+                            and DoesNotExist.
+                          type: string
+                        values:
+                          description: values is an array of string values. If the
+                            operator is In or NotIn, the values array must be non-empty.
+                            If the operator is Exists or DoesNotExist, the values
+                            array must be empty. This array is replaced during a strategic
+                            merge patch.
+                          items:
+                            type: string
+                          type: array
+                      required:
+                      - key
+                      - operator
+                      type: object
+                    type: array
+                  matchLabels:
+                    additionalProperties:
+                      type: string
+                    description: matchLabels is a map of {key,value} pairs. A single
+                      {key,value} in the matchLabels map is equivalent to an element
+                      of matchExpressions, whose key field is "key", the operator
+                      is "In", and the values array contains only "value". The requirements
+                      are ANDed.
+                    type: object
+                type: object
               initContainers:
                 description: InitContainers allows to specify init containers for
                   the scan container, to pre-load data into them.

--- a/operator/crds/execution.securecodebox.io_scans.yaml
+++ b/operator/crds/execution.securecodebox.io_scans.yaml
@@ -76,6 +76,11 @@ spec:
                     description: InheritEnv defines whether cascading scans should
                       inherit environment variables from the parent scan
                     type: boolean
+                  inheritHookSelector:
+                    default: true
+                    description: InheritHookSelector defines whether cascading scans
+                      should inherit hookSelector from the parent scan.
+                    type: boolean
                   inheritInitContainers:
                     default: false
                     description: InheritInitContainers defines whether cascading scans

--- a/operator/crds/execution.securecodebox.io_scheduledscans.yaml
+++ b/operator/crds/execution.securecodebox.io_scheduledscans.yaml
@@ -96,6 +96,11 @@ spec:
                         description: InheritEnv defines whether cascading scans should
                           inherit environment variables from the parent scan
                         type: boolean
+                      inheritHookSelector:
+                        default: true
+                        description: InheritHookSelector defines whether cascading
+                          scans should inherit hookSelector from the parent scan.
+                        type: boolean
                       inheritInitContainers:
                         default: false
                         description: InheritInitContainers defines whether cascading

--- a/operator/crds/execution.securecodebox.io_scheduledscans.yaml
+++ b/operator/crds/execution.securecodebox.io_scheduledscans.yaml
@@ -97,7 +97,7 @@ spec:
                           inherit environment variables from the parent scan
                         type: boolean
                       inheritHookSelector:
-                        default: true
+                        default: false
                         description: InheritHookSelector defines whether cascading
                           scans should inherit hookSelector from the parent scan.
                         type: boolean

--- a/operator/crds/execution.securecodebox.io_scheduledscans.yaml
+++ b/operator/crds/execution.securecodebox.io_scheduledscans.yaml
@@ -265,6 +265,51 @@ spec:
                       - name
                       type: object
                     type: array
+                  hookSelector:
+                    description: HookSelector allows to specify a LabelSelector with
+                      which the hooks are selected.
+                    properties:
+                      matchExpressions:
+                        description: matchExpressions is a list of label selector
+                          requirements. The requirements are ANDed.
+                        items:
+                          description: A label selector requirement is a selector
+                            that contains values, a key, and an operator that relates
+                            the key and values.
+                          properties:
+                            key:
+                              description: key is the label key that the selector
+                                applies to.
+                              type: string
+                            operator:
+                              description: operator represents a key's relationship
+                                to a set of values. Valid operators are In, NotIn,
+                                Exists and DoesNotExist.
+                              type: string
+                            values:
+                              description: values is an array of string values. If
+                                the operator is In or NotIn, the values array must
+                                be non-empty. If the operator is Exists or DoesNotExist,
+                                the values array must be empty. This array is replaced
+                                during a strategic merge patch.
+                              items:
+                                type: string
+                              type: array
+                          required:
+                          - key
+                          - operator
+                          type: object
+                        type: array
+                      matchLabels:
+                        additionalProperties:
+                          type: string
+                        description: matchLabels is a map of {key,value} pairs. A
+                          single {key,value} in the matchLabels map is equivalent
+                          to an element of matchExpressions, whose key field is "key",
+                          the operator is "In", and the values array contains only
+                          "value". The requirements are ANDed.
+                        type: object
+                    type: object
                   initContainers:
                     description: InitContainers allows to specify init containers
                       for the scan container, to pre-load data into them.


### PR DESCRIPTION
## Description
This PR, if applied, closes #728, mainly by adding the field `hookSelector` in the scan spec. Besides, this PR adds the cascading scans field `inheritHookSelector` (default `false`) for more control over the `hookSelector` field in cascading scans.

Related documentation PR secureCodeBox/documentation#152

### Example usage

To select all hooks, leave the `hookSelector` field undefined or specify:
```yaml
hookSelector: {}
```

To select specific hooks:

```yaml
hookSelector:
  matchExpressions:
   - key: app.kubernetes.io/instance
     operator: In
     values: [ "defectdojo", "update-field" ]
```

To ignore certain hooks:
```yaml
hookSelector:
  matchExpressions:
  -  key: app.kubernetes.io/instance
     operator: NotIn
     values: [ "defectdojo" ]
```

Available operators are:
`In`, `NotIn`, `Exists`, `DoesNotExist`

You may also use `matchLabels` for exact matches on labels:
```yaml
hookSelector:
  matchLabels:
    app.kubernetes.io/instance: "defectdojo"
```

`matchLabels` and `matchExpressions` may be used simultaneously.

### Default Hook labels
To select a certain hook deployment, use the label `app.kubernetes.io/instance` (e.g. `update-severity` for the `update-field` hook). To select a certain hook type, use the label `app.kubernetes.io/name` (e.g. `update-field`).

Extra hook labels may be added by deploying the hook with the `hook.labels` field set in `values.yaml`.

### Usage in combination with Cascading Scans

Besides existing fields (e.g. `inheritVolumes`, `inheritLabels`, etc.), the field `inheritHookSelector` is now available with the same behavior as the other existing fields.

**Note:** to use cascading scans in combination with `hookSelector`, ensure that you also select the cascading scans hook. You can use the existing label `securecodebox.io/internal` to select core features like cascading scans. You should manually ensure that your other selectors override this selector in behavior.

```yaml
hookSelector:
  matchLabels:
    securecodebox.io/internal: "true"
```

### Checklist

* [x] Test your changes as thoroughly as possible before you commit them. Preferably, automate your test by unit/integration tests.
* [ ] Make sure `npm test` runs for the whole project.
* [x] Make codeclimate checks happy
