### PR TITLE
Make common.mk use python3 (Closes #1019)

### DIFF
--- a/scanners/git-repo-scanner/Makefile
+++ b/scanners/git-repo-scanner/Makefile
@@ -12,8 +12,7 @@ custom_scanner = set
 include ../../scanners.mk
 
 unit-tests:
-	@echo "Disabled due to errors."
-	#@$(MAKE) -s unit-test-py
+	@$(MAKE) -s unit-test-py
 
 integration-tests:
 	@echo ".: 🩺 Starting integration test in kind namespace 'integration-tests'."


### PR DESCRIPTION
## Description
On some systems, the command `python` is either non-existing or actually calling `python3`. This PR, once applied, makes sure, that the correct command is selected and saved in the new `$(PYTHON)` variable and that Python version >= 3.0 is actually used (which is necessary for the makefile).

Also re-enables deactivated unit tests for git-repo-scanner.

To test if the PR works on your system, run the following commands:
```bash
cd scanners/git-repo-scanner
make unit-tests
# Should finish with all tests passed
```

Closes #1019.

### Checklist
Works and tested for the following setups:
- [x] Linux (Ubuntu)
- [x] Linux with Anaconda
- [ ] MacOs 
- [ ] PyEnv 