### PR TITLE
Update Trivy Command used in Kubernetes Container AutoDiscovery

### DIFF
--- a/auto-discovery/kubernetes/README.md
+++ b/auto-discovery/kubernetes/README.md
@@ -139,7 +139,7 @@ kubectl -n juice-shop annotate service juice-shop auto-discovery.securecodebox.i
 | config.containerAutoDiscovery.scanConfig.labels | object | `{}` | labels to be added to the scans started by the auto-discovery, all label values support templating |
 | config.containerAutoDiscovery.scanConfig.parameters | list | `["{{ .ImageID }}"]` | parameters used for the scans created by the containerAutoDiscovery, all parameters support templating |
 | config.containerAutoDiscovery.scanConfig.repeatInterval | string | `"168h"` | interval in which scans are automatically repeated. If the target is updated (meaning a new image revision is deployed) the scan will repeated beforehand and the interval is reset. |
-| config.containerAutoDiscovery.scanConfig.scanType | string | `"trivy"` |  |
+| config.containerAutoDiscovery.scanConfig.scanType | string | `"trivy-image"` |  |
 | config.containerAutoDiscovery.scanConfig.volumeMounts | list | `[]` | volumeMounts to add to the scan job, see: https://kubernetes.io/docs/reference/kubernetes-api/workload-resources/pod-v1/#volumes-1 the fields: `name`, `mountPath`, `subPath`, `subPathExpr` of each volumeMount support templating |
 | config.containerAutoDiscovery.scanConfig.volumes | list | `[]` | volumes to add to the scan job, see: https://kubernetes.io/docs/reference/kubernetes-api/workload-resources/pod-v1/#volumes the fields: `name`, `secret.secretName`, `configMap.name` of each volume support templating |
 | config.health.healthProbeBindAddress | string | `":8081"` |  |

--- a/auto-discovery/kubernetes/auto-discovery-config.yaml
+++ b/auto-discovery/kubernetes/auto-discovery-config.yaml
@@ -47,7 +47,7 @@ serviceAutoDiscovery:
 containerAutoDiscovery:
   enabled: true
   scanConfig:
-    scanType: trivy
+    scanType: trivy-image
     # -- parameters used for the scans created by the containerAutoDiscovery
     parameters:
       - "{{ .ImageID }}"

--- a/auto-discovery/kubernetes/docs/README.ArtifactHub.md
+++ b/auto-discovery/kubernetes/docs/README.ArtifactHub.md
@@ -131,7 +131,7 @@ kubectl -n juice-shop annotate service juice-shop auto-discovery.securecodebox.i
 | config.containerAutoDiscovery.scanConfig.labels | object | `{}` | labels to be added to the scans started by the auto-discovery, all label values support templating |
 | config.containerAutoDiscovery.scanConfig.parameters | list | `["{{ .ImageID }}"]` | parameters used for the scans created by the containerAutoDiscovery, all parameters support templating |
 | config.containerAutoDiscovery.scanConfig.repeatInterval | string | `"168h"` | interval in which scans are automatically repeated. If the target is updated (meaning a new image revision is deployed) the scan will repeated beforehand and the interval is reset. |
-| config.containerAutoDiscovery.scanConfig.scanType | string | `"trivy"` |  |
+| config.containerAutoDiscovery.scanConfig.scanType | string | `"trivy-image"` |  |
 | config.containerAutoDiscovery.scanConfig.volumeMounts | list | `[]` | volumeMounts to add to the scan job, see: https://kubernetes.io/docs/reference/kubernetes-api/workload-resources/pod-v1/#volumes-1 the fields: `name`, `mountPath`, `subPath`, `subPathExpr` of each volumeMount support templating |
 | config.containerAutoDiscovery.scanConfig.volumes | list | `[]` | volumes to add to the scan job, see: https://kubernetes.io/docs/reference/kubernetes-api/workload-resources/pod-v1/#volumes the fields: `name`, `secret.secretName`, `configMap.name` of each volume support templating |
 | config.health.healthProbeBindAddress | string | `":8081"` |  |

--- a/auto-discovery/kubernetes/values.yaml
+++ b/auto-discovery/kubernetes/values.yaml
@@ -49,7 +49,7 @@ config:
   containerAutoDiscovery:
     enabled: false
     scanConfig:
-      scanType: trivy
+      scanType: trivy-image
       # -- parameters used for the scans created by the containerAutoDiscovery, all parameters support templating
       parameters:
         - "{{ .ImageID }}"


### PR DESCRIPTION
This PR updates the scanType of the container autodiscovery to `trivy-image` because trivy was updated recently which changed its parameters.