### PR TITLE
Fix logging of cascading scan name

### DIFF
--- a/hooks/cascading-scans/hook/scan-helpers.ts
+++ b/hooks/cascading-scans/hook/scan-helpers.ts
@@ -139,7 +139,7 @@ export async function startSubsequentSecureCodeBoxScan(scan: Scan) {
 
   try {
     // Submitting the Scan to the kubernetes api
-    await k8sApiCRD.createNamespacedCustomObject(
+    const createdScan = await k8sApiCRD.createNamespacedCustomObject(
       "execution.securecodebox.io",
       "v1",
       namespace,
@@ -147,6 +147,7 @@ export async function startSubsequentSecureCodeBoxScan(scan: Scan) {
       scan,
       "false"
     );
+    console.log(`-> Created scan ${createdScan.body["metadata"].name}`)
   } catch (error) {
     console.error(`Failed to start Scan ${scan.metadata.generateName}`);
     console.error(error);

--- a/hooks/cascading-scans/hook/scan-helpers.ts
+++ b/hooks/cascading-scans/hook/scan-helpers.ts
@@ -135,7 +135,7 @@ export function mergeInheritedSelector(parentSelector: LabelSelector = {}, ruleS
 }
 
 export async function startSubsequentSecureCodeBoxScan(scan: Scan) {
-  console.log(`Starting Scan ${scan.metadata.name}`);
+  console.log(`Starting Scan ${scan.metadata.generateName}`);
 
   try {
     // Submitting the Scan to the kubernetes api
@@ -148,7 +148,7 @@ export async function startSubsequentSecureCodeBoxScan(scan: Scan) {
       "false"
     );
   } catch (error) {
-    console.error(`Failed to start Scan ${scan.metadata.name}`);
+    console.error(`Failed to start Scan ${scan.metadata.generateName}`);
     console.error(error);
   }
 }


### PR DESCRIPTION
The cascading hook had a problem with logging the name of the cascaded scan (it was using a key that was undefined at the time it was used). This PR switches it to use the `metadata.generateName` key. The disadvantage of this approach is that it does not show the suffix that Kubernetes generates for the scan name - it will only log the combined scan name from parent and cascaded scan, but not the four-letter suffixes that are appended automatically. If there is a way to get these into the name as well, let me know, but I don't think there is (and, [judging from the Git history, this was also the behavior before it broke](https://github.com/secureCodeBox/secureCodeBox/blame/b38d8cffb2cd4b7b8139a564ce99981a31e5d53d/hooks/declarative-subsequent-scans/scan-helpers.ts#L80-L124)).

Closes #921.

### Checklist

* [x] Test your changes as thoroughly as possible before you commit them. Preferably, automate your test by unit/integration tests.
* [x] Make sure `npm test` runs for the whole project.
* [x] Make codeclimate checks happy
