### PR TITLE
Run angularjs-csti As User In Container

### DIFF
--- a/scanners/angularjs-csti-scanner/.helm-docs.gotmpl
+++ b/scanners/angularjs-csti-scanner/.helm-docs.gotmpl
@@ -80,7 +80,7 @@ Then, mount it into the container:
          name: "acstis-config"
    volumeMounts:
      - name: "acstis-config"
-       mountPath: "/acstis/config/"
+       mountPath: "/home/angularjscsti/acstis/config/"
 ```
 
 #### Configuration options in *acstis-config.py*

--- a/scanners/angularjs-csti-scanner/.helm-docs.gotmpl
+++ b/scanners/angularjs-csti-scanner/.helm-docs.gotmpl
@@ -65,7 +65,7 @@ Optional arguments:
 
 Because *acstis* does not provide command line arguments for configuring the sent requests,
 you have to mount a config map into the scan container on a specific location. Your additional config map should be
- mounted to `/acstis/config/acstis-config.py`. For example create a config map:
+ mounted to `/home/angularjscsti/acstis/config/acstis-config.py`. For example create a config map:
 
  ```bash
 kubectl create configmap --from-file /path/to/my/acstis-config.py acstis-config
@@ -74,11 +74,11 @@ kubectl create configmap --from-file /path/to/my/acstis-config.py acstis-config
 Then, mount it into the container:
 
 ```yaml
- volumes:
+    volumes:
      - name: "acstis-config"
        configMap:
          name: "acstis-config"
-   volumeMounts:
+    volumeMounts:
      - name: "acstis-config"
        mountPath: "/home/angularjscsti/acstis/config/"
 ```

--- a/scanners/angularjs-csti-scanner/README.md
+++ b/scanners/angularjs-csti-scanner/README.md
@@ -83,7 +83,7 @@ Kubernetes: `>=v1.11.0-0`
 
 Because *acstis* does not provide command line arguments for configuring the sent requests,
 you have to mount a config map into the scan container on a specific location. Your additional config map should be
- mounted to `/acstis/config/acstis-config.py`. For example create a config map:
+ mounted to `/home/angularjscsti/acstis/config/acstis-config.py`. For example create a config map:
 
  ```bash
 kubectl create configmap --from-file /path/to/my/acstis-config.py acstis-config
@@ -92,11 +92,11 @@ kubectl create configmap --from-file /path/to/my/acstis-config.py acstis-config
 Then, mount it into the container:
 
 ```yaml
- volumes:
+    volumes:
      - name: "acstis-config"
        configMap:
          name: "acstis-config"
-   volumeMounts:
+    volumeMounts:
      - name: "acstis-config"
        mountPath: "/home/angularjscsti/acstis/config/"
 ```

--- a/scanners/angularjs-csti-scanner/README.md
+++ b/scanners/angularjs-csti-scanner/README.md
@@ -98,7 +98,7 @@ Then, mount it into the container:
          name: "acstis-config"
    volumeMounts:
      - name: "acstis-config"
-       mountPath: "/acstis/config/"
+       mountPath: "/home/angularjscsti/acstis/config/"
 ```
 
 #### Configuration options in *acstis-config.py*
@@ -185,11 +185,11 @@ options.scope.request_methods = [
 | scanner.image.tag | string | `nil` | defaults to the charts appVersion |
 | scanner.nameAppend | string | `nil` | append a string to the default scantype name. |
 | scanner.resources | object | `{}` | CPU/memory resource requests/limits (see: https://kubernetes.io/docs/tasks/configure-pod-container/assign-memory-resource/, https://kubernetes.io/docs/tasks/configure-pod-container/assign-cpu-resource/) |
-| scanner.securityContext | object | `{"allowPrivilegeEscalation":false,"capabilities":{"drop":["all"]},"privileged":false,"readOnlyRootFilesystem":true,"runAsNonRoot":true}` | Optional securityContext set on scanner container (see: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/) |
+| scanner.securityContext | object | `{"allowPrivilegeEscalation":false,"capabilities":{"drop":["all"]},"privileged":false,"readOnlyRootFilesystem":false,"runAsNonRoot":true}` | Optional securityContext set on scanner container (see: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/) |
 | scanner.securityContext.allowPrivilegeEscalation | bool | `false` | Ensure that users privileges cannot be escalated |
 | scanner.securityContext.capabilities.drop[0] | string | `"all"` | This drops all linux privileges from the container. |
 | scanner.securityContext.privileged | bool | `false` | Ensures that the scanner container is not run in privileged mode |
-| scanner.securityContext.readOnlyRootFilesystem | bool | `true` | Prevents write access to the containers file system |
+| scanner.securityContext.readOnlyRootFilesystem | bool | `false` | Prevents write access to the containers file system |
 | scanner.securityContext.runAsNonRoot | bool | `true` | Enforces that the scanner image is run as a non root user |
 | scanner.ttlSecondsAfterFinished | string | `nil` | seconds after which the kubernetes job for the scanner will be deleted. Requires the Kubernetes TTLAfterFinished controller: https://kubernetes.io/docs/concepts/workloads/controllers/ttlafterfinished/ |
 

--- a/scanners/angularjs-csti-scanner/examples/scan-website-with-options/scan.yaml
+++ b/scanners/angularjs-csti-scanner/examples/scan-website-with-options/scan.yaml
@@ -21,4 +21,4 @@ spec:
         name: "acstis-config"
   volumeMounts:
     - name: "acstis-config"
-      mountPath: "/acstis/config/"
+      mountPath: "/home/angularjscsti/acstis/config/"

--- a/scanners/angularjs-csti-scanner/scanner/Dockerfile
+++ b/scanners/angularjs-csti-scanner/scanner/Dockerfile
@@ -4,8 +4,18 @@
 
 FROM python:3.6-alpine
 ARG scannerVersion
-COPY acstis-script.py /acstis/acstis-script.py
-COPY wrapper.sh /wrapper.sh
-RUN apk add --update --no-cache g++ gcc libxslt-dev
-RUN pip install https://github.com/tijme/angularjs-csti-scanner/archive/$scannerVersion.zip
-ENTRYPOINT [ "sh", "/wrapper.sh" ]
+
+RUN apk add --update --no-cache g++ gcc libxslt-dev \
+    && pip install https://github.com/tijme/angularjs-csti-scanner/archive/$scannerVersion.zip
+
+RUN adduser -S -H -u 1001 angularjscsti
+
+COPY acstis-script.py /home/angularjscsti/acstis/acstis-script.py
+COPY wrapper.sh /home/angularjscsti/wrapper.sh
+
+RUN pip install https://github.com/tijme/angularjs-csti-scanner/archive/$scannerVersion.zip \
+    && chown -R angularjscsti /home/angularjscsti
+    
+USER 1001
+
+ENTRYPOINT [ "sh", "/home/angularjscsti/wrapper.sh" ]

--- a/scanners/angularjs-csti-scanner/scanner/Dockerfile
+++ b/scanners/angularjs-csti-scanner/scanner/Dockerfile
@@ -5,9 +5,7 @@
 FROM python:3.6-alpine
 ARG scannerVersion
 
-RUN apk add --update --no-cache g++ gcc libxslt-dev \
-    && pip install https://github.com/tijme/angularjs-csti-scanner/archive/$scannerVersion.zip
-
+RUN apk add --update --no-cache g++ gcc libxslt-dev 
 RUN adduser -S -H -u 1001 angularjscsti
 
 COPY acstis-script.py /home/angularjscsti/acstis/acstis-script.py

--- a/scanners/angularjs-csti-scanner/scanner/wrapper.sh
+++ b/scanners/angularjs-csti-scanner/scanner/wrapper.sh
@@ -3,13 +3,13 @@
 # SPDX-License-Identifier: Apache-2.0
 
 # If acstis config exists paste it into the acstis script
-if [ -f /acstis/config/acstis-config.py ]; then
+if [ -f /home/angularjscsti/acstis/config/acstis-config.py ]; then
   echo "Insert acstis-config file into acstis script"
-  awk '{$1=$1}1' /acstis/config/acstis-config.py | # Trim start end end spaces of each line of the config
+  awk '{$1=$1}1' /home/angularjscsti/acstis/config/acstis-config.py | # Trim start end end spaces of each line of the config
   awk -v x=4 '{printf "%" x "s%s\n", "", $0}' | # Add indentation of 4 to every line
-  sed -i '/#INSERT CUSTOM OPTIONS HERE/ r /dev/stdin' /acstis/acstis-script.py # Insert config into script
+  sed -i '/#INSERT CUSTOM OPTIONS HERE/ r /dev/stdin' /home/angularjscsti/acstis/acstis-script.py # Insert config into script
 fi
-python /acstis/acstis-script.py $@
+python /home/angularjscsti/acstis/acstis-script.py $@
 
 # If no finding occurred generate a empty file for the lurker
 if [ ! -f /home/securecodebox/findings.log ]; then

--- a/scanners/angularjs-csti-scanner/templates/angularjs-csti-scanner-scan-type.yaml
+++ b/scanners/angularjs-csti-scanner/templates/angularjs-csti-scanner-scan-type.yaml
@@ -28,7 +28,7 @@ spec:
               imagePullPolicy: {{ .Values.scanner.image.pullPolicy }}
               command:
                 - "sh"
-                - "/wrapper.sh"
+                - "/home/angularjscsti/wrapper.sh"
                 - "-vrl"
                 - "/home/securecodebox/findings.log"
               resources:

--- a/scanners/angularjs-csti-scanner/values.yaml
+++ b/scanners/angularjs-csti-scanner/values.yaml
@@ -64,7 +64,7 @@ scanner:
     # scanner.securityContext.runAsNonRoot -- Enforces that the scanner image is run as a non root user
     runAsNonRoot: true
     # scanner.securityContext.readOnlyRootFilesystem -- Prevents write access to the containers file system
-    readOnlyRootFilesystem: true
+    readOnlyRootFilesystem: false
     # scanner.securityContext.allowPrivilegeEscalation -- Ensure that users privileges cannot be escalated
     allowPrivilegeEscalation: false
     # scanner.securityContext.privileged -- Ensures that the scanner container is not run in privileged mode


### PR DESCRIPTION
angularjs-csti scanner now runs as NonRoot
* A new user is added to the docker image
* Path to wrapper.sh is changed to new user's
home directory
It should be noted that angularjs-csti currently does not have any integration tests. So testing was done manually.
See: #286