### PR TITLE
Fix Email Reciever Field in Notification Hook

### DIFF
--- a/hooks/notification/.helm-docs.gotmpl
+++ b/hooks/notification/.helm-docs.gotmpl
@@ -252,7 +252,11 @@ notificationChannels:
     endPoint: "someone@somewhere.xyz"
 env:
   - name: SMTP_CONFIG
-    value: "smtp://user:pass@smtp.domain.tld/"
+    # you can create the secret via: kubectl create secret generic email-credentials-token --from-literal="smtp-config=smtp://user:pass@smtp.domain.tld/"
+    valueFrom:
+      secretKeyRef:
+        name: email-credentials
+        key: smtp-config
 ```
 
 To provide a custom `from` field for your email you can specify `EMAIL_FROM` under env.
@@ -261,7 +265,10 @@ For example:
 ```
 env:
   - name: SMTP_CONFIG
-    value: "smtp://user:pass@smtp.domain.tld/"
+    valueFrom:
+      secretKeyRef:
+        name: email-credentials
+        key: smtp-config
   - name: EMAIL_FROM
     value: secureCodeBox
 ```

--- a/hooks/notification/.helm-docs.gotmpl
+++ b/hooks/notification/.helm-docs.gotmpl
@@ -252,7 +252,7 @@ notificationChannels:
     endPoint: "someone@somewhere.xyz"
 env:
   - name: SMTP_CONFIG
-    # you can create the secret via: kubectl create secret generic email-credentials-token --from-literal="smtp-config=smtp://user:pass@smtp.domain.tld/"
+    # you can create the secret via: kubectl create secret generic email-credentials --from-literal="smtp-config=smtp://user:pass@smtp.domain.tld/"
     valueFrom:
       secretKeyRef:
         name: email-credentials

--- a/hooks/notification/README.md
+++ b/hooks/notification/README.md
@@ -271,7 +271,7 @@ notificationChannels:
     endPoint: "someone@somewhere.xyz"
 env:
   - name: SMTP_CONFIG
-    # you can create the secret via: kubectl create secret generic email-credentials-token --from-literal="smtp-config=smtp://user:pass@smtp.domain.tld/"
+    # you can create the secret via: kubectl create secret generic email-credentials --from-literal="smtp-config=smtp://user:pass@smtp.domain.tld/"
     valueFrom:
       secretKeyRef:
         name: email-credentials

--- a/hooks/notification/README.md
+++ b/hooks/notification/README.md
@@ -271,7 +271,11 @@ notificationChannels:
     endPoint: "someone@somewhere.xyz"
 env:
   - name: SMTP_CONFIG
-    value: "smtp://user:pass@smtp.domain.tld/"
+    # you can create the secret via: kubectl create secret generic email-credentials-token --from-literal="smtp-config=smtp://user:pass@smtp.domain.tld/"
+    valueFrom:
+      secretKeyRef:
+        name: email-credentials
+        key: smtp-config
 ```
 
 To provide a custom `from` field for your email you can specify `EMAIL_FROM` under env.
@@ -280,7 +284,10 @@ For example:
 ```
 env:
   - name: SMTP_CONFIG
-    value: "smtp://user:pass@smtp.domain.tld/"
+    valueFrom:
+      secretKeyRef:
+        name: email-credentials
+        key: smtp-config
   - name: EMAIL_FROM
     value: secureCodeBox
 ```

--- a/hooks/notification/docs/README.ArtifactHub.md
+++ b/hooks/notification/docs/README.ArtifactHub.md
@@ -279,7 +279,11 @@ notificationChannels:
     endPoint: "someone@somewhere.xyz"
 env:
   - name: SMTP_CONFIG
-    value: "smtp://user:pass@smtp.domain.tld/"
+    # you can create the secret via: kubectl create secret generic email-credentials-token --from-literal="smtp-config=smtp://user:pass@smtp.domain.tld/"
+    valueFrom:
+      secretKeyRef:
+        name: email-credentials
+        key: smtp-config
 ```
 
 To provide a custom `from` field for your email you can specify `EMAIL_FROM` under env.
@@ -288,7 +292,10 @@ For example:
 ```
 env:
   - name: SMTP_CONFIG
-    value: "smtp://user:pass@smtp.domain.tld/"
+    valueFrom:
+      secretKeyRef:
+        name: email-credentials
+        key: smtp-config
   - name: EMAIL_FROM
     value: secureCodeBox
 ```

--- a/hooks/notification/docs/README.ArtifactHub.md
+++ b/hooks/notification/docs/README.ArtifactHub.md
@@ -279,7 +279,7 @@ notificationChannels:
     endPoint: "someone@somewhere.xyz"
 env:
   - name: SMTP_CONFIG
-    # you can create the secret via: kubectl create secret generic email-credentials-token --from-literal="smtp-config=smtp://user:pass@smtp.domain.tld/"
+    # you can create the secret via: kubectl create secret generic email-credentials --from-literal="smtp-config=smtp://user:pass@smtp.domain.tld/"
     valueFrom:
       secretKeyRef:
         name: email-credentials

--- a/hooks/notification/hook/Notifiers/AbstractNotifier.ts
+++ b/hooks/notification/hook/Notifiers/AbstractNotifier.ts
@@ -42,6 +42,18 @@ export abstract class AbstractNotifier implements Notifier {
     return JSON.stringify(this.renderYamlTemplate());
   }
 
+
+  /**
+   * By default the value of the endpoint channel config is mapped to a environment variable to be able to store these values securely
+   * This behavior can be overwritten for hooks where it doesn't make sense as the endpoint is not considered sensitive.
+   * 
+   * @param envName value of the channels endpoint
+   * @returns string actual EndPoint value
+   */
+  public resolveEndPoint(): string {
+    return process.env[this.channel.endPoint];
+  }
+
   protected renderYamlTemplate(): any {
     nunjucks.configure(AbstractNotifier.TEMPLATE_DIR);
     const renderedTemplate = nunjucks.render(

--- a/hooks/notification/hook/Notifiers/AbstractWebHookNotifier.ts
+++ b/hooks/notification/hook/Notifiers/AbstractWebHookNotifier.ts
@@ -23,7 +23,7 @@ export abstract class AbstractWebHookNotifier extends AbstractNotifier {
 
   protected async sendPostRequest(message: string) {
     try {
-      await axios.post(this.channel.endPoint, message)
+      await axios.post(this.resolveEndPoint(), message)
     } catch (e) {
       console.log(`There was an Error sending the Message for the "${this.type}": "${this.channel.name}"`);
       console.log(e);

--- a/hooks/notification/hook/Notifiers/EMailNotifier.test.ts
+++ b/hooks/notification/hook/Notifiers/EMailNotifier.test.ts
@@ -100,7 +100,7 @@ A Client Error response code was returned by the server: 1<br>
 Information Disclosure - Sensitive Information in URL: 1<br>
 Strict-Transport-Security Header Not Set: 1<br>
 `,
-    subject: "New nmap security scan resulsts are available!",
+    subject: "New nmap security scan results are available!",
     text: `*Scan demo-scan-1601086432*
 Created at ${creationTimestamp.toString()}
 

--- a/hooks/notification/hook/Notifiers/EMailNotifier.test.ts
+++ b/hooks/notification/hook/Notifiers/EMailNotifier.test.ts
@@ -21,6 +21,8 @@ jest.mock("nodemailer", () => {
   };
 });
 
+const creationTimestamp = new Date("2021-01-01T14:29:25Z")
+
 test("Should Send Mail", async () => {
   const from = "secureCodeBox";
   const smtp = "smtp://user:pass@smtp.ethereal.email/";
@@ -37,7 +39,7 @@ test("Should Send Mail", async () => {
       uid: "09988cdf-1fc7-4f85-95ee-1b1d65dbc7cc",
       name: "demo-scan-1601086432",
       namespace: "my-scans",
-      creationTimestamp: new Date("2021-01-01T14:29:25Z"),
+      creationTimestamp,
       labels: {
         company: "iteratec",
         "attack-surface": "external",
@@ -83,7 +85,7 @@ test("Should Send Mail", async () => {
   expect(sendMail).toBeCalledWith({
     from: "secureCodeBox",
     html: `<strong>Scan demo-scan-1601086432</strong><br>
-Created at Fri Jan 01 2021 15:29:25 GMT+0100 (Central European Standard Time)
+Created at ${creationTimestamp.toString()}
 <br>
 <br>
 <strong>Findings Severity Overview:</strong><br>
@@ -100,7 +102,7 @@ Strict-Transport-Security Header Not Set: 1<br>
 `,
     subject: "New nmap security scan resulsts are available!",
     text: `*Scan demo-scan-1601086432*
-Created at Fri Jan 01 2021 15:29:25 GMT+0100 (Central European Standard Time)
+Created at ${creationTimestamp.toString()}
 
 *Findings Severity Overview*:
 high: 10

--- a/hooks/notification/hook/Notifiers/EMailNotifier.test.ts
+++ b/hooks/notification/hook/Notifiers/EMailNotifier.test.ts
@@ -80,6 +80,40 @@ test("Should Send Mail", async () => {
 
   await notifier.sendMessage();
 
-  expect(sendMail).toBeCalled();
+  expect(sendMail).toBeCalledWith({
+    from: "secureCodeBox",
+    html: `<strong>Scan demo-scan-1601086432</strong><br>
+Created at Fri Jan 01 2021 15:29:25 GMT+0100 (Central European Standard Time)
+<br>
+<br>
+<strong>Findings Severity Overview:</strong><br>
+high: 10<br>
+medium: 5<br>
+low: 2<br>
+informational: 1<br>
+
+<br>
+<strong>Findings Category Overview:</strong><br>
+A Client Error response code was returned by the server: 1<br>
+Information Disclosure - Sensitive Information in URL: 1<br>
+Strict-Transport-Security Header Not Set: 1<br>
+`,
+    subject: "New nmap security scan resulsts are available!",
+    text: `*Scan demo-scan-1601086432*
+Created at Fri Jan 01 2021 15:29:25 GMT+0100 (Central European Standard Time)
+
+*Findings Severity Overview*:
+high: 10
+medium: 5
+low: 2
+informational: 1
+
+*Findings Category Overview*:
+A Client Error response code was returned by the server: 1
+Information Disclosure - Sensitive Information in URL: 1
+Strict-Transport-Security Header Not Set: 1
+`,
+    to: "mail@some.email",
+  });
   expect(close).toBeCalled();
 });

--- a/hooks/notification/hook/Notifiers/EMailNotifier.test.ts
+++ b/hooks/notification/hook/Notifiers/EMailNotifier.test.ts
@@ -16,21 +16,21 @@ jest.mock("nodemailer", () => {
       return {
         sendMail,
         close,
-      }
-    }
+      };
+    },
   };
 });
 
 test("Should Send Mail", async () => {
   const from = "secureCodeBox";
-  const smtp = "smtp://user:pass@smtp.ethereal.email/"
+  const smtp = "smtp://user:pass@smtp.ethereal.email/";
   process.env[EMailNotifier.SMTP_CONFIG] = smtp;
   const channel: NotificationChannel = {
     name: "Channel Name",
     type: NotifierType.EMAIL,
     template: "email",
     rules: [],
-    endPoint: "mail@some.email"
+    endPoint: "mail@some.email",
   };
   const scan: Scan = {
     metadata: {
@@ -82,5 +82,4 @@ test("Should Send Mail", async () => {
 
   expect(sendMail).toBeCalled();
   expect(close).toBeCalled();
-
-})
+});

--- a/hooks/notification/hook/Notifiers/EMailNotifier.ts
+++ b/hooks/notification/hook/Notifiers/EMailNotifier.ts
@@ -11,6 +11,13 @@ export class EMailNotifier extends AbstractNotifier {
   public static readonly EMAIL_FROM = 'EMAIL_FROM';
   protected type: NotifierType.EMAIL;
 
+  /**
+   * Emails endPoints are not considered sensitive as they are just the receiver of the email.
+   */
+  public resolveEndPoint(): string {
+    return this.channel.endPoint;
+  }
+
   public async sendMessage(): Promise<void> {
     const message = this.prepareMessage();
     const smtpConfig = this.getSMTPConfig();

--- a/hooks/notification/hook/Notifiers/EMailNotifier.ts
+++ b/hooks/notification/hook/Notifiers/EMailNotifier.ts
@@ -35,7 +35,7 @@ export class EMailNotifier extends AbstractNotifier {
 
   private prepareMessage(): any {
     const message = JSON.parse(this.renderMessage());
-    message.to = this.channel.endPoint;
+    message.to = this.resolveEndPoint();
     message.from = this.args[EMailNotifier.EMAIL_FROM];
     return message;
   }

--- a/hooks/notification/hook/hook.ts
+++ b/hooks/notification/hook/hook.ts
@@ -17,7 +17,6 @@ export async function handle({ getFindings, scan }) {
   let notificationChannels: NotificationChannel[] = getNotificationChannels(CHANNEL_FILE);
   let args: Object = getArgs();
   for (const channel of notificationChannels) {
-    channel.endPoint = mapToEndPoint(channel.endPoint);
     const findingsToNotify = findings.filter(finding => matches(finding, channel.rules));
 
     if (channel.skipNotificationOnZeroFindings === true && findingsToNotify.length === 0) {

--- a/hooks/notification/hook/notification-templates/email.njk
+++ b/hooks/notification/hook/notification-templates/email.njk
@@ -3,7 +3,7 @@ SPDX-FileCopyrightText: 2021 iteratec GmbH
 
 SPDX-License-Identifier: Apache-2.0
 #}
-subject: New {{ scan.spec.scanType }} security scan resulsts are available!
+subject: New {{ scan.spec.scanType }} security scan results are available!
 text: |
   *Scan {{ scan.metadata.name }}*
   Created at {{ scan.metadata.creationTimestamp }}


### PR DESCRIPTION
## Description

The Email Notifier of the Notification Hook currently behaves differently as described in the Docs.
The docs indicate that `channel.endPoint` is supposed to be email recipient for the notification but actually has to be the name of a `env` var which then contains the email address.
This is a feature was added for the Slack & Microsoft Teams Notifier as these use webhook urls containing sensitive tokens.

I've updated the implementation to behave like the documentation.

### Checklist

* [x] Test your changes as thoroughly as possible before you commit them. Preferably, automate your test by unit/integration tests.
* [x] Make sure `npm test` runs for the whole project.
* [x] Make codeclimate checks happy
