### PR TITLE
Migrate Zap Advanced to ZAPs new Reporting Addon

### DIFF
--- a/scanners/zap-advanced/scanner/Dockerfile
+++ b/scanners/zap-advanced/scanner/Dockerfile
@@ -2,7 +2,7 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-FROM python:3.9.0-alpine
+FROM python:3.10.2-alpine
 COPY . /zap-client/
 RUN pip3 install -r /zap-client/requirements.txt
 RUN addgroup --system --gid 1001 zap-client && adduser zap-client --system --uid 1001 --ingroup zap-client

--- a/scanners/zap-advanced/scanner/requirements.txt
+++ b/scanners/zap-advanced/scanner/requirements.txt
@@ -2,6 +2,6 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-python-owasp-zap-v2.4==0.0.18
+python-owasp-zap-v2.4==0.0.20
 HiYaPyCo==0.4.16
 MarkupSafe==2.0.1

--- a/scanners/zap-advanced/scanner/zapclient/zap_automation.py
+++ b/scanners/zap-advanced/scanner/zapclient/zap_automation.py
@@ -143,45 +143,34 @@ class ZapAutomation:
         # Search for the corresponding context based on the given targetUrl which should correspond to defined the spider url
         self.__zap_scanner.start_scan_by_url(target)
 
+    def get_report_template_for_file_type(self, file_type: str):
+        if file_type == "XML":
+            return "traditional-xml"
+        elif file_type == "JSON":
+            return "traditional-json"
+        elif file_type == "HTML":
+            return "traditional-html"
+        elif file_type == "MD":
+            return "traditional-md"
+        else:
+            raise RuntimeError(
+                "Report file type: '" + file_type + "' hasn't been implemented. Available: XML, JSON, HTML or MD")
+
     def generate_report_file(self, file_path: str, report_type: str):
         # To retrieve ZAP report in XML or HTML format
         logging.info("Creating a new ZAP Report file with type '%s' at location: '%s'", report_type, file_path)
         
-        # To retrieve ZAP report in XML or HTML format
-        logging.info('Creating a new ZAP Report with type %s', report_type)
-        if report_type is None or report_type == "XML":
-            # Save the XML report (default)
-            self.__write_report(
-                self.__zap.core.xmlreport(),
-                file_path,
-                "xml"
-            )
-        if report_type is None or report_type == "HTML":
-            # Get the HTML report
-            self.__write_report(
-                self.__zap.core.htmlreport(),
-                file_path,
-                "html"
-            )
-        if report_type is None or report_type == "JSON":
-            # Get the JSON report
-            self.__write_report(
-                self.__zap.core.jsonreport(),
-                file_path,
-                "json"
-            )
-        if report_type is None or report_type == "MD":
-            # Get the Markdown report
-            self.__write_report(
-                self.__zap.core.mdreport(),
-                file_path,
-                "md"
-            )
-    
-    def __write_report(self, report, file_path:str, filetype:str):
-        Path(file_path).mkdir(parents=True, exist_ok=True)
-        with open(f'{file_path}/zap-results.{filetype}', mode='w') as f:
-            f.write(report)
+        if report_type is None:
+            report_type = "XML"
+
+        report_file = "zap-results." + report_type.lower()
+        self.__zap.reports.generate(
+            title="ZAP Report",
+            template=self.get_report_template_for_file_type(report_type),
+            reportdir=file_path,
+            contexts=self.__config.get_active_context_config["name"],
+            reportfilename=report_file
+        )
     
     def wait_for_zap_start(self, timeout_in_secs = 600):
         version = None

--- a/scanners/zap-advanced/templates/zap-advanced-scan-type.yaml
+++ b/scanners/zap-advanced/templates/zap-advanced-scan-type.yaml
@@ -31,7 +31,7 @@ metadata:
 spec:
   extractResults:
     type: zap-advanced-xml
-    location: "/home/securecodebox/results/zap-results.xml"
+    location: "/home/securecodebox/zap-results.xml"
   jobTemplate:
     spec:
       {{- if .Values.scanner.ttlSecondsAfterFinished }}
@@ -65,7 +65,7 @@ spec:
                 - "--config-folder"
                 - "/home/securecodebox/configs/"
                 - "--output-folder"
-                - "/home/securecodebox/results/"
+                - "/home/securecodebox/"
               resources:
                 {{- toYaml .Values.scanner.resources | nindent 16 }}
               securityContext:
@@ -111,7 +111,12 @@ spec:
               envFrom:
                 {{- toYaml .Values.zapContainer.envFrom | nindent 16 }}
               volumeMounts:
+                - mountPath: /home/securecodebox/
+                  name: scan-results
+                  readOnly: false
+                {{ if .Values.zapContainer.extraVolumeMounts }}
                 {{- toYaml .Values.zapContainer.extraVolumeMounts | nindent 16 }}
+                {{- end }}
               ports:
                 - containerPort: 8080
             {{- if .Values.zapContainer.extraContainers }}

--- a/scanners/zap-advanced/templates/zap-advanced-scan-type.yaml
+++ b/scanners/zap-advanced/templates/zap-advanced-scan-type.yaml
@@ -112,10 +112,10 @@ spec:
                 {{- toYaml .Values.zapContainer.envFrom | nindent 16 }}
               volumeMounts:
                 {{- toYaml .Values.zapContainer.extraVolumeMounts | nindent 16 }}
-              {{- if .Values.zapContainer.extraContainers }}
-              {{- toYaml .Values.zapContainer.extraContainers | nindent 12 }}
-              {{- end }}
               ports:
                 - containerPort: 8080
+            {{- if .Values.zapContainer.extraContainers }}
+            {{- toYaml .Values.zapContainer.extraContainers | nindent 12 }}
+            {{- end }}
           volumes:
             {{- toYaml .Values.scanner.extraVolumes | nindent 12 }}


### PR DESCRIPTION
## Description

This PR migrates the Zap Advanced ScanType to use ZAPs new Reporting API.

This allows to properly scope the results to the configured context.

To allow this change we had to make some changes to the way results are passed to the secureCodeBox Lurker:

Previously the Results were fetched by the zap-advanced python script and written to disk. This is not possible with the new reporting addon as it only supports writing the report directly to disk and isn't returned in the api.
This limitation is worked around by mounting the zap-results volume also into the zap-sidecar so that zap can write the results directly to disk / the shared results volume.

### Checklist

* [x] Test your changes as thoroughly as possible before you commit them. Preferably, automate your test by unit/integration tests.
* [x] Make sure `npm test` runs for the whole project.
