### PR TITLE
Fix markdown issues in ZAP-advanced docs

### DIFF
--- a/scanners/zap-advanced/.helm-docs.gotmpl
+++ b/scanners/zap-advanced/.helm-docs.gotmpl
@@ -100,7 +100,7 @@ Additionally, there will be some ZAP Scripts included, these are stored in the c
 
 ```
 
-The following picture outlines the reference concept of the ZAP YAML configuration `zapConfiguration`. If you want to configure an `api` scan, `spider` or active 'scan` you must at least add one `context` item with a `name` and `url` configured. The context `url` must match the target url used in the `Scan` execution:
+The following picture outlines the reference concept of the ZAP YAML configuration `zapConfiguration`. If you want to configure an `api` scan, `spider` or active `scan` you must at least add one `context` item with a `name` and `url` configured. The context `url` must match the target url used in the `Scan` execution:
 
 ```yaml
 spec:
@@ -111,7 +111,7 @@ spec:
     - "http://bodgeit.default.svc:8080/bodgeit/"
 ```
 
-If you want to configure the `api` scan, `spider` or active 'scan` section it is mandatory to add the `context: ` reference the section. Otherwise it is not possible to identify which configuration must be used for a scan. The `url` in the `api` , `spider` or active 'scan` section can be different to the context.url (and scan target url).
+If you want to configure the `api` scan, `spider` or active `scan` section it is mandatory to add the `context: ` reference the section. Otherwise it is not possible to identify which configuration must be used for a scan. The `url` in the `api` , `spider` or active 'scan` section can be different to the context.url (and scan target url).
 
 ```bash
 ┌────────────────────────────────────────────────────────────────┐

--- a/scanners/zap-advanced/README.md
+++ b/scanners/zap-advanced/README.md
@@ -118,7 +118,7 @@ Additionally, there will be some ZAP Scripts included, these are stored in the c
 
 ```
 
-The following picture outlines the reference concept of the ZAP YAML configuration `zapConfiguration`. If you want to configure an `api` scan, `spider` or active 'scan` you must at least add one `context` item with a `name` and `url` configured. The context `url` must match the target url used in the `Scan` execution:
+The following picture outlines the reference concept of the ZAP YAML configuration `zapConfiguration`. If you want to configure an `api` scan, `spider` or active `scan` you must at least add one `context` item with a `name` and `url` configured. The context `url` must match the target url used in the `Scan` execution:
 
 ```yaml
 spec:
@@ -129,7 +129,7 @@ spec:
     - "http://bodgeit.default.svc:8080/bodgeit/"
 ```
 
-If you want to configure the `api` scan, `spider` or active 'scan` section it is mandatory to add the `context: ` reference the section. Otherwise it is not possible to identify which configuration must be used for a scan. The `url` in the `api` , `spider` or active 'scan` section can be different to the context.url (and scan target url).
+If you want to configure the `api` scan, `spider` or active `scan` section it is mandatory to add the `context: ` reference the section. Otherwise it is not possible to identify which configuration must be used for a scan. The `url` in the `api` , `spider` or active 'scan` section can be different to the context.url (and scan target url).
 
 ```bash
 ┌────────────────────────────────────────────────────────────────┐

--- a/scanners/zap-advanced/docs/README.ArtifactHub.md
+++ b/scanners/zap-advanced/docs/README.ArtifactHub.md
@@ -123,7 +123,7 @@ Additionally, there will be some ZAP Scripts included, these are stored in the c
 
 ```
 
-The following picture outlines the reference concept of the ZAP YAML configuration `zapConfiguration`. If you want to configure an `api` scan, `spider` or active 'scan` you must at least add one `context` item with a `name` and `url` configured. The context `url` must match the target url used in the `Scan` execution:
+The following picture outlines the reference concept of the ZAP YAML configuration `zapConfiguration`. If you want to configure an `api` scan, `spider` or active `scan` you must at least add one `context` item with a `name` and `url` configured. The context `url` must match the target url used in the `Scan` execution:
 
 ```yaml
 spec:
@@ -134,7 +134,7 @@ spec:
     - "http://bodgeit.default.svc:8080/bodgeit/"
 ```
 
-If you want to configure the `api` scan, `spider` or active 'scan` section it is mandatory to add the `context: ` reference the section. Otherwise it is not possible to identify which configuration must be used for a scan. The `url` in the `api` , `spider` or active 'scan` section can be different to the context.url (and scan target url).
+If you want to configure the `api` scan, `spider` or active `scan` section it is mandatory to add the `context: ` reference the section. Otherwise it is not possible to identify which configuration must be used for a scan. The `url` in the `api` , `spider` or active 'scan` section can be different to the context.url (and scan target url).
 
 ```bash
 ┌────────────────────────────────────────────────────────────────┐


### PR DESCRIPTION
There were some issues with the rendering of the markdown because someone had confused a `` ` `` with a `'`, which led to broken markdown formatting:
> <img width="967" alt="grafik" src="https://user-images.githubusercontent.com/1688580/162190323-5b7eab64-10ca-4da3-a125-42e3c789f2e5.png">

This PR fixes that.