### PR TITLE
Use venv when installing deps with pip

### DIFF
--- a/common.mk
+++ b/common.mk
@@ -103,11 +103,11 @@ $(PYTHON_VENV_NAME):
 
 install-deps-py: | $(PYTHON_VENV_NAME)
 	@echo ".: ⚙️ Installing all $(module) specific python dependencies."
-	./venv/bin/pip install --upgrade pip setuptools wheel pytest
-	./venv/bin/pip install -r $(module)/requirements.txt
+	./$(PYTHON_VENV_NAME)/bin/pip install --upgrade pip setuptools wheel pytest
+	./$(PYTHON_VENV_NAME)/bin/pip install -r $(module)/requirements.txt
 
 unit-test-py: install-deps-py
-	cd $(module)/ && ../venv/bin/python -m pytest --ignore-glob='*_local.py' --ignore=tests/docker
+	cd $(module)/ && ../$(PYTHON_VENV_NAME)/bin/python -m pytest --ignore-glob='*_local.py' --ignore=tests/docker
 
 unit-test-java:
 	cd $(module)/ && ./gradlew test

--- a/common.mk
+++ b/common.mk
@@ -98,11 +98,13 @@ unit-test-js: install-deps-js
 
 install-deps-py:
 	@echo ".: ⚙️ Installing all $(module) specific python dependencies."
-	$(PYTHON) -m pip install --upgrade pip setuptools wheel pytest
-	cd $(module)/ && $(PYTHON) -m pip install -r requirements.txt
+	@echo "Creating venv to avoid installing deps system wide"
+	$(PYTHON) -m venv venv
+	./venv/bin/pip install --upgrade pip setuptools wheel pytest
+	./venv/bin/pip install -r $(module)/requirements.txt
 
 unit-test-py: install-deps-py
-	cd $(module)/ && $(PYTHON) -m pytest --ignore-glob='*_local.py' --ignore=tests/docker
+	cd $(module)/ && ../venv/bin/python -m pytest --ignore-glob='*_local.py' --ignore=tests/docker
 
 unit-test-java:
 	cd $(module)/ && ./gradlew test

--- a/common.mk
+++ b/common.mk
@@ -75,6 +75,7 @@ BASE_IMG_TAG ?= sha-$(GIT_TAG)
 IMG_TAG ?= "sha-$(GIT_TAG)"
 JEST_VERSION ?= latest
 KIND_CLUSTER_NAME ?= kind
+PYTHON_VENV_NAME ?= venv
 
 parser-prefix = parser
 scanner-prefix = scanner
@@ -96,10 +97,12 @@ unit-test-js: install-deps-js
 	@echo ".: 🧪 Starting unit-tests for '$(name)' $(module) with 'jest@$(JEST_VERSION)'."
 	npx --yes --package jest@$(JEST_VERSION) jest --ci --colors --coverage --passWithNoTests ${name}/${module}/
 
-install-deps-py:
-	@echo ".: ⚙️ Installing all $(module) specific python dependencies."
+$(PYTHON_VENV_NAME):
 	@echo "Creating venv to avoid installing deps system wide"
-	$(PYTHON) -m venv venv
+	$(PYTHON) -m venv $(PYTHON_VENV_NAME)
+
+install-deps-py: | $(PYTHON_VENV_NAME)
+	@echo ".: ⚙️ Installing all $(module) specific python dependencies."
 	./venv/bin/pip install --upgrade pip setuptools wheel pytest
 	./venv/bin/pip install -r $(module)/requirements.txt
 

--- a/scanners/git-repo-scanner/.helmignore
+++ b/scanners/git-repo-scanner/.helmignore
@@ -38,3 +38,4 @@ integration-tests/*
 examples/*
 docs/*
 Makefile
+venv # venv folder name is specified in common.mk

--- a/scanners/git-repo-scanner/Makefile
+++ b/scanners/git-repo-scanner/Makefile
@@ -21,3 +21,23 @@ integration-tests:
 	#cd ../../tests/integration/ && npm ci
 	#cd ../../scanners/${scanner}
 	#npx --yes --package jest@$(JEST_VERSION) jest --verbose --ci --colors --coverage --passWithNoTests ${scanner}/integration-tests
+
+deploy-without-scanner:
+	rm -rf venv # delete venv. Otherwise it would be deployed with zap
+	@echo ".: 💾 Deploying '$(name)' $(scanner-prefix) HelmChart with the docker tag '$(IMG_TAG)' into kind namespace 'integration-tests'."
+	helm -n integration-tests upgrade --install $(name) ./ --wait \
+		--set="parser.image.repository=docker.io/$(IMG_NS)/$(parser-prefix)-$(name)" \
+		--set="parser.image.tag=$(IMG_TAG)" \
+    --set="parser.env[0].name=CRASH_ON_FAILED_VALIDATION" \
+    --set-string="parser.env[0].value=true"
+
+deploy-with-scanner:
+	rm -rf venv # delete venv. Otherwise it would be deployed with zap
+	@echo ".: 💾 Deploying '$(name)' $(scanner-prefix) HelmChart with the docker tag '$(IMG_TAG)' into kind namespace 'integration-tests'."
+	helm -n integration-tests upgrade --install $(name) ./ --wait \
+		--set="parser.image.repository=docker.io/$(IMG_NS)/$(parser-prefix)-$(name)" \
+		--set="parser.image.tag=$(IMG_TAG)" \
+    --set="parser.env[0].name=CRASH_ON_FAILED_VALIDATION" \
+    --set-string="parser.env[0].value=true" \
+		--set="scanner.image.repository=docker.io/$(IMG_NS)/$(scanner-prefix)-$(name)" \
+		--set="scanner.image.tag=$(IMG_TAG)"

--- a/scanners/git-repo-scanner/Makefile
+++ b/scanners/git-repo-scanner/Makefile
@@ -21,23 +21,3 @@ integration-tests:
 	#cd ../../tests/integration/ && npm ci
 	#cd ../../scanners/${scanner}
 	#npx --yes --package jest@$(JEST_VERSION) jest --verbose --ci --colors --coverage --passWithNoTests ${scanner}/integration-tests
-
-deploy-without-scanner:
-	rm -rf venv # delete venv. Otherwise it would be deployed with zap
-	@echo ".: 💾 Deploying '$(name)' $(scanner-prefix) HelmChart with the docker tag '$(IMG_TAG)' into kind namespace 'integration-tests'."
-	helm -n integration-tests upgrade --install $(name) ./ --wait \
-		--set="parser.image.repository=docker.io/$(IMG_NS)/$(parser-prefix)-$(name)" \
-		--set="parser.image.tag=$(IMG_TAG)" \
-    --set="parser.env[0].name=CRASH_ON_FAILED_VALIDATION" \
-    --set-string="parser.env[0].value=true"
-
-deploy-with-scanner:
-	rm -rf venv # delete venv. Otherwise it would be deployed with zap
-	@echo ".: 💾 Deploying '$(name)' $(scanner-prefix) HelmChart with the docker tag '$(IMG_TAG)' into kind namespace 'integration-tests'."
-	helm -n integration-tests upgrade --install $(name) ./ --wait \
-		--set="parser.image.repository=docker.io/$(IMG_NS)/$(parser-prefix)-$(name)" \
-		--set="parser.image.tag=$(IMG_TAG)" \
-    --set="parser.env[0].name=CRASH_ON_FAILED_VALIDATION" \
-    --set-string="parser.env[0].value=true" \
-		--set="scanner.image.repository=docker.io/$(IMG_NS)/$(scanner-prefix)-$(name)" \
-		--set="scanner.image.tag=$(IMG_TAG)"

--- a/scanners/zap-advanced/.helmignore
+++ b/scanners/zap-advanced/.helmignore
@@ -44,3 +44,4 @@ integration-tests/*
 examples/*
 docs/*
 Makefile
+venv # venv folder name is specified in common.mk

--- a/scanners/zap-advanced/Makefile
+++ b/scanners/zap-advanced/Makefile
@@ -30,6 +30,7 @@ kind-import-parser:
 	cd $(SCANNERS_DIR)/zap/ && $(MAKE) -s kind-import-parser
 
 deploy-with-scanner:
+	rm -rf venv # delete venv. Otherwise it would be deployed with zap
 	@echo ".: 💾 Deploying custom '$(scanner)' scanner HelmChart with the docker tag '$(IMG_TAG)' into kind namespace 'integration-tests'."
 	helm -n integration-tests upgrade --install $(scanner) ./ --wait \
 		--set="parser.image.repository=docker.io/$(IMG_NS)/$(parser-prefix)-zap" \

--- a/scanners/zap-advanced/Makefile
+++ b/scanners/zap-advanced/Makefile
@@ -29,15 +29,6 @@ docker-export-parser:
 kind-import-parser:
 	cd $(SCANNERS_DIR)/zap/ && $(MAKE) -s kind-import-parser
 
-deploy-with-scanner:
-	rm -rf venv # delete venv. Otherwise it would be deployed with zap
-	@echo ".: 💾 Deploying custom '$(scanner)' scanner HelmChart with the docker tag '$(IMG_TAG)' into kind namespace 'integration-tests'."
-	helm -n integration-tests upgrade --install $(scanner) ./ --wait \
-		--set="parser.image.repository=docker.io/$(IMG_NS)/$(parser-prefix)-zap" \
-		--set="parser.image.tag=$(IMG_TAG)" \
-		--set="scanner.image.repository=docker.io/$(IMG_NS)/$(scanner-prefix)-$(scanner)" \
-		--set="scanner.image.tag=$(IMG_TAG)"
-
 deploy-test-deps: deploy-test-dep-nginx deploy-test-dep-bodgeit deploy-test-dep-juiceshop deploy-test-dep-petstore
 
 integration-tests:


### PR DESCRIPTION
This PR closes #1150.
The make target `install-deps-py` and `unit-test-py` will now use a virtual environment (venv) instead of installing packages system wide.
This can be tested by running `make unit-tests` in the zap-advaned folder.