### PR TITLE
Make common.mk use python3 (new) (Closes #1019) 

### DIFF
--- a/common.mk
+++ b/common.mk
@@ -25,8 +25,23 @@ ifeq ($(name),)
   $(error name ENV is not set)
 endif
 
+PYTHON = $(shell which python3)
+ifeq ($(PYTHON),)
+  PYTHON = $(shell which python)
+  ifeq ($(PYTHON),)
+  	$(error "PYTHON=$(PYTHON) not found in $(PATH)")
+  endif
+endif
+PYTHON_VERSION_MIN=3.0
+PYTHON_VERSION=$(shell $(PYTHON) -c \
+'import sys; print(float(str(sys.version_info[0]) + "." + str(sys.version_info[1])))')
+PYTHON_VERSION_OK=$(shell $(PYTHON) -c 'print(int($(PYTHON_VERSION) >= $(PYTHON_VERSION_MIN)))' )
+ifeq ($(PYTHON_VERSION_OK), 0) # True == 1
+   $(error "Need python version >= $(PYTHON_VERSION_MIN) (current: $(PYTHON_VERSION))")
+endif
+
 # Thx to https://stackoverflow.com/questions/5618615/check-if-a-program-exists-from-a-makefile
-EXECUTABLES = make docker kind git node npm npx kubectl helm yq java python
+EXECUTABLES = make docker kind git node npm npx kubectl helm yq java $(PYTHON)
 ALL_EXECUTABLES_OK := $(foreach exec,$(EXECUTABLES),\
         $(if $(shell which $(exec)),some string,$(error "ERROR: The prerequisites are not met to execute this makefile! No '$(exec)' found in your PATH")))
 
@@ -83,11 +98,11 @@ unit-test-js: install-deps-js
 
 install-deps-py:
 	@echo ".: ⚙️ Installing all $(module) specific python dependencies."
-	python -m pip install --upgrade pip setuptools wheel pytest
-	cd $(module)/ && pip install -r requirements.txt
+	$(PYTHON) -m pip install --upgrade pip setuptools wheel pytest
+	cd $(module)/ && $(PYTHON) -m pip install -r requirements.txt
 
 unit-test-py: install-deps-py
-	cd $(module)/ && pytest --ignore-glob='*_local.py' --ignore=tests/docker
+	cd $(module)/ && $(PYTHON) -m pytest --ignore-glob='*_local.py' --ignore=tests/docker
 
 unit-test-java:
 	cd $(module)/ && ./gradlew test
@@ -146,7 +161,7 @@ deploy-test-dep-juiceshop:
 
 deploy-test-dep-vulnerable-log4j:
 	# Install vulnerable-log4j app
-	helm -n demo-targets upgrade --install vulnerable-log4j ../../demo-targets/vulnerable-log4j/ --set="fullnameOverride=vulnerable-log4j" --wait	
+	helm -n demo-targets upgrade --install vulnerable-log4j ../../demo-targets/vulnerable-log4j/ --set="fullnameOverride=vulnerable-log4j" --wait
 
 deploy-test-dep-nginx:
 	# Delete leftover nginx's. Unfortunately can't create deployment only if not exists (like namespaces)

--- a/common.mk
+++ b/common.mk
@@ -27,7 +27,7 @@ endif
 
 # Thx to https://stackoverflow.com/questions/5618615/check-if-a-program-exists-from-a-makefile
 EXECUTABLES = make docker kind git node npm npx kubectl helm yq java python
-K := $(foreach exec,$(EXECUTABLES),\
+ALL_EXECUTABLES_OK := $(foreach exec,$(EXECUTABLES),\
         $(if $(shell which $(exec)),some string,$(error "ERROR: The prerequisites are not met to execute this makefile! No '$(exec)' found in your PATH")))
 
 # Variables you might want to override:

--- a/scanners/git-repo-scanner/Makefile
+++ b/scanners/git-repo-scanner/Makefile
@@ -12,8 +12,7 @@ custom_scanner = set
 include ../../scanners.mk
 
 unit-tests:
-	@echo "Disabled due to errors."
-	#@$(MAKE) -s unit-test-py
+	@$(MAKE) -s unit-test-py
 
 integration-tests:
 	@echo ".: 🩺 Starting integration test in kind namespace 'integration-tests'."


### PR DESCRIPTION
## Description
On some systems, the command `python` is either non-existing or actually calling `python3`. This PR, once applied, makes sure, that the correct command is selected and saved in the new `$(PYTHON)` variable and that Python version >= 3.0 is actually used (which is necessary for the makefile).

Also re-enables deactivated unit tests for git-repo-scanner.

To test if the PR works on your system, run the following commands:
```bash
cd scanners/git-repo-scanner
make unit-tests
# Should finish with all tests passed
```

Closes #1019.

### Checklist
Works and tested for the following setups:
- [x] Linux (Ubuntu)
- [x] Linux with Anaconda
- [x] MacOs 
- [x] PyEnv 

*This is a new version of the old pull-request #1071 which had a failed rebase and unsigned commits.* 