### PR TITLE
Update Nuclei cascading rule to include protocol information and allow alternative HTTP ports

### DIFF
--- a/scanners/nuclei/cascading-rules/subdomain_http.yaml
+++ b/scanners/nuclei/cascading-rules/subdomain_http.yaml
@@ -5,18 +5,29 @@
 apiVersion: "cascading.securecodebox.io/v1"
 kind: CascadingRule
 metadata:
-  name: "nuclei-subdomain-scan-light"
+  name: "nuclei-subdomain-scan-light-http"
   labels:
     securecodebox.io/invasive: non-invasive
     securecodebox.io/intensive: light
 spec:
   matches:
     anyOf:
-      - category: "Subdomain"
-        osi_layer: "NETWORK"
+      - category: "Open Port"
+        attributes:
+          port: 80
+          state: open
+      - category: "Open Port"
+        attributes:
+          service: "http"
+          state: open
+      - category: "Open Port"
+        attributes:
+          service: "http-*"
+          state: open
+      
   scanSpec:
     scanType: "nuclei"
     parameters:
       # Target domain name of the finding and start a nuclei scan
       - "-u"
-      - "{{location}}"
+      - "http://{{$.hostOrIP}}:{{attributes.port}}"

--- a/scanners/nuclei/cascading-rules/subdomain_https.yaml
+++ b/scanners/nuclei/cascading-rules/subdomain_https.yaml
@@ -1,0 +1,32 @@
+# SPDX-FileCopyrightText: 2021 iteratec GmbH
+#
+# SPDX-License-Identifier: Apache-2.0
+
+apiVersion: "cascading.securecodebox.io/v1"
+kind: CascadingRule
+metadata:
+  name: "nuclei-subdomain-scan-light-https"
+  labels:
+    securecodebox.io/invasive: non-invasive
+    securecodebox.io/intensive: light
+spec:
+  matches:
+    anyOf:
+      - category: "Open Port"
+        attributes:
+          port: 443
+          state: open
+      - category: "Open Port"
+        attributes:
+          service: "https"
+          state: open
+      - category: "Open Port"
+        attributes:
+          service: "https*"
+          state: open
+  scanSpec:
+    scanType: "nuclei"
+    parameters:
+      # Target domain name of the finding and start a nuclei scan
+      - "-u"
+      - "https://{{$.hostOrIP}}:{{attributes.port}}"


### PR DESCRIPTION
The nuclei rule had problems because it omitted the protocol and port information (#713). This PR splits it into two separate rules, one for http and one for https. This should make it more robust.

An alternative that would only require a single rule would be the following:

```yaml
# SPDX-FileCopyrightText: 2021 iteratec GmbH
#
# SPDX-License-Identifier: Apache-2.0

apiVersion: "cascading.securecodebox.io/v1"
kind: CascadingRule
metadata:
  name: "nuclei-subdomain-scan-light"
  labels:
    securecodebox.io/invasive: non-invasive
    securecodebox.io/intensive: light
spec:
  matches:
    anyOf:
      - category: "Open Port"
        attributes:
          port: 80
          state: open
      - category: "Open Port"
        attributes:
          port: 443
          state: open
      - category: "Open Port"
        attributes:
          service: "http"
          state: open
      - category: "Open Port"
        attributes:
          service: "https"
          state: open
      
  scanSpec:
    scanType: "nuclei"
    parameters:
      # Target domain name of the finding and start a nuclei scan
      - "-u"
      - "{{attributes.service}}://{{$.hostOrIP}}:{{attributes.port}}"
```

However, this would no longer allow us to trigger on alternative HTTP(S) ports like 8080, 8443, etc., since they have alternative service descriptors (`http-proxy`, ...) which would break the URL when based on `{{attributes.service}}` as the protocol selector. I thus opted to split it into two separate rules.

Closes #713.

### Checklist

* [x] Test your changes as thoroughly as possible before you commit them. Preferably, automate your test by unit/integration tests.
* [x] Make sure `npm test` runs for the whole project.
* [x] Make codeclimate checks happy
