### PR TITLE
Revert "[SCB-Bot] Upgraded semgrep from 0.84.0 to 0.85.0"

### DIFF
--- a/scanners/semgrep/Chart.yaml
+++ b/scanners/semgrep/Chart.yaml
@@ -18,7 +18,7 @@ version: "v3.1.0-alpha1"
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "0.85.0"
+appVersion: "0.84.0"
 annotations:
   versionApi: https://api.github.com/repos/returntocorp/semgrep/releases/latest
 kubeVersion: ">=v1.11.0-0"

--- a/scanners/semgrep/README.md
+++ b/scanners/semgrep/README.md
@@ -3,7 +3,7 @@ title: "Semgrep"
 category: "scanner"
 type: "Repository"
 state: "released"
-appVersion: "0.85.0"
+appVersion: "0.84.0"
 usecase: "Static Code Analysis"
 ---
 

--- a/scanners/semgrep/docs/README.DockerHub-Parser.md
+++ b/scanners/semgrep/docs/README.DockerHub-Parser.md
@@ -42,7 +42,7 @@ You can find resources to help you get started on our [documentation website](ht
 
 ## Supported Tags
 - `latest`  (represents the latest stable release build)
-- tagged releases, e.g. `0.85.0`
+- tagged releases, e.g. `0.84.0`
 
 ## How to use this image
 This `parser` image is intended to work in combination with the corresponding security scanner docker image to parse the `findings` results. For more information details please take a look at the documentation page: https://docs.securecodebox.io/docs/scanners/semgrep.


### PR DESCRIPTION
The new update for semgrep has changed how files are found - it now also considers hidden folders. This leads to the test file in the integration tests being found either twice or not at all: apparently K8s, when mounting ConfigMaps, will put the real file in a hidden folder, and then symlink to it. As there is currently an [inconsistency in how symlinks are handled by semgrep](https://github.com/returntocorp/semgrep/issues/4827), I cannot simply tell the integration test the path to the (symlink) file directly, because this will be considered as "not existing" by semgrep (see linked issue).

As I don't want to update the test case with an ugly hack (e.g., trying to wildcard my way into the hidden folder k8s uses), and don't want to update the expected number of results to two times the results we would actually expect, I'm reverting the change for now to get the CI to turn green again. When the dependency bot opens a new PR, we can find a nice way of getting the CI to pass, or wait for the next semgrep release that fixes the inconsistency in symlink handling and then merge that.