### PR TITLE
Add Cronjob Configuration Options and Fix Security Context for Nuclei Chart 

### DIFF
--- a/scanners/nuclei/README.md
+++ b/scanners/nuclei/README.md
@@ -161,8 +161,11 @@ Kubernetes: `>=v1.11.0-0`
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
 | cascadingRules.enabled | bool | `true` | Enables or disables the installation of the default cascading rules for this scanner |
+| nucleiTemplateCache.concurrencyPolicy | string | `"Replace"` | Determines how kubernetes handles cases where multiple instances of the cronjob would work if they are running at the same time. See: https://kubernetes.io/docs/tasks/job/automated-tasks-with-cron-jobs/#concurrency-policy |
 | nucleiTemplateCache.enabled | bool | `true` | Enables or disables the use of an persistent volume to cache the always downloaded nuclei-templates for all scans. |
+| nucleiTemplateCache.failedJobsHistoryLimit | int | `10` | Determines how many failed jobs are kept until kubernetes cleans them up. See: https://kubernetes.io/docs/tasks/job/automated-tasks-with-cron-jobs/#jobs-history-limits |
 | nucleiTemplateCache.schedule | string | `"0 */1 * * *"` |  |
+| nucleiTemplateCache.successfulJobsHistoryLimit | int | `3` | Determines how many successful jobs are kept until kubernetes cleans them up. See: https://kubernetes.io/docs/tasks/job/automated-tasks-with-cron-jobs/#jobs-history-limits |
 | parser.env | list | `[]` | Optional environment variables mapped into each parseJob (see: https://kubernetes.io/docs/tasks/inject-data-application/define-environment-variable-container/) |
 | parser.image.pullPolicy | string | `"IfNotPresent"` | Image pull policy. One of Always, Never, IfNotPresent. Defaults to Always if :latest tag is specified, or IfNotPresent otherwise. More info: https://kubernetes.io/docs/concepts/containers/images#updating-images |
 | parser.image.repository | string | `"docker.io/securecodebox/parser-nuclei"` | Parser image repository |

--- a/scanners/nuclei/README.md
+++ b/scanners/nuclei/README.md
@@ -182,12 +182,12 @@ Kubernetes: `>=v1.11.0-0`
 | scanner.image.tag | string | `nil` | defaults to the charts appVersion |
 | scanner.nameAppend | string | `nil` | append a string to the default scantype name. |
 | scanner.resources | object | `{}` | CPU/memory resource requests/limits (see: https://kubernetes.io/docs/tasks/configure-pod-container/assign-memory-resource/, https://kubernetes.io/docs/tasks/configure-pod-container/assign-cpu-resource/) |
-| scanner.securityContext | object | `{"allowPrivilegeEscalation":false,"capabilities":{"drop":["all"]},"privileged":false,"readOnlyRootFilesystem":true,"runAsNonRoot":true}` | Optional securityContext set on scanner container (see: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/) |
+| scanner.securityContext | object | `{"allowPrivilegeEscalation":false,"capabilities":{"drop":["all"]},"privileged":false,"readOnlyRootFilesystem":false,"runAsNonRoot":false}` | Optional securityContext set on scanner container (see: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/) |
 | scanner.securityContext.allowPrivilegeEscalation | bool | `false` | Ensure that users privileges cannot be escalated |
 | scanner.securityContext.capabilities.drop[0] | string | `"all"` | This drops all linux privileges from the container. |
 | scanner.securityContext.privileged | bool | `false` | Ensures that the scanner container is not run in privileged mode |
-| scanner.securityContext.readOnlyRootFilesystem | bool | `true` | Prevents write access to the containers file system |
-| scanner.securityContext.runAsNonRoot | bool | `true` | Enforces that the scanner image is run as a non root user |
+| scanner.securityContext.readOnlyRootFilesystem | bool | `false` | Prevents write access to the containers file system |
+| scanner.securityContext.runAsNonRoot | bool | `false` | Enforces that the scanner image is run as a non root user |
 | scanner.ttlSecondsAfterFinished | string | `nil` | seconds after which the kubernetes job for the scanner will be deleted. Requires the Kubernetes TTLAfterFinished controller: https://kubernetes.io/docs/concepts/workloads/controllers/ttlafterfinished/ |
 
 ## License

--- a/scanners/nuclei/templates/nuclei-update-cache-job.yaml
+++ b/scanners/nuclei/templates/nuclei-update-cache-job.yaml
@@ -14,6 +14,8 @@ metadata:
   name: nuclei-update-template-cache
 spec:
   schedule: {{ .Values.nucleiTemplateCache.schedule | default "0 8 * * *" }}
+  failedJobsHistoryLimit: {{ .Values.nucleiTemplateCache.failedJobsHistoryLimit }}
+  successfulJobsHistoryLimit: {{ .Values.nucleiTemplateCache.successfulJobsHistoryLimit }}
   jobTemplate:
     spec:
       template:

--- a/scanners/nuclei/templates/nuclei-update-cache-job.yaml
+++ b/scanners/nuclei/templates/nuclei-update-cache-job.yaml
@@ -16,6 +16,7 @@ spec:
   schedule: {{ .Values.nucleiTemplateCache.schedule | default "0 8 * * *" }}
   failedJobsHistoryLimit: {{ .Values.nucleiTemplateCache.failedJobsHistoryLimit }}
   successfulJobsHistoryLimit: {{ .Values.nucleiTemplateCache.successfulJobsHistoryLimit }}
+  concurrencyPolicy: {{ .Values.nucleiTemplateCache.concurrencyPolicy }}
   jobTemplate:
     spec:
       template:

--- a/scanners/nuclei/values.yaml
+++ b/scanners/nuclei/values.yaml
@@ -62,9 +62,9 @@ scanner:
   # scanner.securityContext -- Optional securityContext set on scanner container (see: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/)
   securityContext:
     # scanner.securityContext.runAsNonRoot -- Enforces that the scanner image is run as a non root user
-    runAsNonRoot: true
+    runAsNonRoot: false
     # scanner.securityContext.readOnlyRootFilesystem -- Prevents write access to the containers file system
-    readOnlyRootFilesystem: true
+    readOnlyRootFilesystem: false
     # scanner.securityContext.allowPrivilegeEscalation -- Ensure that users privileges cannot be escalated
     allowPrivilegeEscalation: false
     # scanner.securityContext.privileged -- Ensures that the scanner container is not run in privileged mode

--- a/scanners/nuclei/values.yaml
+++ b/scanners/nuclei/values.yaml
@@ -81,8 +81,11 @@ nucleiTemplateCache:
   # every full hour: "0 */1 * * *""
   # -- The schedule indicates when and how often the nuclei template cache should be updated 
   schedule: "0 */1 * * *"
-  failedJobsHistoryLimit: 10
+  # -- Determines how many successful jobs are kept until kubernetes cleans them up. See: https://kubernetes.io/docs/tasks/job/automated-tasks-with-cron-jobs/#jobs-history-limits
   successfulJobsHistoryLimit: 3
+  # -- Determines how many failed jobs are kept until kubernetes cleans them up. See: https://kubernetes.io/docs/tasks/job/automated-tasks-with-cron-jobs/#jobs-history-limits
+  failedJobsHistoryLimit: 10
+  # -- Determines how kubernetes handles cases where multiple instances of the cronjob would work if they are running at the same time. See: https://kubernetes.io/docs/tasks/job/automated-tasks-with-cron-jobs/#concurrency-policy
   concurrencyPolicy: "Replace"
 
 cascadingRules:

--- a/scanners/nuclei/values.yaml
+++ b/scanners/nuclei/values.yaml
@@ -81,6 +81,8 @@ nucleiTemplateCache:
   # every full hour: "0 */1 * * *""
   # -- The schedule indicates when and how often the nuclei template cache should be updated 
   schedule: "0 */1 * * *"
+  failedJobsHistoryLimit: 10
+  successfulJobsHistoryLimit: 3
 
 cascadingRules:
   # cascadingRules.enabled -- Enables or disables the installation of the default cascading rules for this scanner

--- a/scanners/nuclei/values.yaml
+++ b/scanners/nuclei/values.yaml
@@ -83,6 +83,7 @@ nucleiTemplateCache:
   schedule: "0 */1 * * *"
   failedJobsHistoryLimit: 10
   successfulJobsHistoryLimit: 3
+  concurrencyPolicy: "Replace"
 
 cascadingRules:
   # cascadingRules.enabled -- Enables or disables the installation of the default cascading rules for this scanner


### PR DESCRIPTION
## Description

Was having some problems with the nuclei CronJobs on a "not so healthy" kubernetes cluster.
Would have liked to have access to these added options to tweak the behavior of this CronJob.

### Checklist

* [x] Test your changes as thoroughly as possible before you commit them. Preferably, automate your test by unit/integration tests.
* [x] Make sure `npm test` runs for the whole project.
* [x] Make codeclimate checks happy
