### PR TITLE
Removed the simply expanded variable for the ABS_PROJECT_DIR in Makefile

### DIFF
--- a/auto-discovery/kubernetes/Makefile
+++ b/auto-discovery/kubernetes/Makefile
@@ -126,7 +126,7 @@ kustomize: ## Download kustomize locally if necessary.
 
 # go-install-tool will 'go install' any package $2 and install it to $1.
 # GOBIN needs to be an absolute path so an additional absolute path project dir variable is used
-ABS_PROJECT_DIR := $(shell dirname $(abspath $(lastword $(MAKEFILE_LIST))))
+ABS_PROJECT_DIR=$(shell dirname $(abspath $(lastword $(MAKEFILE_LIST))))
 define go-install-tool
 @[ -f $(1) ] || { \
 set -e ;\

--- a/operator/Makefile
+++ b/operator/Makefile
@@ -150,7 +150,7 @@ kustomize: ## Download kustomize locally if necessary.
 
 # go-install-tool will 'go install' any package $2 and install it to $1.
 # GOBIN needs to be an absolute path so an additional absolute path project dir variable is used
-ABS_PROJECT_DIR := $(shell dirname $(abspath $(lastword $(MAKEFILE_LIST))))
+ABS_PROJECT_DIR=$(shell dirname $(abspath $(lastword $(MAKEFILE_LIST))))
 define go-install-tool
 @[ -f $(1) ] || { \
 set -e ;\


### PR DESCRIPTION
This is mainly to have consistency between the different variables
Ref: https://ftp.gnu.org/old-gnu/Manuals/make-3.79.1/html_chapter/make_6.html#SEC59

**This is also a test to see if the CI works on Forks**

Signed-off-by: Ilyes Ben Dlala <ilyes.bendlala@iteratec.com>

<!-- 
Thank you for your contribution to our Project 🙌 

Before submitting your Pull Request, please take the time to check the points below and provide some descriptive information.
* [ ] If this PR comes from a fork, please [Allow edits from maintainers](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork)
* [ ] Set a meaningful title. Format: {task_name} (closes #{issue_number}). For example: Use logger (closes #41)
* [ ] [Link your Pull Request to an issue](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) (if applicable)
* [ ] Create Draft pull requests if you need clarification or an explicit review before you can continue your work item.
* [ ] Make sure that your PR is not introducing _unnecessary_ reformatting (e.g., introduced by on-save hooks in your IDE)
* [ ] Make sure each new source file you add has a correct license header.
-->

## Description
<!-- Please be brief in describing which issue is solved by your PR or which enhancement it brings -->


### Checklist

* [x] Test your changes as thoroughly as possible before you commit them. Preferably, automate your test by unit/integration tests.
* [x] Make sure `npm test` runs for the whole project.
