### PR TITLE
Adding kind cluster name variable to common.mk makefile config (closes #1037)

### DIFF
--- a/common.mk
+++ b/common.mk
@@ -43,9 +43,12 @@ K := $(foreach exec,$(EXECUTABLES),\
 #
 # JEST_VERSION  		Defines the jest version used for executing the tests. Defaults to latest
 #
+# KIND_CLUSTER_NAME:	Defines the name of the kind cluster (created by kind create cluster --name cluster-name)
+#
 # Examples:
 # 	make all IMG_TAG=main
 # 	make deploy IMG_TAG=$(git rev-parse --short HEAD)
+#   make kind-import KIND_CLUSTER_NAME=your-cluster-name
 # 	make integration-tests
 #
 
@@ -56,8 +59,7 @@ GIT_TAG ?= $$(git rev-parse --short HEAD)
 BASE_IMG_TAG ?= sha-$(GIT_TAG)
 IMG_TAG ?= "sha-$(GIT_TAG)"
 JEST_VERSION ?= latest
-
-KIND_CLUSTER_NAME=$(shell kubectl config current-context | cut -c 6-) # Cut off kind- prefix
+KIND_CLUSTER_NAME ?= kind
 
 parser-prefix = parser
 scanner-prefix = scanner

--- a/common.mk
+++ b/common.mk
@@ -57,6 +57,8 @@ BASE_IMG_TAG ?= sha-$(GIT_TAG)
 IMG_TAG ?= "sha-$(GIT_TAG)"
 JEST_VERSION ?= latest
 
+KIND_CLUSTER_NAME=$(shell kubectl config current-context | cut -c 6-) # Cut off kind- prefix
+
 parser-prefix = parser
 scanner-prefix = scanner
 hook-prefix = hook
@@ -103,7 +105,7 @@ common-docker-export:
 
 common-kind-import:
 	@echo ".: 💾 Importing the image archive '$(module)-$(name).tar' to local kind cluster."
-	kind load image-archive ./$(module)-$(name).tar
+	kind load image-archive ./$(module)-$(name).tar --name $(KIND_CLUSTER_NAME)
 
 deploy-test-deps: deploy-test-dep-namespace
 


### PR DESCRIPTION
<!-- 
Thank you for your contribution to our Project 🙌 

Before submitting your Pull Request, please take the time to check the points below and provide some descriptive information.
* [ ] If this PR comes from a fork, please [Allow edits from maintainers](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork)
* [ ] Set a meaningful title. Format: {task_name} (closes #{issue_number}). For example: Use logger (closes #41)
* [ ] [Link your Pull Request to an issue](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) (if applicable)
* [ ] Create Draft pull requests if you need clarification or an explicit review before you can continue your work item.
* [ ] Make sure that your PR is not introducing _unnecessary_ reformatting (e.g., introduced by on-save hooks in your IDE)
* [ ] Make sure each new source file you add has a correct license header.
-->

## Description
<!-- Please be brief in describing which issue is solved by your PR or which enhancement it brings -->
The PR, once applied, makes sure that the kind command in common.mk also works with local clusters that have a different name than "kind". `kubectl config-current-context` gives the current kind cluster, but its output looks like "kind-scb" for a kind cluster named "scb", so you have to cut off the prefix with the cut command.

(closes #1037)

### Checklist

* [x] Test your changes as thoroughly as possible before you commit them. Preferably, automate your test by unit/integration tests.
* [ ] Make sure `npm test` runs for the whole project.
