### PR TITLE
ZapAdvanced Enforced Spider Timeouts

### DIFF
--- a/scanners/zap-advanced/scanner/zapclient/spider/zap_abstract_spider.py
+++ b/scanners/zap-advanced/scanner/zapclient/spider/zap_abstract_spider.py
@@ -8,6 +8,7 @@
 
 import collections
 import logging
+import time
 
 from abc import abstractmethod
 from zapv2 import ZAPv2, spider
@@ -104,8 +105,25 @@ class ZapConfigureSpider(ZapClient):
             The spider configuration based on ZapConfiguration.
         """
         raise NotImplementedError
-    
+
     @abstractmethod
-    def wait_until_spider_finished(self):
-        """ Wait until the running ZAP Spider finished and log results."""
+    def check_if_spider_completed(self):
+        """Method to ask ZAP Api if the Spider has completed.
+
+        Returns
+        -------
+        true: if spider has completed
+        false: if spider is still working
+        """
         raise NotImplementedError
+
+    @abstractmethod
+    def print_spider_summary(self):
+        """Method to print out a summary of the spider results"""
+        raise NotImplementedError
+
+    def wait_until_spider_finished(self):
+        while self.check_if_spider_completed() is not True:
+            time.sleep(1)
+
+        self.print_spider_summary()

--- a/scanners/zap-advanced/scanner/zapclient/spider/zap_spider_ajax.py
+++ b/scanners/zap-advanced/scanner/zapclient/spider/zap_spider_ajax.py
@@ -180,3 +180,6 @@ class ZapConfigureSpiderAjax(ZapConfigureSpider):
             logging.info("Ajax Spider found total: %s URLs", str(num_urls))
             for url in self.get_zap_spider.results():
                 logging.debug("URL: %s", url['requestHeader'])
+
+    def stop_spider(self):
+        self.get_zap_spider.stop()

--- a/scanners/zap-advanced/scanner/zapclient/spider/zap_spider_ajax.py
+++ b/scanners/zap-advanced/scanner/zapclient/spider/zap_spider_ajax.py
@@ -159,21 +159,23 @@ class ZapConfigureSpiderAjax(ZapConfigureSpider):
                 method_name="set_option_random_inputs"
             )
 
-    def wait_until_spider_finished(self):
-        """ Wait until the running ZAP Spider finished and log results."""
+    def check_if_spider_completed(self):
+        finished = self.get_zap_spider.status != 'running'
+        logging.info('Ajax Spider running, found urls: %s', self.get_zap_spider.number_of_results)
+        return finished
 
-        if(self.get_zap_spider.status == 'running'):
-            while (self.get_zap_spider.status == 'running'):
-                logging.info('Ajax Spider running, found urls: %s', self.get_zap_spider.number_of_results)
-                time.sleep(1)
+    def print_spider_summary(self):
+        """Method to print out a summary of the spider results"""
 
-            logging.info('Ajax Spider complete')
+        logging.info('Ajax Spider complete')
 
         # Print out a count of the number of urls
         num_urls = len(self.get_zap.core.urls())
         if num_urls == 0:
-            logging.error("No URLs found - is the target URL accessible? Local services may not be accessible from the Docker container")
-            raise RuntimeError('No URLs found by ZAP Spider :-( - is the target URL accessible? Local services may not be accessible from the Docker container')
+            logging.error(
+                "No URLs found - is the target URL accessible? Local services may not be accessible from the Docker container")
+            raise RuntimeError(
+                'No URLs found by ZAP Spider :-( - is the target URL accessible? Local services may not be accessible from the Docker container')
         else:
             logging.info("Ajax Spider found total: %s URLs", str(num_urls))
             for url in self.get_zap_spider.results():

--- a/scanners/zap-advanced/scanner/zapclient/spider/zap_spider_http.py
+++ b/scanners/zap-advanced/scanner/zapclient/spider/zap_spider_http.py
@@ -258,3 +258,6 @@ class ZapConfigureSpiderHttp(ZapConfigureSpider):
             for url in self.get_zap_spider.results(scanid=self.get_spider_id):
                 logging.info("Spidered URL: %s", url)
             logging.info("Spider(%s) found total: %s URLs", str(self.get_spider_id), str(num_urls))
+
+    def stop_spider(self):
+        self.get_zap_spider.stop()

--- a/scanners/zap-advanced/scanner/zapclient/spider/zap_spider_http.py
+++ b/scanners/zap-advanced/scanner/zapclient/spider/zap_spider_http.py
@@ -241,20 +241,15 @@ class ZapConfigureSpiderHttp(ZapConfigureSpider):
                 method_name="set_option_user_agent"
             )
 
-    def wait_until_spider_finished(self):
-        """ Wait until the running ZAP HTTP Spider finished and log results."""
+    def check_if_spider_completed(self):
+        progress = int(self.get_zap_spider.status(self.get_spider_id))
+        logging.info("HTTP Spider(%d) progress: %d", self.get_spider_id, progress)
+        return progress >= 100
 
-        if self.has_spider_id:
-            while int(self.get_zap_spider.status(self.get_spider_id)) < 100:
-                logging.info("HTTP Spider(%s) progress: %s", str(self.get_spider_id), str(self.get_zap_spider.status(self.get_spider_id)))
-                time.sleep(1)
-                
-            logging.info("HTTP Spider(%s) completed", str(self.get_spider_id))
+    def print_spider_summary(self):
+        """Method to print out a summary of the spider results"""
+        logging.info("HTTP Spider(%s) completed", str(self.get_spider_id))
 
-            self.__log_statistics()
-
-    def __log_statistics(self):
-        # Print out a count of the number of urls
         num_urls = len(self.get_zap.core.urls())
         if num_urls == 0:
             logging.error("No URLs found - is the target URL accessible? Local services may not be accessible from the Docker container.")


### PR DESCRIPTION
## Description

This PR enforces the max duration feature of ZAP if ZAP is unable to do it by its own.
This prevents Scenarios where scans are stuck endlessly in the spidering phase.

To make this easier I have refactored the spider waiting logic so that the waiting is handled by the parent class shared by the traditional and ajax spider. (b039dd95d1d77af05cfdcff9601ba1e7d9174d88)
This was required to implement the maxDuration logic for both without duplicating the code.

This is unfortunately pretty hard to test as the cases where the Spider hangs are hard to reproduce.
I've tested the enforcement logic locally by overwriting the maxDuration set for ZAP to a much higher value so that the ZapAdvanced maxDuration enforcement mechanism could kick in.

### Checklist

* [x] Test your changes as thoroughly as possible before you commit them. Preferably, automate your test by unit/integration tests.
* [x] Make sure `npm test` runs for the whole project.
