### PR TITLE
Demo-target build process moved to release pipeline

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -538,68 +538,6 @@ jobs:
           echo "Operator Startup Logs"
           kubectl -n securecodebox-system logs deployment/securecodebox-controller-manager
 
-  # ---- Build | Demo-Targets | Custom ----
-
-  # This Section contains Demo-Targets that are developed by the secureCodeBox project
-  # The tag for these images will be the Semver of the release
-
-  demo-targets:
-    name: "Build | Custom Demo-Targets"
-    runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        target:
-          - old-joomla
-          - old-typo3
-          - old-wordpress
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v2
-
-      - name: Set ENV Var with Demo-Target Version
-        uses: mikefarah/yq@v4.4.1
-        # Notice: The current version of the demo-target is provided via the Chart.yaml to ensure
-        # there is only one place to edit the version of a scanner
-        with:
-          cmd: echo targetVersion=$(yq e .appVersion demo-targets/${{ matrix.target }}/Chart.yaml) >> $GITHUB_ENV
-
-      - name: Docker Meta
-        id: docker_meta
-        uses: docker/metadata-action@v3
-        with:
-          images: ${{ env.DOCKER_NAMESPACE }}/${{ matrix.target }}
-          tags: |
-            type=sha
-            latest
-            ${{ env.targetVersion }}
-
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v1
-
-      - name: Login to DockerHub
-        uses: docker/login-action@v1
-        with:
-          username: ${{ secrets.DOCKER_USERNAME }}
-          password: ${{ secrets.DOCKER_TOKEN }}
-
-      - name: Build and Push
-        uses: docker/build-push-action@v2
-        with:
-          context: ./demo-targets/${{ matrix.target }}/container
-          file: ./demo-targets/${{ matrix.target }}/container/Dockerfile
-          platforms: linux/amd64
-          push: true
-          tags: ${{ steps.docker_meta.outputs.tags }}
-          labels: ${{ steps.docker_meta.outputs.labels }}
-
-      - name: Update Docker Hub Description
-        uses: peter-evans/dockerhub-description@v2
-        with:
-          username: ${{ secrets.DOCKERHUB_USERNAME }}
-          password: ${{ secrets.DOCKERHUB_PASSWORD }}
-          repository: ${{ env.DOCKER_NAMESPACE }}/${{ matrix.target }}
-          readme-filepath: ./demo-targets/${{ matrix.target }}/docs/README.DockerHub-Target.md
-
   # ---- Integration Tests ----
 
   Integration-tests-hooks:

--- a/.github/workflows/release-build.yaml
+++ b/.github/workflows/release-build.yaml
@@ -21,7 +21,6 @@ env:
   DOCKER_NAMESPACE: ${{ secrets.DOCKER_NAMESPACE }}
 
 jobs:
-
   # ---- Operator & Lurcher ----
 
   operator:
@@ -219,7 +218,6 @@ jobs:
           password: ${{ secrets.DOCKERHUB_PASSWORD }}
           repository: ${{ env.DOCKER_NAMESPACE }}/hook-${{ matrix.hook }}
           readme-filepath: ./hooks/${{ matrix.hook }}/docs/README.DockerHub-Hook.md
-
 
   # ---- Dashboard Importer ----
 
@@ -471,3 +469,64 @@ jobs:
           password: ${{ secrets.DOCKERHUB_PASSWORD }}
           repository: ${{ env.DOCKER_NAMESPACE }}/scanner-${{ matrix.scanner }}
           readme-filepath: ./scanners/${{ matrix.scanner }}/docs/README.DockerHub-Scanner.md
+  # ---- Build | Demo-Targets | Custom ----
+
+  # This Section contains Demo-Targets that are developed by the secureCodeBox project
+  # The tag for these images will be the Semver of the release
+
+  demo-targets:
+    name: "Build | Custom Demo-Targets"
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        target:
+          - old-joomla
+          - old-typo3
+          - old-wordpress
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+
+      - name: Set ENV Var with Demo-Target Version
+        uses: mikefarah/yq@v4.4.1
+        # Notice: The current version of the demo-target is provided via the Chart.yaml to ensure
+        # there is only one place to edit the version of a scanner
+        with:
+          cmd: echo targetVersion=$(yq e .appVersion demo-targets/${{ matrix.target }}/Chart.yaml) >> $GITHUB_ENV
+
+      - name: Docker Meta
+        id: docker_meta
+        uses: docker/metadata-action@v3
+        with:
+          images: ${{ env.DOCKER_NAMESPACE }}/${{ matrix.target }}
+          tags: |
+            type=sha
+            latest
+            ${{ env.targetVersion }}
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v1
+
+      - name: Login to DockerHub
+        uses: docker/login-action@v1
+        with:
+          username: ${{ secrets.DOCKER_USERNAME }}
+          password: ${{ secrets.DOCKER_TOKEN }}
+
+      - name: Build and Push
+        uses: docker/build-push-action@v2
+        with:
+          context: ./demo-targets/${{ matrix.target }}/container
+          file: ./demo-targets/${{ matrix.target }}/container/Dockerfile
+          platforms: linux/amd64
+          push: true
+          tags: ${{ steps.docker_meta.outputs.tags }}
+          labels: ${{ steps.docker_meta.outputs.labels }}
+
+      - name: Update Docker Hub Description
+        uses: peter-evans/dockerhub-description@v2
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_PASSWORD }}
+          repository: ${{ env.DOCKER_NAMESPACE }}/${{ matrix.target }}
+          readme-filepath: ./demo-targets/${{ matrix.target }}/docs/README.DockerHub-Target.md


### PR DESCRIPTION
As requested in issue #717 the demo-targets are no longer pushed to Dockerhub on each CI Run.
Instead they are only pushed with a new SCB release, i.e the `release-build.yaml` CI pipeline.

Signed-off-by: Ilyes Ben Dlala <ilyes.bendlala@iteratec.com>

<!-- 
Thank you for your contribution to our Project 🙌 

Before submitting your Pull Request, please take the time to check the points below and provide some descriptive information.
* [ ] If this PR comes from a fork, please [Allow edits from maintainers](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork)
* [ ] Set a meaningful title. Format: {task_name} (closes #{issue_number}). For example: Use logger (closes #41)
* [ ] [Link your Pull Request to an issue](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) (if applicable)
* [ ] Create Draft pull requests if you need clarification or an explicit review before you can continue your work item.
* [ ] Make sure that your PR is not introducing _unnecessary_ reformatting (e.g., introduced by on-save hooks in your IDE)
* [ ] Make sure each new source file you add has a correct license header.
-->

## Description
<!-- Please be brief in describing which issue is solved by your PR or which enhancement it brings -->


### Checklist

* [X] Test your changes as thoroughly as possible before you commit them. Preferably, automate your test by unit/integration tests.
* [X] Make sure `npm test` runs for the whole project.
