### PR TITLE
Fix/nuclei without template cache pvc

### DIFF
--- a/scanners/nuclei/.helm-docs.gotmpl
+++ b/scanners/nuclei/.helm-docs.gotmpl
@@ -137,6 +137,19 @@ STATISTICS:
 {{- end }}
 
 {{- define "extra.chartConfigurationSection" -}}
+## Install Nuclei without Template Cache CronJob / PersistentVolume
+
+Nuclei uses dynamic templates as its scan rules, these determine which requests are performed and which responses are considered to be a finding.
+These templates are usually dynamically downloaded by nuclei from GitHub before each scan. When you are running dozens of parallel nuclei scans you quickly run into situations where GitHub will rate limit you causing the scans to fail.
+To avoid these errors we included a CronJob which periodically fetches the current templates and writes them into a kubernetes PersistentVolume (PV). This volume is then mounted (as a `ReadOnlyMany` mount) into every scan so that nuclei scans have the up-to-date templates without having to download them on every scan.
+
+Unfortunately not every cluster supports the required `ReadOnlyMany` volume type.
+In these cases you can disable the template cache mechanism by setting `nucleiTemplateCache.enabled=false`.
+Note thought, that this will limit the number of scans you can run in parallel as the rate limit will likely cause some of the scans to fail.
+
+```bash
+helm install nuclei secureCodeBox/nuclei --set="nucleiTemplateCache.enabled=false"
+```
 {{- end }}
 
 {{- define "extra.scannerLinksSection" -}}

--- a/scanners/nuclei/README.md
+++ b/scanners/nuclei/README.md
@@ -156,6 +156,20 @@ STATISTICS:
 
 Kubernetes: `>=v1.11.0-0`
 
+## Install Nuclei without Template Cache CronJob / PersistentVolume
+
+Nuclei uses dynamic templates as its scan rules, these determine which requests are performed and which responses are considered to be a finding.
+These templates are usually dynamically downloaded by nuclei from GitHub before each scan. When you are running dozens of parallel nuclei scans you quickly run into situations where GitHub will rate limit you causing the scans to fail.
+To avoid these errors we included a CronJob which periodically fetches the current templates and writes them into a kubernetes PersistentVolume (PV). This volume is then mounted (as a `ReadOnlyMany` mount) into every scan so that nuclei scans have the up-to-date templates without having to download them on every scan.
+
+Unfortunately not every cluster supports the required `ReadOnlyMany` volume type.
+In these cases you can disable the template cache mechanism by setting `nucleiTemplateCache.enabled=false`.
+Note thought, that this will limit the number of scans you can run in parallel as the rate limit will likely cause some of the scans to fail.
+
+```bash
+helm install nuclei secureCodeBox/nuclei --set="nucleiTemplateCache.enabled=false"
+```
+
 ## Values
 
 | Key | Type | Default | Description |

--- a/scanners/nuclei/templates/nuclei-scan-type.yaml
+++ b/scanners/nuclei/templates/nuclei-scan-type.yaml
@@ -28,7 +28,9 @@ spec:
               imagePullPolicy: {{ .Values.scanner.image.pullPolicy }}
               command:
                 - "nuclei"
+                {{ if .Values.nucleiTemplateCache.enabled }}
                 - "-no-update-templates"
+                {{ end }}
                 - "-json"
                 - "-output"
                 - "/home/securecodebox/nuclei-results.jsonl"


### PR DESCRIPTION
## Description

Related to secureCodeBox/documentation#166

Noticed that there was still a bug in the chart when disabling the template cache.
Also added docs on how to actually disable it.

### Checklist

* [x] Test your changes as thoroughly as possible before you commit them. Preferably, automate your test by unit/integration tests.
* [x] Make sure `npm test` runs for the whole project.
* [x] Make codeclimate checks happy
