### PR TITLE
Fix Crash in Cascading Hook when using Label Selectors

### DIFF
--- a/hooks/cascading-scans/hook/scan-helpers.ts
+++ b/hooks/cascading-scans/hook/scan-helpers.ts
@@ -174,6 +174,7 @@ export async function getCascadingRulesForScan(scan: Scan) {
       undefined,
       undefined,
       undefined,
+      undefined,
       labelSelector
     );
 


### PR DESCRIPTION
## Description

Bug was introduced by the recent upgrade to the kubernetes client node

Closes #887

### Checklist

* [x] Test your changes as thoroughly as possible before you commit them. Preferably, automate your test by unit/integration tests.
* [x] Make sure `npm test` runs for the whole project.
* [ ] Make codeclimate checks happy
