### PR TITLE
Fixes typo in setting the SCB-Bot changelog env variable

### DIFF
--- a/.github/workflows/scb-bot.yaml
+++ b/.github/workflows/scb-bot.yaml
@@ -62,7 +62,7 @@ jobs:
               upgrade=$(echo $release| tr -d "v")
             fi
           fi
-          
+
           echo $upgrade
           echo release=$upgrade >> $GITHUB_ENV
 
@@ -82,7 +82,8 @@ jobs:
         # Fetches changelog and filters out any issue references
         run: |
           changelog=$(curl -sL ${{env.versionApi}} | jq -r ".body")
-          echo "releaseChangelog=$changelog" >> $GITHUB_ENV
+          echo $changelog
+          echo 'releaseChangelog=$changelog' >> $GITHUB_ENV
 
       - name: Upgrade Scanner Helm Chart
         if: ${{ env.release != env.local && env.prExists == 0 && env.release != null}}

--- a/.github/workflows/scb-bot.yaml
+++ b/.github/workflows/scb-bot.yaml
@@ -82,7 +82,6 @@ jobs:
         # Fetches changelog and filters out any issue references
         run: |
           changelog=$(curl -sL ${{env.versionApi}} | jq -r ".body")
-          echo $changelog
           echo 'releaseChangelog=$changelog' >> $GITHUB_ENV
 
       - name: Upgrade Scanner Helm Chart

--- a/.github/workflows/scb-bot.yaml
+++ b/.github/workflows/scb-bot.yaml
@@ -1,6 +1,5 @@
 name: Check outdated scanners
 on:
-  push:
   schedule:
     - cron: "15 9 * * *" # Daily at 9:15 (avoids the beginning of the hour congestion)
 jobs:

--- a/.github/workflows/scb-bot.yaml
+++ b/.github/workflows/scb-bot.yaml
@@ -82,7 +82,7 @@ jobs:
         # Fetches changelog and filters out any issue references
         run: |
           changelog=$(curl -sL ${{env.versionApi}} | jq -r ".body")
-          echo releaseChangelog="$changelog" >> $GITHUB_ENV
+          echo "releaseChangelog=$changelog" >> $GITHUB_ENV
 
       - name: Upgrade Scanner Helm Chart
         if: ${{ env.release != env.local && env.prExists == 0 && env.release != null}}

--- a/.github/workflows/scb-bot.yaml
+++ b/.github/workflows/scb-bot.yaml
@@ -1,5 +1,6 @@
 name: Check outdated scanners
 on:
+  push:
   schedule:
     - cron: "15 9 * * *" # Daily at 9:15 (avoids the beginning of the hour congestion)
 jobs:


### PR DESCRIPTION
fixes the failing SCB-Bot workflow. See [here](https://github.com/secureCodeBox/secureCodeBox/actions/runs/1525083070) 
