### PR TITLE
Allow Volumes & VolumeMounts Config for AutoDiscovery Scans

### DIFF
--- a/auto-discovery/kubernetes/README.md
+++ b/auto-discovery/kubernetes/README.md
@@ -135,13 +135,13 @@ kubectl -n juice-shop annotate service juice-shop auto-discovery.securecodebox.i
 | config.apiVersion | string | `"config.securecodebox.io/v1"` |  |
 | config.cluster.name | string | `"docker-desktop"` |  |
 | config.containerAutoDiscovery.enabled | bool | `false` |  |
-| config.containerAutoDiscovery.scanConfig.annotations | object | `{}` | annotations to be added to the scans started by the auto-discovery all annotation values support templating |
-| config.containerAutoDiscovery.scanConfig.labels | object | `{}` | labels to be added to the scans started by the auto-discovery all label values support templating |
-| config.containerAutoDiscovery.scanConfig.parameters | list | `["{{ .ImageID }}"]` | parameters used for the scans created by the containerAutoDiscovery |
+| config.containerAutoDiscovery.scanConfig.annotations | object | `{}` | annotations to be added to the scans started by the auto-discovery, all annotation values support templating |
+| config.containerAutoDiscovery.scanConfig.labels | object | `{}` | labels to be added to the scans started by the auto-discovery, all label values support templating |
+| config.containerAutoDiscovery.scanConfig.parameters | list | `["{{ .ImageID }}"]` | parameters used for the scans created by the containerAutoDiscovery, all parameters support templating |
 | config.containerAutoDiscovery.scanConfig.repeatInterval | string | `"168h"` | interval in which scans are automatically repeated. If the target is updated (meaning a new image revision is deployed) the scan will repeated beforehand and the interval is reset. |
 | config.containerAutoDiscovery.scanConfig.scanType | string | `"trivy"` |  |
-| config.containerAutoDiscovery.scanConfig.volumeMounts | list | `[]` | volumes to add to the scan job, see: https://kubernetes.io/docs/reference/kubernetes-api/workload-resources/pod-v1/#volumes-1 the fields: `name`, `mountPath`, `subPath`, `subPathExpr` of each volumeMount support templating |
-| config.containerAutoDiscovery.scanConfig.volumes | list | `[]` | volumes to add to the scan job, see: https://kubernetes.io/docs/reference/kubernetes-api/workload-resources/pod-v1/#volumes-1 the fields: `name`, `secret.secretName`, `configMap.name` of each volume support templating |
+| config.containerAutoDiscovery.scanConfig.volumeMounts | list | `[]` | volumeMounts to add to the scan job, see: https://kubernetes.io/docs/reference/kubernetes-api/workload-resources/pod-v1/#volumes-1 the fields: `name`, `mountPath`, `subPath`, `subPathExpr` of each volumeMount support templating |
+| config.containerAutoDiscovery.scanConfig.volumes | list | `[]` | volumes to add to the scan job, see: https://kubernetes.io/docs/reference/kubernetes-api/workload-resources/pod-v1/#volumes the fields: `name`, `secret.secretName`, `configMap.name` of each volume support templating |
 | config.health.healthProbeBindAddress | string | `":8081"` |  |
 | config.kind | string | `"AutoDiscoveryConfig"` |  |
 | config.leaderElection.leaderElect | bool | `true` |  |
@@ -150,13 +150,13 @@ kubectl -n juice-shop annotate service juice-shop auto-discovery.securecodebox.i
 | config.resourceInclusion.mode | string | `"enabled-per-namespace"` |  |
 | config.serviceAutoDiscovery.enabled | bool | `true` |  |
 | config.serviceAutoDiscovery.passiveReconcileInterval | string | `"1m"` | interval in which every service is re-checked for updated pods, if service object is updated directly this the service will get reconciled immediately |
-| config.serviceAutoDiscovery.scanConfig.annotations | object | `{"defectdojo.securecodebox.io/engagement-name":"{{ .Target.Name }}","defectdojo.securecodebox.io/engagement-version":"{{if (index .Target.Labels `app.kubernetes.io/version`) }}{{ index .Target.Labels `app.kubernetes.io/version` }}{{end}}","defectdojo.securecodebox.io/product-name":"{{ .Cluster.Name }} | {{ .Namespace.Name }} | {{ .Target.Name }}","defectdojo.securecodebox.io/product-tags":"cluster/{{ .Cluster.Name }},namespace/{{ .Namespace.Name }}"}` | annotations to be added to the scans started by the auto-discovery all annotation values support templating |
-| config.serviceAutoDiscovery.scanConfig.labels | object | `{}` | labels to be added to the scans started by the auto-discovery all label values support templating |
-| config.serviceAutoDiscovery.scanConfig.parameters | list | `["-t","{{ .Host.Type }}://{{ .Service.Name }}.{{ .Service.Namespace }}.svc:{{ .Host.Port }}"]` | parameters used for the scans created by the serviceAutoDiscovery all parameters |
+| config.serviceAutoDiscovery.scanConfig.annotations | object | `{"defectdojo.securecodebox.io/engagement-name":"{{ .Target.Name }}","defectdojo.securecodebox.io/engagement-version":"{{if (index .Target.Labels `app.kubernetes.io/version`) }}{{ index .Target.Labels `app.kubernetes.io/version` }}{{end}}","defectdojo.securecodebox.io/product-name":"{{ .Cluster.Name }} | {{ .Namespace.Name }} | {{ .Target.Name }}","defectdojo.securecodebox.io/product-tags":"cluster/{{ .Cluster.Name }},namespace/{{ .Namespace.Name }}"}` | annotations to be added to the scans started by the auto-discovery, all annotation values support templating |
+| config.serviceAutoDiscovery.scanConfig.labels | object | `{}` | labels to be added to the scans started by the auto-discovery, all label values support templating |
+| config.serviceAutoDiscovery.scanConfig.parameters | list | `["-t","{{ .Host.Type }}://{{ .Service.Name }}.{{ .Service.Namespace }}.svc:{{ .Host.Port }}"]` | parameters used for the scans created by the serviceAutoDiscovery, all parameters support templating |
 | config.serviceAutoDiscovery.scanConfig.repeatInterval | string | `"168h"` | interval in which scans are automatically repeated. If the target is updated (meaning a new image revision is deployed) the scan will repeated beforehand and the interval is reset. |
 | config.serviceAutoDiscovery.scanConfig.scanType | string | `"zap-advanced-scan"` | scanType used for the scans created by the serviceAutoDiscovery |
-| config.serviceAutoDiscovery.scanConfig.volumeMounts | list | `[]` | volumes to add to the scan job, see: https://kubernetes.io/docs/reference/kubernetes-api/workload-resources/pod-v1/#volumes-1 the fields: `name`, `mountPath`, `subPath`, `subPathExpr` of each volumeMount support templating |
-| config.serviceAutoDiscovery.scanConfig.volumes | list | `[]` | volumes to add to the scan job, see: https://kubernetes.io/docs/reference/kubernetes-api/workload-resources/pod-v1/#volumes-1 the fields: `name`, `secret.secretName`, `configMap.name` of each volume support templating |
+| config.serviceAutoDiscovery.scanConfig.volumeMounts | list | `[]` | volumeMounts to add to the scan job, see: https://kubernetes.io/docs/reference/kubernetes-api/workload-resources/pod-v1/#volumes-1 the fields: `name`, `mountPath`, `subPath`, `subPathExpr` of each volumeMount support templating |
+| config.serviceAutoDiscovery.scanConfig.volumes | list | `[]` | volumes to add to the scan job, see: https://kubernetes.io/docs/reference/kubernetes-api/workload-resources/pod-v1/#volumes the fields: `name`, `secret.secretName`, `configMap.name` of each volume support templating |
 | image.pullPolicy | string | `"IfNotPresent"` | Image pull policy. One of Always, Never, IfNotPresent. Defaults to Always if :latest tag is specified, or IfNotPresent otherwise. More info: https://kubernetes.io/docs/concepts/containers/images#updating-images |
 | image.repository | string | `"securecodebox/auto-discovery-kubernetes"` |  |
 | image.tag | string | `nil` |  |

--- a/auto-discovery/kubernetes/README.md
+++ b/auto-discovery/kubernetes/README.md
@@ -135,11 +135,13 @@ kubectl -n juice-shop annotate service juice-shop auto-discovery.securecodebox.i
 | config.apiVersion | string | `"config.securecodebox.io/v1"` |  |
 | config.cluster.name | string | `"docker-desktop"` |  |
 | config.containerAutoDiscovery.enabled | bool | `false` |  |
-| config.containerAutoDiscovery.scanConfig.annotations | object | `{}` | annotations to be added to the scans started by the auto-discovery |
-| config.containerAutoDiscovery.scanConfig.labels | object | `{}` | labels to be added to the scans started by the auto-discovery |
+| config.containerAutoDiscovery.scanConfig.annotations | object | `{}` | annotations to be added to the scans started by the auto-discovery all annotation values support templating |
+| config.containerAutoDiscovery.scanConfig.labels | object | `{}` | labels to be added to the scans started by the auto-discovery all label values support templating |
 | config.containerAutoDiscovery.scanConfig.parameters | list | `["{{ .ImageID }}"]` | parameters used for the scans created by the containerAutoDiscovery |
 | config.containerAutoDiscovery.scanConfig.repeatInterval | string | `"168h"` | interval in which scans are automatically repeated. If the target is updated (meaning a new image revision is deployed) the scan will repeated beforehand and the interval is reset. |
 | config.containerAutoDiscovery.scanConfig.scanType | string | `"trivy"` |  |
+| config.containerAutoDiscovery.scanConfig.volumeMounts | list | `[]` | volumes to add to the scan job, see: https://kubernetes.io/docs/reference/kubernetes-api/workload-resources/pod-v1/#volumes-1 the fields: `name`, `mountPath`, `subPath`, `subPathExpr` of each volumeMount support templating |
+| config.containerAutoDiscovery.scanConfig.volumes | list | `[]` | volumes to add to the scan job, see: https://kubernetes.io/docs/reference/kubernetes-api/workload-resources/pod-v1/#volumes-1 the fields: `name`, `secret.secretName`, `configMap.name` of each volume support templating |
 | config.health.healthProbeBindAddress | string | `":8081"` |  |
 | config.kind | string | `"AutoDiscoveryConfig"` |  |
 | config.leaderElection.leaderElect | bool | `true` |  |
@@ -148,11 +150,13 @@ kubectl -n juice-shop annotate service juice-shop auto-discovery.securecodebox.i
 | config.resourceInclusion.mode | string | `"enabled-per-namespace"` |  |
 | config.serviceAutoDiscovery.enabled | bool | `true` |  |
 | config.serviceAutoDiscovery.passiveReconcileInterval | string | `"1m"` | interval in which every service is re-checked for updated pods, if service object is updated directly this the service will get reconciled immediately |
-| config.serviceAutoDiscovery.scanConfig.annotations | object | `{"defectdojo.securecodebox.io/engagement-name":"{{ .Target.Name }}","defectdojo.securecodebox.io/engagement-version":"{{if (index .Target.Labels `app.kubernetes.io/version`) }}{{ index .Target.Labels `app.kubernetes.io/version` }}{{end}}","defectdojo.securecodebox.io/product-name":"{{ .Cluster.Name }} | {{ .Namespace.Name }} | {{ .Target.Name }}","defectdojo.securecodebox.io/product-tags":"cluster/{{ .Cluster.Name }},namespace/{{ .Namespace.Name }}"}` | annotations to be added to the scans started by the auto-discovery |
-| config.serviceAutoDiscovery.scanConfig.labels | object | `{}` | labels to be added to the scans started by the auto-discovery |
-| config.serviceAutoDiscovery.scanConfig.parameters | list | `["-t","{{ .Host.Type }}://{{ .Service.Name }}.{{ .Service.Namespace }}.svc:{{ .Host.Port }}"]` | parameters used for the scans created by the serviceAutoDiscovery |
+| config.serviceAutoDiscovery.scanConfig.annotations | object | `{"defectdojo.securecodebox.io/engagement-name":"{{ .Target.Name }}","defectdojo.securecodebox.io/engagement-version":"{{if (index .Target.Labels `app.kubernetes.io/version`) }}{{ index .Target.Labels `app.kubernetes.io/version` }}{{end}}","defectdojo.securecodebox.io/product-name":"{{ .Cluster.Name }} | {{ .Namespace.Name }} | {{ .Target.Name }}","defectdojo.securecodebox.io/product-tags":"cluster/{{ .Cluster.Name }},namespace/{{ .Namespace.Name }}"}` | annotations to be added to the scans started by the auto-discovery all annotation values support templating |
+| config.serviceAutoDiscovery.scanConfig.labels | object | `{}` | labels to be added to the scans started by the auto-discovery all label values support templating |
+| config.serviceAutoDiscovery.scanConfig.parameters | list | `["-t","{{ .Host.Type }}://{{ .Service.Name }}.{{ .Service.Namespace }}.svc:{{ .Host.Port }}"]` | parameters used for the scans created by the serviceAutoDiscovery all parameters |
 | config.serviceAutoDiscovery.scanConfig.repeatInterval | string | `"168h"` | interval in which scans are automatically repeated. If the target is updated (meaning a new image revision is deployed) the scan will repeated beforehand and the interval is reset. |
 | config.serviceAutoDiscovery.scanConfig.scanType | string | `"zap-advanced-scan"` | scanType used for the scans created by the serviceAutoDiscovery |
+| config.serviceAutoDiscovery.scanConfig.volumeMounts | list | `[]` | volumes to add to the scan job, see: https://kubernetes.io/docs/reference/kubernetes-api/workload-resources/pod-v1/#volumes-1 the fields: `name`, `mountPath`, `subPath`, `subPathExpr` of each volumeMount support templating |
+| config.serviceAutoDiscovery.scanConfig.volumes | list | `[]` | volumes to add to the scan job, see: https://kubernetes.io/docs/reference/kubernetes-api/workload-resources/pod-v1/#volumes-1 the fields: `name`, `secret.secretName`, `configMap.name` of each volume support templating |
 | image.pullPolicy | string | `"IfNotPresent"` | Image pull policy. One of Always, Never, IfNotPresent. Defaults to Always if :latest tag is specified, or IfNotPresent otherwise. More info: https://kubernetes.io/docs/concepts/containers/images#updating-images |
 | image.repository | string | `"securecodebox/auto-discovery-kubernetes"` |  |
 | image.tag | string | `nil` |  |

--- a/auto-discovery/kubernetes/api/v1/autodiscoveryconfig_types.go
+++ b/auto-discovery/kubernetes/api/v1/autodiscoveryconfig_types.go
@@ -5,6 +5,7 @@
 package v1
 
 import (
+	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	cfg "sigs.k8s.io/controller-runtime/pkg/config/v1alpha1"
 )
@@ -51,11 +52,13 @@ type ResourceInclusionConfig struct {
 }
 
 type ScanConfig struct {
-	RepeatInterval metav1.Duration   `json:"repeatInterval"`
-	Annotations    map[string]string `json:"annotations"`
-	Labels         map[string]string `json:"labels"`
-	ScanType       string            `json:"scanType"`
-	Parameters     []string          `json:"parameters"`
+	RepeatInterval metav1.Duration      `json:"repeatInterval"`
+	Annotations    map[string]string    `json:"annotations"`
+	Labels         map[string]string    `json:"labels"`
+	ScanType       string               `json:"scanType"`
+	Parameters     []string             `json:"parameters"`
+	Volumes        []corev1.Volume      `json:"volumes"`
+	VolumeMounts   []corev1.VolumeMount `json:"volumeMounts"`
 }
 
 func init() {

--- a/auto-discovery/kubernetes/api/v1/zz_generated.deepcopy.go
+++ b/auto-discovery/kubernetes/api/v1/zz_generated.deepcopy.go
@@ -10,6 +10,7 @@
 package v1
 
 import (
+	corev1 "k8s.io/api/core/v1"
 	runtime "k8s.io/apimachinery/pkg/runtime"
 )
 
@@ -110,6 +111,20 @@ func (in *ScanConfig) DeepCopyInto(out *ScanConfig) {
 		in, out := &in.Parameters, &out.Parameters
 		*out = make([]string, len(*in))
 		copy(*out, *in)
+	}
+	if in.Volumes != nil {
+		in, out := &in.Volumes, &out.Volumes
+		*out = make([]corev1.Volume, len(*in))
+		for i := range *in {
+			(*in)[i].DeepCopyInto(&(*out)[i])
+		}
+	}
+	if in.VolumeMounts != nil {
+		in, out := &in.VolumeMounts, &out.VolumeMounts
+		*out = make([]corev1.VolumeMount, len(*in))
+		for i := range *in {
+			(*in)[i].DeepCopyInto(&(*out)[i])
+		}
 	}
 }
 

--- a/auto-discovery/kubernetes/controllers/container_scan_controller.go
+++ b/auto-discovery/kubernetes/controllers/container_scan_controller.go
@@ -33,6 +33,17 @@ type ContainerScanReconciler struct {
 	Config   configv1.AutoDiscoveryConfig
 }
 
+type Cluster struct {
+	Name string
+}
+type ContainerAutoDiscoveryTemplateArgs struct {
+	Config     configv1.AutoDiscoveryConfig
+	ScanConfig configv1.ScanConfig
+	Target     metav1.ObjectMeta
+	Namespace  corev1.Namespace
+	ImageID    string
+}
+
 // +kubebuilder:rbac:groups=core,resources=pods,verbs=get;list;watch;
 
 // Reconcile compares the Pod object against the state of the cluster and updates both if needed
@@ -159,7 +170,7 @@ func (r *ContainerScanReconciler) createScheduledScans(ctx context.Context, pod 
 func (r *ContainerScanReconciler) createScheduledScan(ctx context.Context, pod corev1.Pod, imageID string) {
 	namespace := r.getNamespace(ctx, pod)
 
-	newScheduledScan := getScanSpec(r.Config, pod, imageID, namespace)
+	newScheduledScan := r.generateScan(pod, imageID, namespace)
 	err := r.Client.Create(ctx, &newScheduledScan)
 
 	if err != nil {
@@ -178,23 +189,25 @@ func (r *ContainerScanReconciler) getNamespace(ctx context.Context, pod corev1.P
 	return result
 }
 
-func getScanSpec(config configv1.AutoDiscoveryConfig, pod corev1.Pod, imageID string, namespace corev1.Namespace) executionv1.ScheduledScan {
-	containerScanConfig := config.ContainerAutoDiscoveryConfig.ScanConfig
+func (r *ContainerScanReconciler) generateScan(pod corev1.Pod, imageID string, namespace corev1.Namespace) executionv1.ScheduledScan {
+	scanConfig := r.Config.ContainerAutoDiscoveryConfig.ScanConfig
+	templateArgs := ContainerAutoDiscoveryTemplateArgs{
+		Config:     r.Config,
+		ScanConfig: scanConfig,
+		Target:     pod.ObjectMeta,
+		Namespace:  namespace,
+		ImageID:    imageID,
+	}
+	scanSpec := util.GenerateScanSpec(scanConfig, templateArgs)
 
 	newScheduledScan := executionv1.ScheduledScan{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:        getScanName(imageID),
 			Namespace:   pod.Namespace,
-			Annotations: getScanAnnotations(config, pod, imageID, namespace),
-			Labels:      getScanLabels(config, pod, imageID, namespace),
+			Annotations: getScanAnnotations(scanConfig, templateArgs),
+			Labels:      getScanLabels(scanConfig, templateArgs),
 		},
-		Spec: executionv1.ScheduledScanSpec{
-			Interval: containerScanConfig.RepeatInterval,
-			ScanSpec: &executionv1.ScanSpec{
-				ScanType:   containerScanConfig.ScanType,
-				Parameters: getScanParameters(config, pod, imageID, namespace),
-			},
-		},
+		Spec: scanSpec,
 	}
 	return newScheduledScan
 }
@@ -273,23 +286,12 @@ func (r *ContainerScanReconciler) getScan(ctx context.Context, pod corev1.Pod, i
 	return scan, err
 }
 
-func getScanAnnotations(config configv1.AutoDiscoveryConfig, pod corev1.Pod, imageID string, namespace corev1.Namespace) map[string]string {
-	data := util.TemplateArgs{Target: pod.ObjectMeta, Namespace: namespace.ObjectMeta, Cluster: util.Cluster(config.Cluster), ImageID: imageID}
-	templates := config.ContainerAutoDiscoveryConfig.ScanConfig.Annotations
-	return util.ParseMapTemplate(data, templates)
+func getScanAnnotations(scanConfig configv1.ScanConfig, templateArgs ContainerAutoDiscoveryTemplateArgs) map[string]string {
+	return util.ParseMapTemplate(templateArgs, scanConfig.Annotations)
 }
 
-func getScanParameters(config configv1.AutoDiscoveryConfig, pod corev1.Pod, imageID string, namespace corev1.Namespace) []string {
-	data := util.TemplateArgs{Target: pod.ObjectMeta, Namespace: namespace.ObjectMeta, Cluster: util.Cluster(config.Cluster), ImageID: imageID}
-	templates := config.ContainerAutoDiscoveryConfig.ScanConfig.Parameters
-	return util.ParseListTemplate(data, templates)
-}
-
-func getScanLabels(config configv1.AutoDiscoveryConfig, pod corev1.Pod, imageID string, namespace corev1.Namespace) map[string]string {
-	data := util.TemplateArgs{Target: pod.ObjectMeta, Namespace: namespace.ObjectMeta, Cluster: util.Cluster(config.Cluster), ImageID: imageID}
-	templates := config.ContainerAutoDiscoveryConfig.ScanConfig.Labels
-
-	generatedLabels := util.ParseMapTemplate(data, templates)
+func getScanLabels(scanConfig configv1.ScanConfig, templateArgs ContainerAutoDiscoveryTemplateArgs) map[string]string {
+	generatedLabels := util.ParseMapTemplate(templateArgs, scanConfig.Labels)
 	generatedLabels["app.kubernetes.io/managed-by"] = "securecodebox-autodiscovery"
 
 	return generatedLabels

--- a/auto-discovery/kubernetes/controllers/container_scan_controller.go
+++ b/auto-discovery/kubernetes/controllers/container_scan_controller.go
@@ -39,6 +39,7 @@ type Cluster struct {
 type ContainerAutoDiscoveryTemplateArgs struct {
 	Config     configv1.AutoDiscoveryConfig
 	ScanConfig configv1.ScanConfig
+	Cluster    configv1.ClusterConfig
 	Target     metav1.ObjectMeta
 	Namespace  corev1.Namespace
 	ImageID    string
@@ -194,6 +195,7 @@ func (r *ContainerScanReconciler) generateScan(pod corev1.Pod, imageID string, n
 	templateArgs := ContainerAutoDiscoveryTemplateArgs{
 		Config:     r.Config,
 		ScanConfig: scanConfig,
+		Cluster:    r.Config.Cluster,
 		Target:     pod.ObjectMeta,
 		Namespace:  namespace,
 		ImageID:    imageID,

--- a/auto-discovery/kubernetes/controllers/service_scan_controller.go
+++ b/auto-discovery/kubernetes/controllers/service_scan_controller.go
@@ -39,6 +39,8 @@ type ServiceScanReconciler struct {
 type ServiceAutoDiscoveryTemplateArgs struct {
 	Config     configv1.AutoDiscoveryConfig
 	ScanConfig configv1.ScanConfig
+	Cluster    configv1.ClusterConfig
+	Target     metav1.ObjectMeta
 	Service    corev1.Service
 	Namespace  corev1.Namespace
 	Host       HostPort
@@ -141,6 +143,8 @@ func (r *ServiceScanReconciler) Reconcile(ctx context.Context, req ctrl.Request)
 		templateArgs := ServiceAutoDiscoveryTemplateArgs{
 			Config:     r.Config,
 			ScanConfig: r.Config.ServiceAutoDiscoveryConfig.ScanConfig,
+			Cluster:    r.Config.Cluster,
+			Target:     service.ObjectMeta,
 			Service:    service,
 			Namespace:  namespace,
 			Host:       host,

--- a/auto-discovery/kubernetes/controllers/service_scan_controller.go
+++ b/auto-discovery/kubernetes/controllers/service_scan_controller.go
@@ -36,6 +36,14 @@ type ServiceScanReconciler struct {
 	Config   configv1.AutoDiscoveryConfig
 }
 
+type ServiceAutoDiscoveryTemplateArgs struct {
+	Config     configv1.AutoDiscoveryConfig
+	ScanConfig configv1.ScanConfig
+	Service    corev1.Service
+	Namespace  corev1.Namespace
+	Host       HostPort
+}
+
 const requeueInterval = 5 * time.Second
 
 // +kubebuilder:rbac:groups="execution.securecodebox.io",resources=scantypes,verbs=get;list;watch
@@ -129,13 +137,23 @@ func (r *ServiceScanReconciler) Reconcile(ctx context.Context, req ctrl.Request)
 		var previousScan executionv1.ScheduledScan
 		err := r.Client.Get(ctx, types.NamespacedName{Name: fmt.Sprintf("%s-service-port-%d", service.Name, host.Port), Namespace: service.Namespace}, &previousScan)
 
+		// generate the scan spec for the current state of the service
+		templateArgs := ServiceAutoDiscoveryTemplateArgs{
+			Config:     r.Config,
+			ScanConfig: r.Config.ServiceAutoDiscoveryConfig.ScanConfig,
+			Service:    service,
+			Namespace:  namespace,
+			Host:       host,
+		}
+		scanSpec := util.GenerateScanSpec(r.Config.ServiceAutoDiscoveryConfig.ScanConfig, templateArgs)
+
 		if apierrors.IsNotFound(err) {
 			// service was never scanned
 			log.Info("Discovered new unscanned service, scanning it now", "service", service.Name, "namespace", service.Namespace)
 
 			// label is added after the initial query as it was added later and isn't garanteed to be on every auto-discovery managed scan.
 			versionedLabels["app.kubernetes.io/managed-by"] = "securecodebox-autodiscovery"
-			versionedLabels = addLabels(versionedLabels, r.Config, service, namespace)
+			versionedLabels = generateScanLabels(versionedLabels, r.Config.ServiceAutoDiscoveryConfig.ScanConfig, templateArgs)
 
 			// No scan for this pod digest yet. Scanning now
 			scan := executionv1.ScheduledScan{
@@ -143,9 +161,9 @@ func (r *ServiceScanReconciler) Reconcile(ctx context.Context, req ctrl.Request)
 					Name:        fmt.Sprintf("%s-service-port-%d", service.Name, host.Port),
 					Namespace:   service.Namespace,
 					Labels:      versionedLabels,
-					Annotations: generateScanAnnotations(r.Config.ServiceAutoDiscoveryConfig.ScanConfig, r.Config.Cluster, service, namespace),
+					Annotations: generateScanAnnotations(service.Annotations, r.Config.ServiceAutoDiscoveryConfig.ScanConfig, templateArgs),
 				},
-				Spec: generateScanSpec(r.Config, r.Config.ServiceAutoDiscoveryConfig.ScanConfig, host, service, namespace),
+				Spec: scanSpec,
 			}
 
 			// Ensure ScanType actually exists
@@ -181,11 +199,11 @@ func (r *ServiceScanReconciler) Reconcile(ctx context.Context, req ctrl.Request)
 
 			// label is added after the initial query as it was added later and isn't garanteed to be on every auto-discovery managed scan.
 			versionedLabels["app.kubernetes.io/managed-by"] = "securecodebox-autodiscovery"
-			versionedLabels = addLabels(versionedLabels, r.Config, service, namespace)
+			versionedLabels = generateScanLabels(versionedLabels, r.Config.ServiceAutoDiscoveryConfig.ScanConfig, templateArgs)
 
 			previousScan.ObjectMeta.Labels = versionedLabels
-			previousScan.ObjectMeta.Annotations = generateScanAnnotations(r.Config.ServiceAutoDiscoveryConfig.ScanConfig, r.Config.Cluster, service, namespace)
-			previousScan.Spec = generateScanSpec(r.Config, r.Config.ServiceAutoDiscoveryConfig.ScanConfig, host, service, namespace)
+			previousScan.ObjectMeta.Annotations = generateScanAnnotations(service.Annotations, r.Config.ServiceAutoDiscoveryConfig.ScanConfig, templateArgs)
+			previousScan.Spec = scanSpec
 
 			log.V(8).Info("Updating previousScan Spec")
 			err := r.Update(ctx, &previousScan)
@@ -363,19 +381,12 @@ podLoop:
 	return false
 }
 
-func generateScanAnnotations(scanConfig configv1.ScanConfig, clusterConfig configv1.ClusterConfig, service corev1.Service, namespace corev1.Namespace) map[string]string {
-	templateArgs := util.TemplateArgs{
-		Target:    service.ObjectMeta,
-		Namespace: namespace.ObjectMeta,
-		Cluster: util.Cluster{
-			Name: clusterConfig.Name,
-		},
-	}
+func generateScanAnnotations(currentAnnotations map[string]string, scanConfig configv1.ScanConfig, templateArgs ServiceAutoDiscoveryTemplateArgs) map[string]string {
 	annotations := util.ParseMapTemplate(templateArgs, scanConfig.Annotations)
 
 	// Copy over securecodebox.io annotations to the created scan
 	re := regexp.MustCompile(`.*securecodebox\.io/.*`)
-	for key, value := range service.Annotations {
+	for key, value := range currentAnnotations {
 		if matches := re.MatchString(key); matches {
 			annotations[key] = value
 		}
@@ -384,45 +395,8 @@ func generateScanAnnotations(scanConfig configv1.ScanConfig, clusterConfig confi
 
 }
 
-// Takes in both autoDiscoveryConfig and scanConfig as this function might be used by other controllers in the future, which can then pass in the their relevant scanConfig into this function
-func generateScanSpec(autoDiscoveryConfig configv1.AutoDiscoveryConfig, scanConfig configv1.ScanConfig, host HostPort, service corev1.Service, namespace corev1.Namespace) executionv1.ScheduledScanSpec {
-	type TemplateArgs struct {
-		Config     configv1.AutoDiscoveryConfig
-		ScanConfig configv1.ScanConfig
-		Service    corev1.Service
-		Namespace  corev1.Namespace
-		Host       HostPort
-	}
-	parameters := scanConfig.Parameters
-
-	templateArgs := TemplateArgs{
-		Config:    autoDiscoveryConfig,
-		Service:   service,
-		Namespace: namespace,
-		Host:      host,
-	}
-
-	params := util.ParseListTemplate(templateArgs, parameters)
-
-	scheduledScanSpec := executionv1.ScheduledScanSpec{
-		Interval: scanConfig.RepeatInterval,
-		ScanSpec: &executionv1.ScanSpec{
-			ScanType:   scanConfig.ScanType,
-			Parameters: params,
-		},
-		RetriggerOnScanTypeChange: true,
-	}
-
-	return scheduledScanSpec
-}
-
-func addLabels(currentLabels map[string]string, config configv1.AutoDiscoveryConfig, service corev1.Service, namespace corev1.Namespace) map[string]string {
-	data := util.TemplateArgs{
-		Target:    service.ObjectMeta,
-		Namespace: namespace.ObjectMeta,
-		Cluster:   util.Cluster(config.Cluster),
-	}
-	newLabels := util.ParseMapTemplate(data, config.ServiceAutoDiscoveryConfig.ScanConfig.Labels)
+func generateScanLabels(currentLabels map[string]string, scanConfig configv1.ScanConfig, templateArgs ServiceAutoDiscoveryTemplateArgs) map[string]string {
+	newLabels := util.ParseMapTemplate(templateArgs, scanConfig.Labels)
 
 	for key, value := range newLabels {
 		currentLabels[key] = value

--- a/auto-discovery/kubernetes/docs/README.ArtifactHub.md
+++ b/auto-discovery/kubernetes/docs/README.ArtifactHub.md
@@ -127,13 +127,13 @@ kubectl -n juice-shop annotate service juice-shop auto-discovery.securecodebox.i
 | config.apiVersion | string | `"config.securecodebox.io/v1"` |  |
 | config.cluster.name | string | `"docker-desktop"` |  |
 | config.containerAutoDiscovery.enabled | bool | `false` |  |
-| config.containerAutoDiscovery.scanConfig.annotations | object | `{}` | annotations to be added to the scans started by the auto-discovery all annotation values support templating |
-| config.containerAutoDiscovery.scanConfig.labels | object | `{}` | labels to be added to the scans started by the auto-discovery all label values support templating |
-| config.containerAutoDiscovery.scanConfig.parameters | list | `["{{ .ImageID }}"]` | parameters used for the scans created by the containerAutoDiscovery |
+| config.containerAutoDiscovery.scanConfig.annotations | object | `{}` | annotations to be added to the scans started by the auto-discovery, all annotation values support templating |
+| config.containerAutoDiscovery.scanConfig.labels | object | `{}` | labels to be added to the scans started by the auto-discovery, all label values support templating |
+| config.containerAutoDiscovery.scanConfig.parameters | list | `["{{ .ImageID }}"]` | parameters used for the scans created by the containerAutoDiscovery, all parameters support templating |
 | config.containerAutoDiscovery.scanConfig.repeatInterval | string | `"168h"` | interval in which scans are automatically repeated. If the target is updated (meaning a new image revision is deployed) the scan will repeated beforehand and the interval is reset. |
 | config.containerAutoDiscovery.scanConfig.scanType | string | `"trivy"` |  |
-| config.containerAutoDiscovery.scanConfig.volumeMounts | list | `[]` | volumes to add to the scan job, see: https://kubernetes.io/docs/reference/kubernetes-api/workload-resources/pod-v1/#volumes-1 the fields: `name`, `mountPath`, `subPath`, `subPathExpr` of each volumeMount support templating |
-| config.containerAutoDiscovery.scanConfig.volumes | list | `[]` | volumes to add to the scan job, see: https://kubernetes.io/docs/reference/kubernetes-api/workload-resources/pod-v1/#volumes-1 the fields: `name`, `secret.secretName`, `configMap.name` of each volume support templating |
+| config.containerAutoDiscovery.scanConfig.volumeMounts | list | `[]` | volumeMounts to add to the scan job, see: https://kubernetes.io/docs/reference/kubernetes-api/workload-resources/pod-v1/#volumes-1 the fields: `name`, `mountPath`, `subPath`, `subPathExpr` of each volumeMount support templating |
+| config.containerAutoDiscovery.scanConfig.volumes | list | `[]` | volumes to add to the scan job, see: https://kubernetes.io/docs/reference/kubernetes-api/workload-resources/pod-v1/#volumes the fields: `name`, `secret.secretName`, `configMap.name` of each volume support templating |
 | config.health.healthProbeBindAddress | string | `":8081"` |  |
 | config.kind | string | `"AutoDiscoveryConfig"` |  |
 | config.leaderElection.leaderElect | bool | `true` |  |
@@ -142,13 +142,13 @@ kubectl -n juice-shop annotate service juice-shop auto-discovery.securecodebox.i
 | config.resourceInclusion.mode | string | `"enabled-per-namespace"` |  |
 | config.serviceAutoDiscovery.enabled | bool | `true` |  |
 | config.serviceAutoDiscovery.passiveReconcileInterval | string | `"1m"` | interval in which every service is re-checked for updated pods, if service object is updated directly this the service will get reconciled immediately |
-| config.serviceAutoDiscovery.scanConfig.annotations | object | `{"defectdojo.securecodebox.io/engagement-name":"{{ .Target.Name }}","defectdojo.securecodebox.io/engagement-version":"{{if (index .Target.Labels `app.kubernetes.io/version`) }}{{ index .Target.Labels `app.kubernetes.io/version` }}{{end}}","defectdojo.securecodebox.io/product-name":"{{ .Cluster.Name }} | {{ .Namespace.Name }} | {{ .Target.Name }}","defectdojo.securecodebox.io/product-tags":"cluster/{{ .Cluster.Name }},namespace/{{ .Namespace.Name }}"}` | annotations to be added to the scans started by the auto-discovery all annotation values support templating |
-| config.serviceAutoDiscovery.scanConfig.labels | object | `{}` | labels to be added to the scans started by the auto-discovery all label values support templating |
-| config.serviceAutoDiscovery.scanConfig.parameters | list | `["-t","{{ .Host.Type }}://{{ .Service.Name }}.{{ .Service.Namespace }}.svc:{{ .Host.Port }}"]` | parameters used for the scans created by the serviceAutoDiscovery all parameters |
+| config.serviceAutoDiscovery.scanConfig.annotations | object | `{"defectdojo.securecodebox.io/engagement-name":"{{ .Target.Name }}","defectdojo.securecodebox.io/engagement-version":"{{if (index .Target.Labels `app.kubernetes.io/version`) }}{{ index .Target.Labels `app.kubernetes.io/version` }}{{end}}","defectdojo.securecodebox.io/product-name":"{{ .Cluster.Name }} | {{ .Namespace.Name }} | {{ .Target.Name }}","defectdojo.securecodebox.io/product-tags":"cluster/{{ .Cluster.Name }},namespace/{{ .Namespace.Name }}"}` | annotations to be added to the scans started by the auto-discovery, all annotation values support templating |
+| config.serviceAutoDiscovery.scanConfig.labels | object | `{}` | labels to be added to the scans started by the auto-discovery, all label values support templating |
+| config.serviceAutoDiscovery.scanConfig.parameters | list | `["-t","{{ .Host.Type }}://{{ .Service.Name }}.{{ .Service.Namespace }}.svc:{{ .Host.Port }}"]` | parameters used for the scans created by the serviceAutoDiscovery, all parameters support templating |
 | config.serviceAutoDiscovery.scanConfig.repeatInterval | string | `"168h"` | interval in which scans are automatically repeated. If the target is updated (meaning a new image revision is deployed) the scan will repeated beforehand and the interval is reset. |
 | config.serviceAutoDiscovery.scanConfig.scanType | string | `"zap-advanced-scan"` | scanType used for the scans created by the serviceAutoDiscovery |
-| config.serviceAutoDiscovery.scanConfig.volumeMounts | list | `[]` | volumes to add to the scan job, see: https://kubernetes.io/docs/reference/kubernetes-api/workload-resources/pod-v1/#volumes-1 the fields: `name`, `mountPath`, `subPath`, `subPathExpr` of each volumeMount support templating |
-| config.serviceAutoDiscovery.scanConfig.volumes | list | `[]` | volumes to add to the scan job, see: https://kubernetes.io/docs/reference/kubernetes-api/workload-resources/pod-v1/#volumes-1 the fields: `name`, `secret.secretName`, `configMap.name` of each volume support templating |
+| config.serviceAutoDiscovery.scanConfig.volumeMounts | list | `[]` | volumeMounts to add to the scan job, see: https://kubernetes.io/docs/reference/kubernetes-api/workload-resources/pod-v1/#volumes-1 the fields: `name`, `mountPath`, `subPath`, `subPathExpr` of each volumeMount support templating |
+| config.serviceAutoDiscovery.scanConfig.volumes | list | `[]` | volumes to add to the scan job, see: https://kubernetes.io/docs/reference/kubernetes-api/workload-resources/pod-v1/#volumes the fields: `name`, `secret.secretName`, `configMap.name` of each volume support templating |
 | image.pullPolicy | string | `"IfNotPresent"` | Image pull policy. One of Always, Never, IfNotPresent. Defaults to Always if :latest tag is specified, or IfNotPresent otherwise. More info: https://kubernetes.io/docs/concepts/containers/images#updating-images |
 | image.repository | string | `"securecodebox/auto-discovery-kubernetes"` |  |
 | image.tag | string | `nil` |  |

--- a/auto-discovery/kubernetes/docs/README.ArtifactHub.md
+++ b/auto-discovery/kubernetes/docs/README.ArtifactHub.md
@@ -127,11 +127,13 @@ kubectl -n juice-shop annotate service juice-shop auto-discovery.securecodebox.i
 | config.apiVersion | string | `"config.securecodebox.io/v1"` |  |
 | config.cluster.name | string | `"docker-desktop"` |  |
 | config.containerAutoDiscovery.enabled | bool | `false` |  |
-| config.containerAutoDiscovery.scanConfig.annotations | object | `{}` | annotations to be added to the scans started by the auto-discovery |
-| config.containerAutoDiscovery.scanConfig.labels | object | `{}` | labels to be added to the scans started by the auto-discovery |
+| config.containerAutoDiscovery.scanConfig.annotations | object | `{}` | annotations to be added to the scans started by the auto-discovery all annotation values support templating |
+| config.containerAutoDiscovery.scanConfig.labels | object | `{}` | labels to be added to the scans started by the auto-discovery all label values support templating |
 | config.containerAutoDiscovery.scanConfig.parameters | list | `["{{ .ImageID }}"]` | parameters used for the scans created by the containerAutoDiscovery |
 | config.containerAutoDiscovery.scanConfig.repeatInterval | string | `"168h"` | interval in which scans are automatically repeated. If the target is updated (meaning a new image revision is deployed) the scan will repeated beforehand and the interval is reset. |
 | config.containerAutoDiscovery.scanConfig.scanType | string | `"trivy"` |  |
+| config.containerAutoDiscovery.scanConfig.volumeMounts | list | `[]` | volumes to add to the scan job, see: https://kubernetes.io/docs/reference/kubernetes-api/workload-resources/pod-v1/#volumes-1 the fields: `name`, `mountPath`, `subPath`, `subPathExpr` of each volumeMount support templating |
+| config.containerAutoDiscovery.scanConfig.volumes | list | `[]` | volumes to add to the scan job, see: https://kubernetes.io/docs/reference/kubernetes-api/workload-resources/pod-v1/#volumes-1 the fields: `name`, `secret.secretName`, `configMap.name` of each volume support templating |
 | config.health.healthProbeBindAddress | string | `":8081"` |  |
 | config.kind | string | `"AutoDiscoveryConfig"` |  |
 | config.leaderElection.leaderElect | bool | `true` |  |
@@ -140,11 +142,13 @@ kubectl -n juice-shop annotate service juice-shop auto-discovery.securecodebox.i
 | config.resourceInclusion.mode | string | `"enabled-per-namespace"` |  |
 | config.serviceAutoDiscovery.enabled | bool | `true` |  |
 | config.serviceAutoDiscovery.passiveReconcileInterval | string | `"1m"` | interval in which every service is re-checked for updated pods, if service object is updated directly this the service will get reconciled immediately |
-| config.serviceAutoDiscovery.scanConfig.annotations | object | `{"defectdojo.securecodebox.io/engagement-name":"{{ .Target.Name }}","defectdojo.securecodebox.io/engagement-version":"{{if (index .Target.Labels `app.kubernetes.io/version`) }}{{ index .Target.Labels `app.kubernetes.io/version` }}{{end}}","defectdojo.securecodebox.io/product-name":"{{ .Cluster.Name }} | {{ .Namespace.Name }} | {{ .Target.Name }}","defectdojo.securecodebox.io/product-tags":"cluster/{{ .Cluster.Name }},namespace/{{ .Namespace.Name }}"}` | annotations to be added to the scans started by the auto-discovery |
-| config.serviceAutoDiscovery.scanConfig.labels | object | `{}` | labels to be added to the scans started by the auto-discovery |
-| config.serviceAutoDiscovery.scanConfig.parameters | list | `["-t","{{ .Host.Type }}://{{ .Service.Name }}.{{ .Service.Namespace }}.svc:{{ .Host.Port }}"]` | parameters used for the scans created by the serviceAutoDiscovery |
+| config.serviceAutoDiscovery.scanConfig.annotations | object | `{"defectdojo.securecodebox.io/engagement-name":"{{ .Target.Name }}","defectdojo.securecodebox.io/engagement-version":"{{if (index .Target.Labels `app.kubernetes.io/version`) }}{{ index .Target.Labels `app.kubernetes.io/version` }}{{end}}","defectdojo.securecodebox.io/product-name":"{{ .Cluster.Name }} | {{ .Namespace.Name }} | {{ .Target.Name }}","defectdojo.securecodebox.io/product-tags":"cluster/{{ .Cluster.Name }},namespace/{{ .Namespace.Name }}"}` | annotations to be added to the scans started by the auto-discovery all annotation values support templating |
+| config.serviceAutoDiscovery.scanConfig.labels | object | `{}` | labels to be added to the scans started by the auto-discovery all label values support templating |
+| config.serviceAutoDiscovery.scanConfig.parameters | list | `["-t","{{ .Host.Type }}://{{ .Service.Name }}.{{ .Service.Namespace }}.svc:{{ .Host.Port }}"]` | parameters used for the scans created by the serviceAutoDiscovery all parameters |
 | config.serviceAutoDiscovery.scanConfig.repeatInterval | string | `"168h"` | interval in which scans are automatically repeated. If the target is updated (meaning a new image revision is deployed) the scan will repeated beforehand and the interval is reset. |
 | config.serviceAutoDiscovery.scanConfig.scanType | string | `"zap-advanced-scan"` | scanType used for the scans created by the serviceAutoDiscovery |
+| config.serviceAutoDiscovery.scanConfig.volumeMounts | list | `[]` | volumes to add to the scan job, see: https://kubernetes.io/docs/reference/kubernetes-api/workload-resources/pod-v1/#volumes-1 the fields: `name`, `mountPath`, `subPath`, `subPathExpr` of each volumeMount support templating |
+| config.serviceAutoDiscovery.scanConfig.volumes | list | `[]` | volumes to add to the scan job, see: https://kubernetes.io/docs/reference/kubernetes-api/workload-resources/pod-v1/#volumes-1 the fields: `name`, `secret.secretName`, `configMap.name` of each volume support templating |
 | image.pullPolicy | string | `"IfNotPresent"` | Image pull policy. One of Always, Never, IfNotPresent. Defaults to Always if :latest tag is specified, or IfNotPresent otherwise. More info: https://kubernetes.io/docs/concepts/containers/images#updating-images |
 | image.repository | string | `"securecodebox/auto-discovery-kubernetes"` |  |
 | image.tag | string | `nil` |  |

--- a/auto-discovery/kubernetes/go.mod
+++ b/auto-discovery/kubernetes/go.mod
@@ -16,7 +16,6 @@ require (
 	github.com/onsi/ginkgo v1.14.1
 	github.com/onsi/gomega v1.10.2
 	github.com/secureCodeBox/secureCodeBox/operator v0.0.0-20211020071729-60497d02f10d
-	github.com/stretchr/testify v1.6.1
 	k8s.io/api v0.20.2
 	k8s.io/apimachinery v0.20.2
 	k8s.io/client-go v0.20.2

--- a/auto-discovery/kubernetes/pkg/util/gotemplate.go
+++ b/auto-discovery/kubernetes/pkg/util/gotemplate.go
@@ -8,6 +8,7 @@ import (
 	"github.com/Masterminds/sprig"
 	configv1 "github.com/secureCodeBox/secureCodeBox/auto-discovery/kubernetes/api/v1"
 	executionv1 "github.com/secureCodeBox/secureCodeBox/operator/apis/execution/v1"
+	corev1 "k8s.io/api/core/v1"
 )
 
 func templateOrPanic(templateString string, templateArgs interface{}) string {
@@ -62,11 +63,36 @@ func GenerateScanSpec(scanConfig configv1.ScanConfig, templateArgs interface{}) 
 
 	params := ParseListTemplate(templateArgs, parameters)
 
+	volumes := make([]corev1.Volume, len(scanConfig.Volumes))
+	for i, volume := range scanConfig.Volumes {
+		templatedVolume := volume.DeepCopy()
+		templatedVolume.Name = templateOrPanic(volume.Name, templateArgs)
+		if volume.Secret != nil {
+			templatedVolume.Secret.SecretName = templateOrPanic(volume.Secret.SecretName, templateArgs)
+		}
+		if volume.ConfigMap != nil {
+			templatedVolume.ConfigMap.Name = templateOrPanic(volume.ConfigMap.Name, templateArgs)
+		}
+		volumes[i] = *templatedVolume
+	}
+	volumeMounts := make([]corev1.VolumeMount, len(scanConfig.VolumeMounts))
+	for i, volumeMount := range scanConfig.VolumeMounts {
+		templatedVolumeMount := volumeMount.DeepCopy()
+		templatedVolumeMount.Name = templateOrPanic(volumeMount.Name, templateArgs)
+		templatedVolumeMount.MountPath = templateOrPanic(volumeMount.MountPath, templateArgs)
+		templatedVolumeMount.SubPath = templateOrPanic(volumeMount.SubPath, templateArgs)
+		templatedVolumeMount.SubPathExpr = templateOrPanic(volumeMount.SubPathExpr, templateArgs)
+
+		volumeMounts[i] = *templatedVolumeMount
+	}
+
 	scheduledScanSpec := executionv1.ScheduledScanSpec{
 		Interval: scanConfig.RepeatInterval,
 		ScanSpec: &executionv1.ScanSpec{
-			ScanType:   scanConfig.ScanType,
-			Parameters: params,
+			ScanType:     scanConfig.ScanType,
+			Parameters:   params,
+			Volumes:      volumes,
+			VolumeMounts: volumeMounts,
 		},
 		RetriggerOnScanTypeChange: true,
 	}

--- a/auto-discovery/kubernetes/pkg/util/gotemplate_test.go
+++ b/auto-discovery/kubernetes/pkg/util/gotemplate_test.go
@@ -7,7 +7,9 @@ package util
 import (
 	"testing"
 
+	configv1 "github.com/secureCodeBox/secureCodeBox/auto-discovery/kubernetes/api/v1"
 	"github.com/stretchr/testify/assert"
+	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
@@ -66,8 +68,20 @@ func render(annotationTemplates map[string]string) map[string]string {
 		"app.kubernetes.io/name": "juice-shop",
 		// "scm.securecodebox.io/branch": "v12.2.2",
 	}}
-	namespaceMeta := metav1.ObjectMeta{Name: "foobar", Labels: map[string]string{"foo": "bar"}}
+	namespace := corev1.Namespace{
+		ObjectMeta: metav1.ObjectMeta{Name: "foobar", Labels: map[string]string{"foo": "bar"}},
+		Spec:       corev1.NamespaceSpec{},
+	}
 
-	data := TemplateArgs{Target: targetMeta, Namespace: namespaceMeta, Cluster: Cluster{"test-cluster"}}
-	return ParseMapTemplate(data, annotationTemplates)
+	type TestTemplateArgs struct {
+		Target    metav1.ObjectMeta
+		Namespace corev1.Namespace
+		Cluster   configv1.ClusterConfig
+	}
+	templateArgs := TestTemplateArgs{
+		Target:    targetMeta,
+		Namespace: namespace,
+		Cluster:   configv1.ClusterConfig{Name: "test-cluster"},
+	}
+	return ParseMapTemplate(templateArgs, annotationTemplates)
 }

--- a/auto-discovery/kubernetes/pkg/util/gotemplate_test.go
+++ b/auto-discovery/kubernetes/pkg/util/gotemplate_test.go
@@ -44,20 +44,19 @@ func TestGetAnnotationsForScan(t *testing.T) {
 
 	assert.Equal(
 		t,
+		render(map[string]string{
+			"defectdojo.securecodebox.io/product-name":    "{{ .Cluster.Name }} | {{ .Namespace.Name }} | {{ .Target.Name }}",
+			"defectdojo.securecodebox.io/product-tags":    "cluster/{{ .Cluster.Name }},namespace/{{ .Namespace.Name }}",
+			"defectdojo.securecodebox.io/engagement-name": "{{ .Target.Name }}",
+			// Need to use "index" function here to be able to access the `app.kubernetes.io/name` as the special chars ('.' & '/') mess with golang templates
+			// Should be dropped as the template renders to a empty string as the service doesn't have the version label included
+			"defectdojo.securecodebox.io/engagement-version": "{{ default \"\" (index .Target.Labels `scm.securecodebox.io/branch`) }}",
+		}),
 		map[string]string{
 			"defectdojo.securecodebox.io/product-name":    "test-cluster | foobar | service-foobar",
 			"defectdojo.securecodebox.io/product-tags":    "cluster/test-cluster,namespace/foobar",
 			"defectdojo.securecodebox.io/engagement-name": "service-foobar",
 		},
-		render(
-			map[string]string{
-				"defectdojo.securecodebox.io/product-name":    "{{ .Cluster.Name }} | {{ .Namespace.Name }} | {{ .Target.Name }}",
-				"defectdojo.securecodebox.io/product-tags":    "cluster/{{ .Cluster.Name }},namespace/{{ .Namespace.Name }}",
-				"defectdojo.securecodebox.io/engagement-name": "{{ .Target.Name }}",
-				// Need to use "index" function here to be able to access the `app.kubernetes.io/name` as the special chars ('.' & '/') mess with golang templates
-				// Should be dropped as the template renders to a empty string as the service doesn't have the version label included
-				"defectdojo.securecodebox.io/engagement-version": "{{ default \"\" (index .Target.Labels `scm.securecodebox.io/branch`) }}",
-			}),
 		"Should be able to render out actual DefectDojo usage",
 	)
 }

--- a/auto-discovery/kubernetes/pkg/util/gotemplate_test.go
+++ b/auto-discovery/kubernetes/pkg/util/gotemplate_test.go
@@ -5,61 +5,55 @@
 package util
 
 import (
-	"testing"
-
 	configv1 "github.com/secureCodeBox/secureCodeBox/auto-discovery/kubernetes/api/v1"
-	"github.com/stretchr/testify/assert"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
 )
 
-type testData struct {
-	in                   map[string]string
-	expectedMapKeyLength int
-}
+var _ = Describe("gotemplate helper util", func() {
 
-// Tests that getAnnotationsForScan drops all annotations not prefixed with "*.securecodebox.io/*"
-func TestGetAnnotationsForScan(t *testing.T) {
-	assert.Equal(
-		t,
-		render(map[string]string{"foo": "bar"}),
-		map[string]string{"foo": "bar"},
-		"Should render plain strings unchanged",
-	)
+	Context("Annotation Templating Scanner Parameter", func() {
+		It("Should render simple static annoation without templating", func() {
+			Expect(render(map[string]string{"foo": "bar"})).To(Equal(
+				map[string]string{"foo": "bar"},
+			))
+		})
 
-	assert.Equal(
-		t,
-		render(map[string]string{"foo": "Name: {{ .Target.Name }}"}),
-		map[string]string{"foo": "Name: service-foobar"},
-		"Should be able to render information of the target object",
-	)
+		It("Should render out simple template strings", func() {
+			Expect(render(map[string]string{"foo": "Name: {{ .Target.Name }}"})).To(Equal(
+				map[string]string{"foo": "Name: service-foobar"},
+			))
+		})
 
-	assert.Equal(
-		t,
-		// Need to use "index" function here to be able to access the `app.kubernetes.io/name` as the special chars ('.' & '/') mess with golang templates
-		render(map[string]string{"foo": "Service: {{ index .Target.Labels `app.kubernetes.io/name` }}"}),
-		map[string]string{"foo": "Service: juice-shop"},
-		"Should be able to render infos from target labels",
-	)
+		It("Should render out more complex template strings", func() {
+			Expect(render(map[string]string{"foo": "Service: {{ index .Target.Labels `app.kubernetes.io/name` }}"})).To(Equal(
+				map[string]string{"foo": "Service: juice-shop"},
+			))
+		})
 
-	assert.Equal(
-		t,
-		render(map[string]string{
-			"defectdojo.securecodebox.io/product-name":    "{{ .Cluster.Name }} | {{ .Namespace.Name }} | {{ .Target.Name }}",
-			"defectdojo.securecodebox.io/product-tags":    "cluster/{{ .Cluster.Name }},namespace/{{ .Namespace.Name }}",
-			"defectdojo.securecodebox.io/engagement-name": "{{ .Target.Name }}",
-			// Need to use "index" function here to be able to access the `app.kubernetes.io/name` as the special chars ('.' & '/') mess with golang templates
-			// Should be dropped as the template renders to a empty string as the service doesn't have the version label included
-			"defectdojo.securecodebox.io/engagement-version": "{{ default \"\" (index .Target.Labels `scm.securecodebox.io/branch`) }}",
-		}),
-		map[string]string{
-			"defectdojo.securecodebox.io/product-name":    "test-cluster | foobar | service-foobar",
-			"defectdojo.securecodebox.io/product-tags":    "cluster/test-cluster,namespace/foobar",
-			"defectdojo.securecodebox.io/engagement-name": "service-foobar",
-		},
-		"Should be able to render out actual DefectDojo usage",
-	)
-}
+		It("Should drop annotations which render to an empty string", func() {
+			Expect(
+				render(map[string]string{
+					"defectdojo.securecodebox.io/product-name":    "{{ .Cluster.Name }} | {{ .Namespace.Name }} | {{ .Target.Name }}",
+					"defectdojo.securecodebox.io/product-tags":    "cluster/{{ .Cluster.Name }},namespace/{{ .Namespace.Name }}",
+					"defectdojo.securecodebox.io/engagement-name": "{{ .Target.Name }}",
+					// Need to use "index" function here to be able to access the `app.kubernetes.io/name` as the special chars ('.' & '/') mess with golang templates
+					// Should be dropped as the template renders to a empty string as the service doesn't have the version label included
+					"defectdojo.securecodebox.io/engagement-version": "{{ default \"\" (index .Target.Labels `scm.securecodebox.io/branch`) }}",
+				}),
+			).To(Equal(
+				map[string]string{
+					"defectdojo.securecodebox.io/product-name":    "test-cluster | foobar | service-foobar",
+					"defectdojo.securecodebox.io/product-tags":    "cluster/test-cluster,namespace/foobar",
+					"defectdojo.securecodebox.io/engagement-name": "service-foobar",
+				},
+			))
+		})
+	})
+})
 
 func render(annotationTemplates map[string]string) map[string]string {
 	targetMeta := metav1.ObjectMeta{Name: "service-foobar", Namespace: "foobar", Labels: map[string]string{

--- a/auto-discovery/kubernetes/pkg/util/util_suite_test.go
+++ b/auto-discovery/kubernetes/pkg/util/util_suite_test.go
@@ -1,0 +1,13 @@
+package util_test
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+func TestUtil(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Util Suite")
+}

--- a/auto-discovery/kubernetes/values.yaml
+++ b/auto-discovery/kubernetes/values.yaml
@@ -42,10 +42,10 @@ config:
         defectdojo.securecodebox.io/product-tags: "cluster/{{ .Cluster.Name }},namespace/{{ .Namespace.Name }}"
         defectdojo.securecodebox.io/engagement-name: "{{ .Target.Name }}"
         defectdojo.securecodebox.io/engagement-version: "{{if (index .Target.Labels `app.kubernetes.io/version`) }}{{ index .Target.Labels `app.kubernetes.io/version` }}{{end}}"
-      # -- volumes to add to the scan job, see: https://kubernetes.io/docs/reference/kubernetes-api/workload-resources/pod-v1/#volumes-1
+      # -- volumes to add to the scan job, see: https://kubernetes.io/docs/reference/kubernetes-api/workload-resources/pod-v1/#volumes
       # the fields: `name`, `secret.secretName`, `configMap.name` of each volume support templating
       volumes: []
-      # -- volumes to add to the scan job, see: https://kubernetes.io/docs/reference/kubernetes-api/workload-resources/pod-v1/#volumes-1
+      # -- volumeMounts to add to the scan job, see: https://kubernetes.io/docs/reference/kubernetes-api/workload-resources/pod-v1/#volumes-1
       # the fields: `name`, `mountPath`, `subPath`, `subPathExpr` of each volumeMount support templating
       volumeMounts: []
 
@@ -64,10 +64,10 @@ config:
       # -- annotations to be added to the scans started by the auto-discovery
       # all annotation values support templating
       annotations: {}
-      # -- volumes to add to the scan job, see: https://kubernetes.io/docs/reference/kubernetes-api/workload-resources/pod-v1/#volumes-1
+      # -- volumes to add to the scan job, see: https://kubernetes.io/docs/reference/kubernetes-api/workload-resources/pod-v1/#volumes
       # the fields: `name`, `secret.secretName`, `configMap.name` of each volume support templating
       volumes: []
-      # -- volumes to add to the scan job, see: https://kubernetes.io/docs/reference/kubernetes-api/workload-resources/pod-v1/#volumes-1
+      # -- volumeMounts to add to the scan job, see: https://kubernetes.io/docs/reference/kubernetes-api/workload-resources/pod-v1/#volumes-1
       # the fields: `name`, `mountPath`, `subPath`, `subPathExpr` of each volumeMount support templating
       volumeMounts: []
 

--- a/auto-discovery/kubernetes/values.yaml
+++ b/auto-discovery/kubernetes/values.yaml
@@ -26,21 +26,28 @@ config:
       # -- scanType used for the scans created by the serviceAutoDiscovery
       scanType: zap-advanced-scan
       # -- parameters used for the scans created by the serviceAutoDiscovery
+      # all parameters
       parameters:
         - "-t"
         - "{{ .Host.Type }}://{{ .Service.Name }}.{{ .Service.Namespace }}.svc:{{ .Host.Port }}"
       # -- interval in which scans are automatically repeated. If the target is updated (meaning a new image revision is deployed) the scan will repeated beforehand and the interval is reset.
       repeatInterval: "168h"
       # -- labels to be added to the scans started by the auto-discovery
+      # all label values support templating
       labels: {}
       # -- annotations to be added to the scans started by the auto-discovery
+      # all annotation values support templating
       annotations:
         defectdojo.securecodebox.io/product-name: "{{ .Cluster.Name }} | {{ .Namespace.Name }} | {{ .Target.Name }}"
         defectdojo.securecodebox.io/product-tags: "cluster/{{ .Cluster.Name }},namespace/{{ .Namespace.Name }}"
         defectdojo.securecodebox.io/engagement-name: "{{ .Target.Name }}"
         defectdojo.securecodebox.io/engagement-version: "{{if (index .Target.Labels `app.kubernetes.io/version`) }}{{ index .Target.Labels `app.kubernetes.io/version` }}{{end}}"
-
-
+      # -- volumes to add to the scan job, see: https://kubernetes.io/docs/reference/kubernetes-api/workload-resources/pod-v1/#volumes-1
+      # the fields: `name`, `secret.secretName`, `configMap.name` of each volume support templating
+      volumes: []
+      # -- volumes to add to the scan job, see: https://kubernetes.io/docs/reference/kubernetes-api/workload-resources/pod-v1/#volumes-1
+      # the fields: `name`, `mountPath`, `subPath`, `subPathExpr` of each volumeMount support templating
+      volumeMounts: []
 
   containerAutoDiscovery:
     enabled: false
@@ -52,10 +59,18 @@ config:
       # -- interval in which scans are automatically repeated. If the target is updated (meaning a new image revision is deployed) the scan will repeated beforehand and the interval is reset.
       repeatInterval: "168h"
       # -- labels to be added to the scans started by the auto-discovery
+      # all label values support templating
       labels: {}
       # -- annotations to be added to the scans started by the auto-discovery
+      # all annotation values support templating
       annotations: {}
-        
+      # -- volumes to add to the scan job, see: https://kubernetes.io/docs/reference/kubernetes-api/workload-resources/pod-v1/#volumes-1
+      # the fields: `name`, `secret.secretName`, `configMap.name` of each volume support templating
+      volumes: []
+      # -- volumes to add to the scan job, see: https://kubernetes.io/docs/reference/kubernetes-api/workload-resources/pod-v1/#volumes-1
+      # the fields: `name`, `mountPath`, `subPath`, `subPathExpr` of each volumeMount support templating
+      volumeMounts: []
+
   health:
     healthProbeBindAddress: :8081
   metrics:

--- a/auto-discovery/kubernetes/values.yaml
+++ b/auto-discovery/kubernetes/values.yaml
@@ -25,18 +25,15 @@ config:
     scanConfig:
       # -- scanType used for the scans created by the serviceAutoDiscovery
       scanType: zap-advanced-scan
-      # -- parameters used for the scans created by the serviceAutoDiscovery
-      # all parameters
+      # -- parameters used for the scans created by the serviceAutoDiscovery, all parameters support templating
       parameters:
         - "-t"
         - "{{ .Host.Type }}://{{ .Service.Name }}.{{ .Service.Namespace }}.svc:{{ .Host.Port }}"
       # -- interval in which scans are automatically repeated. If the target is updated (meaning a new image revision is deployed) the scan will repeated beforehand and the interval is reset.
       repeatInterval: "168h"
-      # -- labels to be added to the scans started by the auto-discovery
-      # all label values support templating
+      # -- labels to be added to the scans started by the auto-discovery, all label values support templating
       labels: {}
-      # -- annotations to be added to the scans started by the auto-discovery
-      # all annotation values support templating
+      # -- annotations to be added to the scans started by the auto-discovery, all annotation values support templating
       annotations:
         defectdojo.securecodebox.io/product-name: "{{ .Cluster.Name }} | {{ .Namespace.Name }} | {{ .Target.Name }}"
         defectdojo.securecodebox.io/product-tags: "cluster/{{ .Cluster.Name }},namespace/{{ .Namespace.Name }}"
@@ -53,16 +50,14 @@ config:
     enabled: false
     scanConfig:
       scanType: trivy
-      # -- parameters used for the scans created by the containerAutoDiscovery
+      # -- parameters used for the scans created by the containerAutoDiscovery, all parameters support templating
       parameters:
         - "{{ .ImageID }}"
       # -- interval in which scans are automatically repeated. If the target is updated (meaning a new image revision is deployed) the scan will repeated beforehand and the interval is reset.
       repeatInterval: "168h"
-      # -- labels to be added to the scans started by the auto-discovery
-      # all label values support templating
+      # -- labels to be added to the scans started by the auto-discovery, all label values support templating
       labels: {}
-      # -- annotations to be added to the scans started by the auto-discovery
-      # all annotation values support templating
+      # -- annotations to be added to the scans started by the auto-discovery, all annotation values support templating
       annotations: {}
       # -- volumes to add to the scan job, see: https://kubernetes.io/docs/reference/kubernetes-api/workload-resources/pod-v1/#volumes
       # the fields: `name`, `secret.secretName`, `configMap.name` of each volume support templating


### PR DESCRIPTION
## Description

Closes #1025 

Refactored with @the-simmon how the auto discovery generates the scan configs so that we can add this functionality in one place for both the service & container auto-discovery.

### Checklist

* [x] Test your changes as thoroughly as possible before you commit them. Preferably, automate your test by unit/integration tests.
* [x] Make sure `npm test` runs for the whole project.
