### PR TITLE
Added a CI trigger on Pull request

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -5,6 +5,7 @@
 name: "CI"
 on:
   push:
+  pull_request:
   schedule:
     - cron: "15 2 * * *" # Nightly-Build at 2:15 AM UTC
 


### PR DESCRIPTION
<!-- 
Thank you for your contribution to our Project 🙌 

Before submitting your Pull Request, please take the time to check the points below and provide some descriptive information.
* [ ] If this PR comes from a fork, please [Allow edits from maintainers](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork)
* [ ] Set a meaningful title. Format: {task_name} (closes #{issue_number}). For example: Use logger (closes #41)
* [ ] [Link your Pull Request to an issue](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) (if applicable)
* [ ] Create Draft pull requests if you need clarification or an explicit review before you can continue your work item.
* [ ] Make sure that your PR is not introducing _unnecessary_ reformatting (e.g., introduced by on-save hooks in your IDE)
* [ ] Make sure each new source file you add has a correct license header.
-->

## Description
<!-- Please be brief in describing which issue is solved by your PR or which enhancement it brings -->
relates to #612 
This will trigger the CI **BOTH** on pushes and pull requests opened.
That means that duplicate workflows will happen when a new PR is opened:
Example:
https://github.com/secureCodeBox/secureCodeBox/actions/runs/2194291551
https://github.com/secureCodeBox/secureCodeBox/actions/runs/2194471682

But it will allow for the CI to work on Forks
Reference: https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#using-multiple-events

Possible solution: https://github.com/marketplace/actions/skip-duplicate-actions.

Signed-off-by: Ilyes Ben Dlala <ilyes.bendlala@iteratec.com>