### PR TITLE
Docs: Small fixes for the trivy documentation

### DIFF
--- a/scanners/trivy/.helm-docs.gotmpl
+++ b/scanners/trivy/.helm-docs.gotmpl
@@ -29,20 +29,20 @@ A software vulnerability is a glitch, flaw, or weakness present in the software 
 `Trivy` detects vulnerabilities of OS packages (Alpine, RHEL, CentOS, etc.) and application dependencies (Bundler, Composer, npm, yarn, etc.).
 `Trivy` is easy to use. Just install the binary, and you're ready to scan. All you need to do for scanning is to specify a target such as an image name of the container.
 
-To learn more about the Trivy scanner itself visit on [Trivy's GitHub Repository](https://github.com/aquasecurity/trivy).
+To learn more about the Trivy scanner itself visit [Trivy's GitHub Repository](https://github.com/aquasecurity/trivy).
 {{- end }}
 
 {{- define "extra.scannerConfigurationSection" -}}
 ## Scanner Configuration
 
-The following security scan configuration example are based on the [Trivy Documentation], please take a look at the original documentation for more configuration examples.
+The following security scan configuration example are based on the [Trivy Documentation](https://aquasecurity.github.io/trivy/), please take a look at the original documentation for more configuration examples.
 
 - Filter the vulnerabilities by severities `trivy image --severity HIGH,CRITICAL ruby:2.4.0`
 - Filter the vulnerabilities by type (`os` or `library`) `trivy image --vuln-type os ruby:2.4.0`
 - Skip update of vulnerability DB: `trivy image --skip-update python:3.4-alpine3.9`
 - Ignore unfixed vulnerabilities:`trivy image --ignore-unfixed ruby:2.4.0` By default, Trivy also detects unpatched/unfixed vulnerabilities. This means you can't fix these vulnerabilities even if you update all packages. If you would like to ignore them, use the `--ignore-unfixed` option.
 
-::: caution
+:::caution
 Due to [limitations in the trivy argument parser](https://github.com/secureCodeBox/secureCodeBox/issues/796), scanning anything other than docker images (e.g., Git repositories) requires some extra parameters.
 Please append the following extra arguments **after** specifying the mode (e.g., `repo`) but **before** specifying the target for the scan:
 ```yaml

--- a/scanners/trivy/README.md
+++ b/scanners/trivy/README.md
@@ -40,7 +40,7 @@ A software vulnerability is a glitch, flaw, or weakness present in the software 
 `Trivy` detects vulnerabilities of OS packages (Alpine, RHEL, CentOS, etc.) and application dependencies (Bundler, Composer, npm, yarn, etc.).
 `Trivy` is easy to use. Just install the binary, and you're ready to scan. All you need to do for scanning is to specify a target such as an image name of the container.
 
-To learn more about the Trivy scanner itself visit on [Trivy's GitHub Repository](https://github.com/aquasecurity/trivy).
+To learn more about the Trivy scanner itself visit [Trivy's GitHub Repository](https://github.com/aquasecurity/trivy).
 
 ## Deployment
 The trivy chart can be deployed via helm:
@@ -52,14 +52,14 @@ helm upgrade --install trivy secureCodeBox/trivy
 
 ## Scanner Configuration
 
-The following security scan configuration example are based on the [Trivy Documentation], please take a look at the original documentation for more configuration examples.
+The following security scan configuration example are based on the [Trivy Documentation](https://aquasecurity.github.io/trivy/), please take a look at the original documentation for more configuration examples.
 
 - Filter the vulnerabilities by severities `trivy image --severity HIGH,CRITICAL ruby:2.4.0`
 - Filter the vulnerabilities by type (`os` or `library`) `trivy image --vuln-type os ruby:2.4.0`
 - Skip update of vulnerability DB: `trivy image --skip-update python:3.4-alpine3.9`
 - Ignore unfixed vulnerabilities:`trivy image --ignore-unfixed ruby:2.4.0` By default, Trivy also detects unpatched/unfixed vulnerabilities. This means you can't fix these vulnerabilities even if you update all packages. If you would like to ignore them, use the `--ignore-unfixed` option.
 
-::: caution
+:::caution
 Due to [limitations in the trivy argument parser](https://github.com/secureCodeBox/secureCodeBox/issues/796), scanning anything other than docker images (e.g., Git repositories) requires some extra parameters.
 Please append the following extra arguments **after** specifying the mode (e.g., `repo`) but **before** specifying the target for the scan:
 ```yaml


### PR DESCRIPTION
Part of our effort to keep the documentation up to date.

Resolves https://github.com/secureCodeBox/documentation/issues/170.