### PR TITLE
Feature/authenticated generic webhook

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -37,3 +37,4 @@ Committing with `git commit -s` will add the sign-off at the end of the commit m
 - Simon Hülkenberg <simon.huelkenberg@iteratec.com>
 - Johanna Walker <johanna.walker@iteratec.com>
 - Felix Belz <felix.belz@iteratec.com>
+- Mateusz Majcher <m.majcher91@gmail.com>

--- a/hooks/generic-webhook/hook/hook.js
+++ b/hooks/generic-webhook/hook/hook.js
@@ -6,12 +6,18 @@ async function handle({
   getFindings,
   scan,
   webhookUrl = process.env["WEBHOOK_URL"],
+  webhookUser = process.env["WEBHOOK_USER"],
+  webhookPassword = process.env["WEBHOOK_PASSWORD"],
   axios = require('axios')
 }) {
   const findings = await getFindings();
 
   console.log(`Sending ${findings.length} findings to ${webhookUrl}`);
 
-  await axios.post(webhookUrl, { scan, findings });
+  if (webhookUser && webhookPassword){
+    await axios.post(webhookUrl, {scan, findings }, {auth: {username: webhookUser, password: webhookPassword}});
+  }else{
+    await axios.post(webhookUrl, {scan, findings });
+  }
 }
 module.exports.handle = handle;

--- a/hooks/generic-webhook/templates/webhook-hook.yaml
+++ b/hooks/generic-webhook/templates/webhook-hook.yaml
@@ -22,14 +22,14 @@ spec:
     - name: WEBHOOK_USER
       valueFrom:
         secretKeyRef:
-          name: {{ .Values.hook.authentication.userSecret }}
-          key: {{ .Values.hook.authentication.usernameKey }}
+          name: {{ .Values.hook.authentication.basic.userSecret }}
+          key: {{ .Values.hook.authentication.basic.usernameKey }}
           optional: true
     - name: WEBHOOK_PASSWORD
       valueFrom:
         secretKeyRef:
-          name: {{ .Values.hook.authentication.userSecret }}
-          key: {{ .Values.hook.authentication.passwordKey }}
+          name: {{ .Values.hook.authentication.basic.userSecret }}
+          key: {{ .Values.hook.authentication.basic.passwordKey }}
           optional: true
   affinity:
     {{- toYaml .Values.hook.affinity | nindent 4 }}

--- a/hooks/generic-webhook/templates/webhook-hook.yaml
+++ b/hooks/generic-webhook/templates/webhook-hook.yaml
@@ -19,6 +19,18 @@ spec:
   env:
     - name: WEBHOOK_URL
       value: {{ .Values.webhookUrl | quote }}
+    - name: WEBHOOK_USER
+      valueFrom:
+        secretKeyRef:
+          name: {{ .Values.hook.authentication.userSecret }}
+          key: {{ .Values.hook.authentication.usernameKey }}
+          optional: true
+    - name: WEBHOOK_PASSWORD
+      valueFrom:
+        secretKeyRef:
+          name: {{ .Values.hook.authentication.userSecret }}
+          key: {{ .Values.hook.authentication.passwordKey }}
+          optional: true
   affinity:
     {{- toYaml .Values.hook.affinity | nindent 4 }}
   tolerations:

--- a/hooks/generic-webhook/values.yaml
+++ b/hooks/generic-webhook/values.yaml
@@ -31,3 +31,12 @@ hook:
 
   # hook.tolerations -- Optional tolerations settings that control how the hook job is scheduled (see: https://kubernetes.io/docs/concepts/scheduling-eviction/taint-and-toleration/)
   tolerations: []
+
+  # hook.authentication -- Optional basic authentication credentials 
+  authentication:
+    # -- Link a pre-existing generic secret with `username` and `password` key / value pairs
+    userSecret: generic-webhook-credentials
+    # -- Name of the username key in the `userSecret` secret. Use this if you already have a secret with different key / value pairs
+    usernameKey: username
+    # -- Name of the password key in the `userSecret` secret. Use this if you already have a secret with different key / value pairs
+    passwordKey: password 

--- a/hooks/generic-webhook/values.yaml
+++ b/hooks/generic-webhook/values.yaml
@@ -34,9 +34,10 @@ hook:
 
   # hook.authentication -- Optional basic authentication credentials 
   authentication:
-    # -- Link a pre-existing generic secret with `usernameKey` and `passwordKey` key / value pairs
-    userSecret: generic-webhook-credentials
-    # -- Name of the username key in the `userSecret` secret. Use this if you already have a secret with different key / value pairs
-    usernameKey: username
-    # -- Name of the password key in the `userSecret` secret. Use this if you already have a secret with different key / value pairs
-    passwordKey: password 
+    basic:
+      # -- Link a pre-existing generic secret with `usernameKey` and `passwordKey` key / value pairs
+      userSecret: generic-webhook-credentials
+      # -- Name of the username key in the `userSecret` secret. Use this if you already have a secret with different key / value pairs
+      usernameKey: username
+      # -- Name of the password key in the `userSecret` secret. Use this if you already have a secret with different key / value pairs
+      passwordKey: password 

--- a/hooks/generic-webhook/values.yaml
+++ b/hooks/generic-webhook/values.yaml
@@ -34,7 +34,7 @@ hook:
 
   # hook.authentication -- Optional basic authentication credentials 
   authentication:
-    # -- Link a pre-existing generic secret with `username` and `password` key / value pairs
+    # -- Link a pre-existing generic secret with `usernameKey` and `passwordKey` key / value pairs
     userSecret: generic-webhook-credentials
     # -- Name of the username key in the `userSecret` secret. Use this if you already have a secret with different key / value pairs
     usernameKey: username


### PR DESCRIPTION
The PR is related to the **generic-webhook** ScanCompletionHook.

This small feature introduces the possibility to post a generic webhook including credentials. 

This can be helpful in CI/CD integration when the destination system requires authentication.

Credentials can be stored as Kubernetes secret.
