### PR TITLE
Update ZAP cascading rule to support non-standard http(s) ports

### DIFF
--- a/scanners/zap/cascading-rules/https.yaml
+++ b/scanners/zap/cascading-rules/https.yaml
@@ -5,7 +5,7 @@
 apiVersion: "cascading.securecodebox.io/v1"
 kind: CascadingRule
 metadata:
-  name: "zap-http"
+  name: "zap-https"
   labels:
     securecodebox.io/invasive: non-invasive
     securecodebox.io/intensive: medium
@@ -14,12 +14,8 @@ spec:
     anyOf:
       - category: "Open Port"
         attributes:
-          service: http
-          state: open
-      - category: "Open Port"
-        attributes:
-          service: http-*
+          service: "https*"
           state: open
   scanSpec:
     scanType: "zap-baseline-scan"
-    parameters: ["-t", "http://{{$.hostOrIP}}:{{attributes.port}}"]
+    parameters: ["-t", "https://{{$.hostOrIP}}:{{attributes.port}}"]

--- a/scanners/zap/integration-tests/zap.test.js
+++ b/scanners/zap/integration-tests/zap.test.js
@@ -17,9 +17,9 @@ test(
     expect(categories).toMatchInlineSnapshot(`
       Object {
         "Content Security Policy (CSP) Header Not Set": 1,
+        "Missing Anti-clickjacking Header": 1,
         "Server Leaks Version Information via \\"Server\\" HTTP Response Header Field": 1,
         "X-Content-Type-Options Header Missing": 1,
-        "X-Frame-Options Header Not Set": 1,
       }
     `);
     expect(severities).toMatchInlineSnapshot(`


### PR DESCRIPTION
Analogous to #920, this commit splits the cascading rule for ZAP into two: one for HTTP and one for HTTPS. This allows it to cover HTTP(S) services on nonstandard ports. This also requires adding the port as an extra parameter, which is also done in this change.

Also updates the integration test to work with the current version of ZAP plugins (started failing without any changes on our end).

### Checklist

* [x] Test your changes as thoroughly as possible before you commit them. Preferably, automate your test by unit/integration tests.
* [x] Make sure `npm test` runs for the whole project.
* [x] Make codeclimate checks happy
