### PR TITLE
Add k8s 1.23 to CI Matrix and Update Existing Versions

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -703,10 +703,10 @@ jobs:
     strategy:
       matrix:
         k8sVersion:
-          - v1.22.0@sha256:b8bda84bb3a190e6e028b1760d277454a72267a5454b57db34437c34a588d047
-          - v1.21.1@sha256:69860bda5563ac81e3c0057d654b5253219618a22ec3a346306239bba8cfa1a6
+          - v1.23.0@sha256:2f93d3c7b12a3e93e6c1f34f331415e105979961fcddbe69a4e3ab5a93ccbb35
+          - v1.22.4@sha256:ca3587e6e545a96c07bf82e2c46503d9ef86fc704f44c17577fca7bcabf5f978
+          - v1.21.2@sha256:9d07ff05e4afefbba983fac311807b3c17a5f36e7061f6cb7e2ba756255b2be4
           - v1.20.7@sha256:cbeaf907fc78ac97ce7b625e4bf0de16e3ea725daf6b04f930bd14c67c671ff9
-          - v1.19.11@sha256:07db187ae84b4b7de440a73886f008cf903fcf5764ba8106a9fd5243d6f32729
     steps:
       - uses: actions/checkout@master
       - name: "Start kind cluster"


### PR DESCRIPTION
Updates the list of kubernetes versions used in ci to the include the new 1.23 release and removes the old 1.19 version which we don't officially support anymore.

After this is merged we have to update the k8s versions referenced on our docs site.