### PR TITLE
Disable SCB-Bot for gitleaks until upgrade to 8.X is complete

### DIFF
--- a/.github/workflows/scb-bot.yaml
+++ b/.github/workflows/scb-bot.yaml
@@ -11,7 +11,7 @@ jobs:
           - amass
           - angularjs-csti-scanner
           - cmseek
-          - gitleaks
+          # - gitleaks
           - kube-hunter
           - kubeaudit
           - ncrack


### PR DESCRIPTION
We need to upgrade gitleaks to the 8.X version (see https://github.com/secureCodeBox/secureCodeBox/pull/830). Until we can do that, there is no need to get new pull request for every new point release, so this PR disables the SCB bot for gitleaks until we can finish up the work in #830, at which point we can enable it again.