### PR TITLE
Trigger CI pipeline nightly build with zap-advanced tests

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -3,7 +3,10 @@
 # SPDX-License-Identifier: Apache-2.0
 
 name: "CI"
-on: push
+on: 
+  push:
+  schedule:
+    - cron: "15 2 * * *" # Nightly-Build at 2:15 AM UTC
 
 env:
   # ---- Language Versions ----
@@ -892,7 +895,7 @@ jobs:
 
       - name: "ZAP Extended Integration Tests"
         # disable zap extended test temporarily as they slow down the pipeline too much
-        if: ${{ false }}
+        if: ${{ github.event_name == 'schedule' }}
         run: |
           kubectl -n integration-tests delete scans --all
           helm -n integration-tests install zap-advanced ./scanners/zap-advanced/  \


### PR DESCRIPTION
Signed-off-by: Rami Souai <rami.souai@iteratec.com>

<!-- 
Thank you for your contribution to our Project 🙌 

Before submitting your Pull Request, please take the time to check the points below and provide some descriptive information.
* [ ] If this PR comes from a fork, please [Allow edits from maintainers](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork)
* [ ] Set a meaningful title. Format: {task_name} (closes #{issue_number}). For example: Use logger (closes #41)
* [ ] [Link your Pull Request to an issue](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) (if applicable)
* [ ] Create Draft pull requests if you need clarification or an explicit review before you can continue your work item.
* [ ] Make sure that your PR is not introducing _unnecessary_ reformatting (e.g., introduced by on-save hooks in your IDE)
* [ ] Make sure each new source file you add has a correct license header.
-->

## Description
<!-- Please be brief in describing which issue is solved by your PR or which enhancement it brings -->
Closes #963 
Adds a schedule event to the github actions to trigger nightly builds (set at 2:15 AM UTC). 
Also re-enables zap-advanced inegration tests and only triggers them on the nightly build.
### Checklist

* [ ] Test your changes as thoroughly as possible before you commit them. Preferably, automate your test by unit/integration tests.
* [ ] Make sure `npm test` runs for the whole project.
* [ ] Make codeclimate checks happy
