### PR TITLE
Remove codeclimate from PR template checklist

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -18,4 +18,3 @@ Before submitting your Pull Request, please take the time to check the points be
 
 * [ ] Test your changes as thoroughly as possible before you commit them. Preferably, automate your test by unit/integration tests.
 * [ ] Make sure `npm test` runs for the whole project.
-* [ ] Make codeclimate checks happy


### PR DESCRIPTION
Since there is no way to know if the codeclimate checks will be successful before opening the PR, it doesn't make sense to ask people to check this. If codeclimate is unhappy, it will let us know and block the merge.

### Checklist

* [x] Test your changes as thoroughly as possible before you commit them. Preferably, automate your test by unit/integration tests.
* [x] Make sure `npm test` runs for the whole project.
* [x] Make codeclimate checks happy 😬 
