### PR TITLE
Remove JCenter Repo from DefectDojo Hook

### DIFF
--- a/hooks/persistence-defectdojo/hook/build.gradle
+++ b/hooks/persistence-defectdojo/hook/build.gradle
@@ -13,7 +13,6 @@ sourceCompatibility = '11'
 
 repositories {
 	mavenCentral()
-  jcenter()
   maven {
     url = "https://oss.sonatype.org/content/repositories/snapshots/"
   }


### PR DESCRIPTION
We don't acutally seem to be using any dependencies from the repo.
The repo is currently not working correctly and is scheduled for shutdown on 1.2.2022.