### PR TITLE
Align common targets for SDK makefile

### DIFF
--- a/sdk.mk
+++ b/sdk.mk
@@ -23,6 +23,10 @@ name = ${sdk}
 module = ${sdk}
 include ../../common.mk
 
+docker-build: | docker-build-sdk
+docker-export: | docker-export-sdk
+kind-import: | kind-import-sdk
+
 docker-build-sdk:
 	@echo ".: ⚙️ Build '$(name)'."
 	docker build -t $(IMG_NS)/$(name)-nodejs:$(IMG_TAG) .
@@ -31,6 +35,6 @@ docker-export-sdk:
 	@echo ".: ⚙️ Build '$(name)'."
 	docker save $(IMG_NS)/$(name)-nodejs:$(IMG_TAG) -o $(name).tar
 
-kind-import:
+kind-import-sdk:
 	@echo ".: 💾 Importing the image archive '$(name).tar' to local kind cluster."
 	kind load image-archive ./$(name).tar


### PR DESCRIPTION
## Description
This PR, if applied, ensures that the targets for building SDK, Scanners, and Hooks are identical. E.g. so that each component can be built with `docker-build` instead of sdk's specific `docker-build-sdk` as spotted in #756.

No breaking changes here (only adds targets to sdk makefile).

I.e.:

sdk.mk
```Makefile
docker-build: | docker-build-sdk
docker-export: | docker-export-sdk
kind-import: | kind-import-sdk
```
hooks.mk:
```Makefile
docker-build: | common-docker-build
docker-export: | common-docker-export
kind-import: | common-kind-import
```

scanners.mk:
```Makefile
ifeq ($(custom_scanner),)
  docker-build: | docker-build-parser
  docker-export: | docker-export-parser
  kind-import: | kind-import-parser
  deploy: deploy-without-scanner
else
  docker-build: | docker-build-parser docker-build-scanner
  docker-export: | docker-export-parser docker-export-scanner
  kind-import: | kind-import-parser kind-import-scanner
  deploy: deploy-with-scanner
endif
```

### Checklist

* [x] Test your changes as thoroughly as possible before you commit them. Preferably, automate your test by unit/integration tests.
* [x] Make sure `npm test` runs for the whole project.
* [x] Make codeclimate checks happy
