### PR TITLE
Git Repo Scanner: add archive status to output

### DIFF
--- a/scanners/git-repo-scanner/examples/github-secureCodeBox-scan/findings.yaml
+++ b/scanners/git-repo-scanner/examples/github-secureCodeBox-scan/findings.yaml
@@ -1,0 +1,557 @@
+# SPDX-FileCopyrightText: 2021 iteratec GmbH
+# 
+# SPDX-License-Identifier: Apache-2.0
+
+[
+  {
+    "name": "GitHub Repo",
+    "description": "A GitHub repository",
+    "category": "Git Repository",
+    "osi_layer": "APPLICATION",
+    "severity": "INFORMATIONAL",
+    "attributes": {
+      "id": "144957631",
+      "web_url": "https://github.com/secureCodeBox/ansible-role-securecodebox-openshift",
+      "full_name": "secureCodeBox/ansible-role-securecodebox-openshift",
+      "owner_type": "Organization",
+      "owner_id": "34573705",
+      "owner_name": "secureCodeBox",
+      "created_at": "2018-08-16T08:11:15Z",
+      "last_activity_at": "2021-02-26T14:43:24Z",
+      "visibility": "public",
+      "archived": true
+    }
+  },
+  {
+    "name": "GitHub Repo",
+    "description": "A GitHub repository",
+    "category": "Git Repository",
+    "osi_layer": "APPLICATION",
+    "severity": "INFORMATIONAL",
+    "attributes": {
+      "id": "142870794",
+      "web_url": "https://github.com/secureCodeBox/integration-pipeline-jenkins-examples",
+      "full_name": "secureCodeBox/integration-pipeline-jenkins-examples",
+      "owner_type": "Organization",
+      "owner_id": "34573705",
+      "owner_name": "secureCodeBox",
+      "created_at": "2018-07-30T12:13:41Z",
+      "last_activity_at": "2021-02-26T14:42:45Z",
+      "visibility": "public",
+      "archived": true
+    }
+  },
+  {
+    "name": "GitHub Repo",
+    "description": "A GitHub repository",
+    "category": "Git Repository",
+    "osi_layer": "APPLICATION",
+    "severity": "INFORMATIONAL",
+    "attributes": {
+      "id": "214418800",
+      "web_url": "https://github.com/secureCodeBox/swagger-petstore-openshift",
+      "full_name": "secureCodeBox/swagger-petstore-openshift",
+      "owner_type": "Organization",
+      "owner_id": "34573705",
+      "owner_name": "secureCodeBox",
+      "created_at": "2019-10-11T11:28:15Z",
+      "last_activity_at": "2019-10-11T11:37:41Z",
+      "visibility": "public",
+      "archived": false
+    }
+  },
+  {
+    "name": "GitHub Repo",
+    "description": "A GitHub repository",
+    "category": "Git Repository",
+    "osi_layer": "APPLICATION",
+    "severity": "INFORMATIONAL",
+    "attributes": {
+      "id": "180568880",
+      "web_url": "https://github.com/secureCodeBox/ruby-scanner-scaffolding",
+      "full_name": "secureCodeBox/ruby-scanner-scaffolding",
+      "owner_type": "Organization",
+      "owner_id": "34573705",
+      "owner_name": "secureCodeBox",
+      "created_at": "2019-04-10T11:39:04Z",
+      "last_activity_at": "2021-02-26T14:42:14Z",
+      "visibility": "public",
+      "archived": true
+    }
+  },
+  {
+    "name": "GitHub Repo",
+    "description": "A GitHub repository",
+    "category": "Git Repository",
+    "osi_layer": "APPLICATION",
+    "severity": "INFORMATIONAL",
+    "attributes": {
+      "id": "141462466",
+      "web_url": "https://github.com/secureCodeBox/scanner-infrastructure-amass",
+      "full_name": "secureCodeBox/scanner-infrastructure-amass",
+      "owner_type": "Organization",
+      "owner_id": "34573705",
+      "owner_name": "secureCodeBox",
+      "created_at": "2018-07-18T16:38:18Z",
+      "last_activity_at": "2021-02-26T14:41:40Z",
+      "visibility": "public",
+      "archived": true
+    }
+  },
+  {
+    "name": "GitHub Repo",
+    "description": "A GitHub repository",
+    "category": "Git Repository",
+    "osi_layer": "APPLICATION",
+    "severity": "INFORMATIONAL",
+    "attributes": {
+      "id": "251007807",
+      "web_url": "https://github.com/secureCodeBox/zap-extensions",
+      "full_name": "secureCodeBox/zap-extensions",
+      "owner_type": "Organization",
+      "owner_id": "34573705",
+      "owner_name": "secureCodeBox",
+      "created_at": "2020-03-29T10:40:12Z",
+      "last_activity_at": "2020-03-29T10:40:13Z",
+      "visibility": "public",
+      "archived": false
+    }
+  },
+  {
+    "name": "GitHub Repo",
+    "description": "A GitHub repository",
+    "category": "Git Repository",
+    "osi_layer": "APPLICATION",
+    "severity": "INFORMATIONAL",
+    "attributes": {
+      "id": "171298120",
+      "web_url": "https://github.com/secureCodeBox/scanner-infrastructure-ssh",
+      "full_name": "secureCodeBox/scanner-infrastructure-ssh",
+      "owner_type": "Organization",
+      "owner_id": "34573705",
+      "owner_name": "secureCodeBox",
+      "created_at": "2019-02-18T14:23:57Z",
+      "last_activity_at": "2021-02-26T14:40:57Z",
+      "visibility": "public",
+      "archived": true
+    }
+  },
+  {
+    "name": "GitHub Repo",
+    "description": "A GitHub repository",
+    "category": "Git Repository",
+    "osi_layer": "APPLICATION",
+    "severity": "INFORMATIONAL",
+    "attributes": {
+      "id": "128396681",
+      "web_url": "https://github.com/secureCodeBox/scanner-webserver-nikto",
+      "full_name": "secureCodeBox/scanner-webserver-nikto",
+      "owner_type": "Organization",
+      "owner_id": "34573705",
+      "owner_name": "secureCodeBox",
+      "created_at": "2018-04-06T13:13:14Z",
+      "last_activity_at": "2021-02-26T14:40:31Z",
+      "visibility": "public",
+      "archived": true
+    }
+  },
+  {
+    "name": "GitHub Repo",
+    "description": "A GitHub repository",
+    "category": "Git Repository",
+    "osi_layer": "APPLICATION",
+    "severity": "INFORMATIONAL",
+    "attributes": {
+      "id": "134673181",
+      "web_url": "https://github.com/secureCodeBox/scanner-webapplication-arachni",
+      "full_name": "secureCodeBox/scanner-webapplication-arachni",
+      "owner_type": "Organization",
+      "owner_id": "34573705",
+      "owner_name": "secureCodeBox",
+      "created_at": "2018-05-24T06:47:00Z",
+      "last_activity_at": "2021-02-26T14:40:03Z",
+      "visibility": "public",
+      "archived": true
+    }
+  },
+  {
+    "name": "GitHub Repo",
+    "description": "A GitHub repository",
+    "category": "Git Repository",
+    "osi_layer": "APPLICATION",
+    "severity": "INFORMATIONAL",
+    "attributes": {
+      "id": "180543766",
+      "web_url": "https://github.com/secureCodeBox/scanner-cms-wpscan",
+      "full_name": "secureCodeBox/scanner-cms-wpscan",
+      "owner_type": "Organization",
+      "owner_id": "34573705",
+      "owner_name": "secureCodeBox",
+      "created_at": "2019-04-10T09:03:38Z",
+      "last_activity_at": "2021-02-26T14:39:25Z",
+      "visibility": "public",
+      "archived": true
+    }
+  },
+  {
+    "name": "GitHub Repo",
+    "description": "A GitHub repository",
+    "category": "Git Repository",
+    "osi_layer": "APPLICATION",
+    "severity": "INFORMATIONAL",
+    "attributes": {
+      "id": "124402117",
+      "web_url": "https://github.com/secureCodeBox/scanner-infrastructure-nmap",
+      "full_name": "secureCodeBox/scanner-infrastructure-nmap",
+      "owner_type": "Organization",
+      "owner_id": "34573705",
+      "owner_name": "secureCodeBox",
+      "created_at": "2018-03-08T14:20:36Z",
+      "last_activity_at": "2021-06-11T21:49:14Z",
+      "visibility": "public",
+      "archived": true
+    }
+  },
+  {
+    "name": "GitHub Repo",
+    "description": "A GitHub repository",
+    "category": "Git Repository",
+    "osi_layer": "APPLICATION",
+    "severity": "INFORMATIONAL",
+    "attributes": {
+      "id": "133507929",
+      "web_url": "https://github.com/secureCodeBox/scanner-infrastructure-sslyze",
+      "full_name": "secureCodeBox/scanner-infrastructure-sslyze",
+      "owner_type": "Organization",
+      "owner_id": "34573705",
+      "owner_name": "secureCodeBox",
+      "created_at": "2018-05-15T11:43:11Z",
+      "last_activity_at": "2021-02-26T14:38:12Z",
+      "visibility": "public",
+      "archived": true
+    }
+  },
+  {
+    "name": "GitHub Repo",
+    "description": "A GitHub repository",
+    "category": "Git Repository",
+    "osi_layer": "APPLICATION",
+    "severity": "INFORMATIONAL",
+    "attributes": {
+      "id": "223956455",
+      "web_url": "https://github.com/secureCodeBox/scanner-infrastructure-ncrack",
+      "full_name": "secureCodeBox/scanner-infrastructure-ncrack",
+      "owner_type": "Organization",
+      "owner_id": "34573705",
+      "owner_name": "secureCodeBox",
+      "created_at": "2019-11-25T13:34:16Z",
+      "last_activity_at": "2021-02-26T14:37:34Z",
+      "visibility": "public",
+      "archived": true
+    }
+  },
+  {
+    "name": "GitHub Repo",
+    "description": "A GitHub repository",
+    "category": "Git Repository",
+    "osi_layer": "APPLICATION",
+    "severity": "INFORMATIONAL",
+    "attributes": {
+      "id": "277835641",
+      "web_url": "https://github.com/secureCodeBox/zaproxy",
+      "full_name": "secureCodeBox/zaproxy",
+      "owner_type": "Organization",
+      "owner_id": "34573705",
+      "owner_name": "secureCodeBox",
+      "created_at": "2020-07-07T14:14:16Z",
+      "last_activity_at": "2020-07-07T14:14:18Z",
+      "visibility": "public",
+      "archived": false
+    }
+  },
+  {
+    "name": "GitHub Repo",
+    "description": "A GitHub repository",
+    "category": "Git Repository",
+    "osi_layer": "APPLICATION",
+    "severity": "INFORMATIONAL",
+    "attributes": {
+      "id": "249731346",
+      "web_url": "https://github.com/secureCodeBox/secureCodeBox-v2",
+      "full_name": "secureCodeBox/secureCodeBox-v2",
+      "owner_type": "Organization",
+      "owner_id": "34573705",
+      "owner_name": "secureCodeBox",
+      "created_at": "2020-03-24T14:33:08Z",
+      "last_activity_at": "2020-11-05T15:40:55Z",
+      "visibility": "public",
+      "archived": true
+    }
+  },
+  {
+    "name": "GitHub Repo",
+    "description": "A GitHub repository",
+    "category": "Git Repository",
+    "osi_layer": "APPLICATION",
+    "severity": "INFORMATIONAL",
+    "attributes": {
+      "id": "203588805",
+      "web_url": "https://github.com/secureCodeBox/securecodebox.github.io",
+      "full_name": "secureCodeBox/securecodebox.github.io",
+      "owner_type": "Organization",
+      "owner_id": "34573705",
+      "owner_name": "secureCodeBox",
+      "created_at": "2019-08-21T13:21:09Z",
+      "last_activity_at": "2020-10-16T11:40:25Z",
+      "visibility": "public",
+      "archived": false
+    }
+  },
+  {
+    "name": "GitHub Repo",
+    "description": "A GitHub repository",
+    "category": "Git Repository",
+    "osi_layer": "APPLICATION",
+    "severity": "INFORMATIONAL",
+    "attributes": {
+      "id": "126042943",
+      "web_url": "https://github.com/secureCodeBox/nodejs-scanner-scaffolding",
+      "full_name": "secureCodeBox/nodejs-scanner-scaffolding",
+      "owner_type": "Organization",
+      "owner_id": "34573705",
+      "owner_name": "secureCodeBox",
+      "created_at": "2018-03-20T15:48:39Z",
+      "last_activity_at": "2021-02-26T14:36:53Z",
+      "visibility": "public",
+      "archived": true
+    }
+  },
+  {
+    "name": "GitHub Repo",
+    "description": "A GitHub repository",
+    "category": "Git Repository",
+    "osi_layer": "APPLICATION",
+    "severity": "INFORMATIONAL",
+    "attributes": {
+      "id": "128920739",
+      "web_url": "https://github.com/secureCodeBox/scanner-webapplication-zap",
+      "full_name": "secureCodeBox/scanner-webapplication-zap",
+      "owner_type": "Organization",
+      "owner_id": "34573705",
+      "owner_name": "secureCodeBox",
+      "created_at": "2018-04-10T11:17:29Z",
+      "last_activity_at": "2021-02-26T14:36:02Z",
+      "visibility": "public",
+      "archived": true
+    }
+  },
+  {
+    "name": "GitHub Repo",
+    "description": "A GitHub repository",
+    "category": "Git Repository",
+    "osi_layer": "APPLICATION",
+    "severity": "INFORMATIONAL",
+    "attributes": {
+      "id": "123422137",
+      "web_url": "https://github.com/secureCodeBox/engine",
+      "full_name": "secureCodeBox/engine",
+      "owner_type": "Organization",
+      "owner_id": "34573705",
+      "owner_name": "secureCodeBox",
+      "created_at": "2018-03-01T10:50:05Z",
+      "last_activity_at": "2021-02-26T14:35:25Z",
+      "visibility": "public",
+      "archived": true
+    }
+  },
+  {
+    "name": "GitHub Repo",
+    "description": "A GitHub repository",
+    "category": "Git Repository",
+    "osi_layer": "APPLICATION",
+    "severity": "INFORMATIONAL",
+    "attributes": {
+      "id": "327336031",
+      "web_url": "https://github.com/secureCodeBox/gitleaks",
+      "full_name": "secureCodeBox/gitleaks",
+      "owner_type": "Organization",
+      "owner_id": "34573705",
+      "owner_name": "secureCodeBox",
+      "created_at": "2021-01-06T14:27:46Z",
+      "last_activity_at": "2021-03-06T20:23:36Z",
+      "visibility": "public",
+      "archived": false
+    }
+  },
+  {
+    "name": "GitHub Repo",
+    "description": "A GitHub repository",
+    "category": "Git Repository",
+    "osi_layer": "APPLICATION",
+    "severity": "INFORMATIONAL",
+    "attributes": {
+      "id": "303349727",
+      "web_url": "https://github.com/secureCodeBox/kubeaudit",
+      "full_name": "secureCodeBox/kubeaudit",
+      "owner_type": "Organization",
+      "owner_id": "34573705",
+      "owner_name": "secureCodeBox",
+      "created_at": "2020-10-12T09:58:26Z",
+      "last_activity_at": "2020-10-12T09:58:28Z",
+      "visibility": "public",
+      "archived": false
+    }
+  },
+  {
+    "name": "GitHub Repo",
+    "description": "A GitHub repository",
+    "category": "Git Repository",
+    "osi_layer": "APPLICATION",
+    "severity": "INFORMATIONAL",
+    "attributes": {
+      "id": "357207085",
+      "web_url": "https://github.com/secureCodeBox/django-DefectDojo",
+      "full_name": "secureCodeBox/django-DefectDojo",
+      "owner_type": "Organization",
+      "owner_id": "34573705",
+      "owner_name": "secureCodeBox",
+      "created_at": "2021-04-12T13:36:31Z",
+      "last_activity_at": "2021-12-14T14:46:54Z",
+      "visibility": "public",
+      "archived": false
+    }
+  },
+  {
+    "name": "GitHub Repo",
+    "description": "A GitHub repository",
+    "category": "Git Repository",
+    "osi_layer": "APPLICATION",
+    "severity": "INFORMATIONAL",
+    "attributes": {
+      "id": "204701677",
+      "web_url": "https://github.com/secureCodeBox/ssh_scan",
+      "full_name": "secureCodeBox/ssh_scan",
+      "owner_type": "Organization",
+      "owner_id": "34573705",
+      "owner_name": "secureCodeBox",
+      "created_at": "2019-08-27T12:46:48Z",
+      "last_activity_at": "2021-06-22T12:11:47Z",
+      "visibility": "public",
+      "archived": false
+    }
+  },
+  {
+    "name": "GitHub Repo",
+    "description": "A GitHub repository",
+    "category": "Git Repository",
+    "osi_layer": "APPLICATION",
+    "severity": "INFORMATIONAL",
+    "attributes": {
+      "id": "222679857",
+      "web_url": "https://github.com/secureCodeBox/nikto",
+      "full_name": "secureCodeBox/nikto",
+      "owner_type": "Organization",
+      "owner_id": "34573705",
+      "owner_name": "secureCodeBox",
+      "created_at": "2019-11-19T11:25:21Z",
+      "last_activity_at": "2021-08-25T14:24:37Z",
+      "visibility": "public",
+      "archived": false
+    }
+  },
+  {
+    "name": "GitHub Repo",
+    "description": "A GitHub repository",
+    "category": "Git Repository",
+    "osi_layer": "APPLICATION",
+    "severity": "INFORMATIONAL",
+    "attributes": {
+      "id": "409468006",
+      "web_url": "https://github.com/secureCodeBox/sslyze",
+      "full_name": "secureCodeBox/sslyze",
+      "owner_type": "Organization",
+      "owner_id": "34573705",
+      "owner_name": "secureCodeBox",
+      "created_at": "2021-09-23T06:03:50Z",
+      "last_activity_at": "2021-09-23T06:03:51Z",
+      "visibility": "public",
+      "archived": false
+    }
+  },
+  {
+    "name": "GitHub Repo",
+    "description": "A GitHub repository",
+    "category": "Git Repository",
+    "osi_layer": "APPLICATION",
+    "severity": "INFORMATIONAL",
+    "attributes": {
+      "id": "327269915",
+      "web_url": "https://github.com/secureCodeBox/defectdojo-client-java",
+      "full_name": "secureCodeBox/defectdojo-client-java",
+      "owner_type": "Organization",
+      "owner_id": "34573705",
+      "owner_name": "secureCodeBox",
+      "created_at": "2021-01-06T09:59:17Z",
+      "last_activity_at": "2021-10-20T08:45:43Z",
+      "visibility": "public",
+      "archived": false
+    }
+  },
+  {
+    "name": "GitHub Repo",
+    "description": "A GitHub repository",
+    "category": "Git Repository",
+    "osi_layer": "APPLICATION",
+    "severity": "INFORMATIONAL",
+    "attributes": {
+      "id": "288212154",
+      "web_url": "https://github.com/secureCodeBox/telemetry",
+      "full_name": "secureCodeBox/telemetry",
+      "owner_type": "Organization",
+      "owner_id": "34573705",
+      "owner_name": "secureCodeBox",
+      "created_at": "2020-08-17T15:09:19Z",
+      "last_activity_at": "2021-12-06T14:24:34Z",
+      "visibility": "public",
+      "archived": false
+    }
+  },
+  {
+    "name": "GitHub Repo",
+    "description": "A GitHub repository",
+    "category": "Git Repository",
+    "osi_layer": "APPLICATION",
+    "severity": "INFORMATIONAL",
+    "attributes": {
+      "id": "292293538",
+      "web_url": "https://github.com/secureCodeBox/documentation",
+      "full_name": "secureCodeBox/documentation",
+      "owner_type": "Organization",
+      "owner_id": "34573705",
+      "owner_name": "secureCodeBox",
+      "created_at": "2020-09-02T13:39:10Z",
+      "last_activity_at": "2021-12-15T13:55:43Z",
+      "visibility": "public",
+      "archived": false
+    }
+  },
+  {
+    "name": "GitHub Repo",
+    "description": "A GitHub repository",
+    "category": "Git Repository",
+    "osi_layer": "APPLICATION",
+    "severity": "INFORMATIONAL",
+    "attributes": {
+      "id": "80711933",
+      "web_url": "https://github.com/secureCodeBox/secureCodeBox",
+      "full_name": "secureCodeBox/secureCodeBox",
+      "owner_type": "Organization",
+      "owner_id": "34573705",
+      "owner_name": "secureCodeBox",
+      "created_at": "2017-02-02T09:48:05Z",
+      "last_activity_at": "2021-12-19T17:51:48Z",
+      "visibility": "public",
+      "archived": false
+    }
+  }
+]

--- a/scanners/git-repo-scanner/scanner/git_repo_scanner/abstract_scanner.py
+++ b/scanners/git-repo-scanner/scanner/git_repo_scanner/abstract_scanner.py
@@ -22,7 +22,7 @@ class AbstractScanner(abc.ABC):
 
     def _create_finding(self, repo_id: str, web_url: str, full_name: str, owner_type: str, owner_id: str,
                         owner_name: str, created_at: str, last_activity_at: str, visibility: str,
-                        archived: bool = False, last_commit_id: str = None) -> FINDING:
+                        archived: bool, last_commit_id: str = None) -> FINDING:
         finding = {
             'name': f'{self.git_type} Repo',
             'description': f'A {self.git_type} repository',

--- a/scanners/git-repo-scanner/scanner/git_repo_scanner/abstract_scanner.py
+++ b/scanners/git-repo-scanner/scanner/git_repo_scanner/abstract_scanner.py
@@ -22,7 +22,7 @@ class AbstractScanner(abc.ABC):
 
     def _create_finding(self, repo_id: str, web_url: str, full_name: str, owner_type: str, owner_id: str,
                         owner_name: str, created_at: str, last_activity_at: str, visibility: str,
-                        last_commit_id: str = None) -> FINDING:
+                        archived: bool = False, last_commit_id: str = None) -> FINDING:
         finding = {
             'name': f'{self.git_type} Repo',
             'description': f'A {self.git_type} repository',
@@ -38,7 +38,8 @@ class AbstractScanner(abc.ABC):
                 'owner_name': owner_name,
                 'created_at': created_at,
                 'last_activity_at': last_activity_at,
-                'visibility': visibility
+                'visibility': visibility,
+                'archived': archived,
             }
         }
         if last_commit_id is not None:

--- a/scanners/git-repo-scanner/scanner/git_repo_scanner/github_scanner.py
+++ b/scanners/git-repo-scanner/scanner/git_repo_scanner/github_scanner.py
@@ -143,5 +143,6 @@ class GitHubScanner(AbstractScanner):
             repo.created_at.strftime("%Y-%m-%dT%H:%M:%SZ"),
             repo.updated_at.strftime("%Y-%m-%dT%H:%M:%SZ"),
             'private' if repo.private else 'public',
+            repo.archived,
             latest_commit
         )

--- a/scanners/git-repo-scanner/scanner/git_repo_scanner/gitlab_scanner.py
+++ b/scanners/git-repo-scanner/scanner/git_repo_scanner/gitlab_scanner.py
@@ -130,5 +130,6 @@ class GitLabScanner(AbstractScanner):
             project.created_at,
             project.last_activity_at,
             project.visibility,
+            project.archived,
             latest_commit_id
         )

--- a/scanners/git-repo-scanner/scanner/tests/git_repo_scanner_test.py
+++ b/scanners/git-repo-scanner/scanner/tests/git_repo_scanner_test.py
@@ -46,6 +46,8 @@ class GitRepoScannerTests(unittest.TestCase):
         self.assertEqual(findings[1]['attributes']['web_url'], 'url2', msg=self.wrong_output_msg)
         self.assertEqual(findings[2]['attributes']['web_url'], 'url3', msg=self.wrong_output_msg)
         self.assertEqual(findings[0]['attributes']["last_commit_id"], "deadbeef")
+        self.assertEqual(findings[1]['attributes']["archived"], False)
+        self.assertEqual(findings[2]['attributes']["archived"], True)
         mock_gptp.assert_called()
         mock_commitmanager.assert_called()
 
@@ -134,6 +136,12 @@ class GitRepoScannerTests(unittest.TestCase):
         # then
         org_mock.get_repos.assert_called_with(type='all', sort='pushed', direction='asc')
         self.assertEqual(6, len(findings), msg='There should be exactly 6 findings')
+        self.assertFalse(findings[0]["attributes"]["archived"])
+        self.assertFalse(findings[1]["attributes"]["archived"])
+        self.assertTrue(findings[2]["attributes"]["archived"])
+        self.assertFalse(findings[3]["attributes"]["archived"])
+        self.assertFalse(findings[4]["attributes"]["archived"])
+        self.assertTrue(findings[5]["attributes"]["archived"])
         for finding in findings:
             self.assertEqual(finding['name'], 'GitHub Repo', msg=self.wrong_output_msg)
             self.assertFalse("last_commit_id" in finding['attributes'])
@@ -200,11 +208,11 @@ def assemble_projects():
                                 o_name='name22')
     project3 = assemble_project(p_id=3, name='name3', url='url3', path='path3', date_created=created,
                                 date_updated=updated, visibility='private', o_id=33, o_kind='group',
-                                o_name='name33')
+                                o_name='name33', archived=True)
     return [project1, project2, project3]
 
 
-def assemble_project(p_id, name, url, path, date_created, date_updated, visibility, o_id, o_kind, o_name):
+def assemble_project(p_id, name, url, path, date_created, date_updated, visibility, o_id, o_kind, o_name, archived=False):
     project = Project(ProjectManager(gitlab), {})
     project.id = p_id
     project.name = name
@@ -218,6 +226,7 @@ def assemble_project(p_id, name, url, path, date_created, date_updated, visibili
         'id': o_id,
         'name': o_name
     }
+    project.archived = archived
     return project
 
 
@@ -232,14 +241,12 @@ def assemble_repos():
                                    o_name='name22')
     project3 = assemble_repository(p_id=3, name='name3', url='url3', path='path3', date_created=date,
                                    date_updated=date, date_pushed=date, visibility=False, o_id=33,
-                                   o_kind='organization',
-                                   o_name='name33')
+                                   o_kind='organization', o_name='name33', archived=True)
     return [project1, project2, project3]
 
 
 def assemble_repository(p_id, name, url, path, date_created: datetime, date_updated: datetime, date_pushed: datetime,
-                        visibility: bool, o_id,
-                        o_kind, o_name):
+                        visibility: bool, o_id, o_kind, o_name, archived = False):
 
     repo = Mock()
     owner = Mock()
@@ -256,6 +263,7 @@ def assemble_repository(p_id, name, url, path, date_created: datetime, date_upda
     repo.private = visibility
     repo.owner = owner
     repo.get_commits = lambda: [Mock(sha="deadbeef")]
+    repo.archived = archived
     return repo
 
 


### PR DESCRIPTION
Closes #892 by adding the archive status of repos to the output. Does not require extra API calls, so I did not add a feature flag for it and instead always add it.