### PR TITLE
New Trello type for the notification hook

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -38,3 +38,4 @@ Committing with `git commit -s` will add the sign-off at the end of the commit m
 - Johanna Walker <johanna.walker@iteratec.com>
 - Felix Belz <felix.belz@iteratec.com>
 - Mateusz Majcher <m.majcher91@gmail.com>
+- Guillermo Rodriguez <guimo.spritekin@gmail.com>

--- a/hooks/notification/docs/README.ArtifactHub.md
+++ b/hooks/notification/docs/README.ArtifactHub.md
@@ -340,17 +340,19 @@ Card Body: <location> <category> <description> <attributes>
 ```
 
 ##### Requirements: 
-- Please read the [Trello API documentation](https://developer.atlassian.com/cloud/trello/guides/rest-api/api-introduction/) for a description on how to setup your Trello key and token. You 
+- Please read the [Trello API documentation](https://developer.atlassian.com/cloud/trello/guides/rest-api/api-introduction/) for a description on how to setup your Trello key and token.
 - Identify your target card list where the new cards will be created and get the list ID. To find the card list and label ids use the Trello JSON hack as described here https://stackoverflow.com/questions/26552278/trello-api-getting-boards-lists-cards-information
+- Read the [Trello Cards API](https://developer.atlassian.com/cloud/trello/rest/api-group-cards) for more information on the card creation options.
 
 ##### Configuration
 To configure a Trello notification set the `type` to `trello` and the `endPoint` to point to your env containing the Trello cards API endpoint. You also need to define the following env vars (if an env var is not defined it will take the default value, if required and not set the notification won't be sent):
 - TRELLO_CARDS_ENDPOINT: The Trello cards API endpoint. Default: https://api.trello.com/1/cards.
 - TRELLO_KEY: Your Trello API key. Reade the requirements above. Required.
-- TRELLO_TOKEN: Your Trello API token. Reade the requirements above. Required.
-- TRELLO_LIST: Id if the list where the cards will be placed. Required.
-- TRELLO_LABELS: Comma separated list of label IDs to apply to the card. If empty no labels will be applied. Default: "")
-- TRELLO_POS: The position in the list where the new card will be placed as defined by the Trello cards API. Default: top.
+- TRELLO_TOKEN: Your Trello API token. Read the requirements above. Required.
+- TRELLO_LIST: Trello unique Id if the list where the cards will be placed. Required.
+- TRELLO_LABELS: Comma separated list of Trello label IDs to apply to the card. If empty no labels will be applied. Default: ""
+- TRELLO_POS: The position of the card in the list as defined by the Trello cards API. Options: top, bottom, or a positive float. Default: top.
+- TRELLO_TITLE_PREFIX: An optional  arbitrary text to add to the title of the card. Default "".
 
 
 ##### Example Config
@@ -359,7 +361,7 @@ The below example shows how to create a helm values chart and load secrets for a
 You must have `endPoint` point to a [defined environment variable](https://github.com/secureCodeBox/secureCodeBox/blob/main/hooks/notification/hook/hook.ts#L20), not a string.
 
 ```
-# cat myvalues.yaml
+# cat trello_values.yaml
 
 notificationChannels:
   - name: nmapopenports
@@ -389,19 +391,21 @@ env:
       value: "111a111b222c333f,555a666b777c888d"
     - name: TRELLO_POS
       value: top
+    - name: TRELLO_TITLE_PREFIX
+      value: "Alert! "
 
-# cat values_trello_secrets.yaml
+# cat trello_secrets.yaml
 apiVersion: v1
 kind: Secret
 metadata:
     name: trello
 type: Opaque
 data:
-    key: <MYTRELLOAPIKEY>
-    token: <MYTRELLOAPITOKEN>
+    key: YOURSECRETTRELLOAPIKEY
+    token: YOURSECRETTRELLOAPITOKEN
 
-kubectl apply -f values_trello_secrets.yaml
-helm upgrade --install nwh secureCodeBox/notification-hook --values myvalues.yaml
+kubectl apply -f trello_secrets.yaml
+helm upgrade --install nwh secureCodeBox/notification-hook --values trello_values.yaml
 ```
 
 ### Custom Message Templates

--- a/hooks/notification/docs/README.ArtifactHub.md
+++ b/hooks/notification/docs/README.ArtifactHub.md
@@ -347,7 +347,7 @@ Card Body: <location> <category> <description> <attributes>
 ##### Configuration
 To configure a Trello notification set the `type` to `trello` and the `endPoint` to point to your env containing the Trello cards API endpoint. You also need to define the following env vars (if an env var is not defined it will take the default value, if required and not set the notification won't be sent):
 - TRELLO_CARDS_ENDPOINT: The Trello cards API endpoint. Default: https://api.trello.com/1/cards.
-- TRELLO_KEY: Your Trello API key. Reade the requirements above. Required.
+- TRELLO_KEY: Your Trello API key. Read the requirements above. Required.
 - TRELLO_TOKEN: Your Trello API token. Read the requirements above. Required.
 - TRELLO_LIST: Trello unique Id if the list where the cards will be placed. Required.
 - TRELLO_LABELS: Comma separated list of Trello label IDs to apply to the card. If empty no labels will be applied. Default: ""

--- a/hooks/notification/docs/README.ArtifactHub.md
+++ b/hooks/notification/docs/README.ArtifactHub.md
@@ -349,7 +349,7 @@ To configure a Trello notification set the `type` to `trello` and the `endPoint`
 - TRELLO_CARDS_ENDPOINT: The Trello cards API endpoint. Default: https://api.trello.com/1/cards.
 - TRELLO_KEY: Your Trello API key. Read the requirements above. Required.
 - TRELLO_TOKEN: Your Trello API token. Read the requirements above. Required.
-- TRELLO_LIST: Trello unique Id if the list where the cards will be placed. Required.
+- TRELLO_LIST: Trello unique Id of the list where the cards will be placed. Required.
 - TRELLO_LABELS: Comma separated list of Trello label IDs to apply to the card. If empty no labels will be applied. Default: ""
 - TRELLO_POS: The position of the card in the list as defined by the Trello cards API. Options: top, bottom, or a positive float. Default: top.
 - TRELLO_TITLE_PREFIX: An optional  arbitrary text to add to the title of the card. Default "".

--- a/hooks/notification/docs/README.ArtifactHub.md
+++ b/hooks/notification/docs/README.ArtifactHub.md
@@ -400,7 +400,7 @@ kind: Secret
 metadata:
     name: trello
 type: Opaque
-data:
+stringData:
     key: YOURSECRETTRELLOAPIKEY
     token: YOURSECRETTRELLOAPITOKEN
 

--- a/hooks/notification/hook/NotifierFactory.test.ts
+++ b/hooks/notification/hook/NotifierFactory.test.ts
@@ -13,6 +13,7 @@ import { NotifierType } from "./NotifierType";
 
 const finding: Finding = {
   name: "test finding",
+  description: "test finding description",
   location: "hostname",
   category: "Open Port",
   severity: "high",

--- a/hooks/notification/hook/NotifierFactory.test.ts
+++ b/hooks/notification/hook/NotifierFactory.test.ts
@@ -8,6 +8,7 @@ import { Scan } from "./model/Scan";
 import { NotifierFactory } from "./NotifierFactory"
 import { SlackNotifier } from "./Notifiers/SlackNotifier";
 import { MSTeamsNotifier } from "./Notifiers/MSTeamsNotifier";
+import { TrelloNotifier } from "./Notifiers/TrelloNotifier";
 import { NotifierType } from "./NotifierType";
 
 const finding: Finding = {
@@ -89,4 +90,20 @@ test("Should Create MS Teams Notifier", async () => {
   const s = NotifierFactory.create(chan, scan, findings, []);
 
   expect(s instanceof MSTeamsNotifier).toBe(true);
+})
+
+test("Should Create Trello Notifier", async () => {
+  const chan: NotificationChannel = {
+    name: "trello",
+    type: NotifierType.TRELLO,
+    template: "template",
+    rules: [],
+    endPoint: "some.endpoint"
+  }
+  const findings: Finding[] = []
+  findings.push(finding)
+
+  const s = NotifierFactory.create(chan, scan, findings, []);
+
+  expect(s instanceof TrelloNotifier).toBe(true);
 })

--- a/hooks/notification/hook/NotifierFactory.ts
+++ b/hooks/notification/hook/NotifierFactory.ts
@@ -8,6 +8,7 @@ import { SlackNotifier } from "./Notifiers/SlackNotifier";
 import { SlackAppNotifier } from "./Notifiers/SlackAppNotifier";
 import { EMailNotifier } from "./Notifiers/EMailNotifier";
 import { MSTeamsNotifier } from "./Notifiers/MSTeamsNotifier";
+import { TrelloNotifier } from "./Notifiers/TrelloNotifier";
 import { NotificationChannel } from "./model/NotificationChannel";
 import { Scan } from "./model/Scan";
 import { Finding } from "./model/Finding";
@@ -28,6 +29,8 @@ export class NotifierFactory {
         return new SlackAppNotifier(channel, scan, findings, args);
       case NotifierType.MS_TEAMS:
         return new MSTeamsNotifier(channel, scan, findings, args);
+      case NotifierType.TRELLO:
+        return new TrelloNotifier(channel, scan, findings, args);
       default:
         throw new Error("This Type is not Implemented :(");
     }

--- a/hooks/notification/hook/NotifierType.ts
+++ b/hooks/notification/hook/NotifierType.ts
@@ -7,4 +7,5 @@ export enum NotifierType {
   SLACK_APP = "slack-app",
   MS_TEAMS = "ms-teams",
   EMAIL = "email",
+  TRELLO = "trello",
 }

--- a/hooks/notification/hook/Notifiers/TrelloNotifier.test.ts
+++ b/hooks/notification/hook/Notifiers/TrelloNotifier.test.ts
@@ -1,0 +1,105 @@
+// SPDX-FileCopyrightText: the secureCodeBox authors
+//
+// SPDX-License-Identifier: Apache-2.0
+
+import { TrelloNotifier } from "./TrelloNotifier";
+import axios from 'axios'
+import { NotificationChannel } from "../model/NotificationChannel";
+import { NotifierType } from "../NotifierType";
+import { Scan } from "../model/Scan";
+
+jest.mock('axios');
+
+beforeEach(() => {
+  jest.clearAllMocks();
+})
+
+const channel: NotificationChannel = {
+  name: "Channel Name",
+  type: NotifierType.TRELLO,
+  template: "",
+  rules: [],
+  endPoint: "https://api.trello.com/1/cards"
+};
+
+test("Should Create Cards With Findings And Severities", async () => {
+
+  const scan: Scan = {
+    metadata: {
+      uid: "09988cdf-1fc7-4f85-95ee-1b1d65dbc7cc",
+      name: "demo-scan-1601086432",
+      namespace: "my-scans",
+      creationTimestamp: new Date("2021-01-01T14:29:25Z"),
+      labels: {
+        company: "iteratec",
+        "attack-surface": "external",
+      },
+    },
+    spec: {
+      scanType: "Nmap",
+      parameters: ["-Pn", "localhost"],
+    },
+    status: {
+      findingDownloadLink:
+        "https://my-secureCodeBox-instance.com/scan-b9as-sdweref--sadf-asdfsdf-dasdgf-asdffdsfa7/findings.json",
+      findings: {
+        categories: {
+          "A Client Error response code was returned by the server": 1,
+          "Information Disclosure - Sensitive Information in URL": 1,
+          "Strict-Transport-Security Header Not Set": 1,
+        },
+        count: 3,
+        severities: {
+          high: 10,
+          medium: 5,
+          low: 2,
+          informational: 1,
+        },
+      },
+      finishedAt: new Date("2020-05-25T02:38:13Z"),
+      rawResultDownloadLink:
+        "https://my-secureCodeBox-instance.com/scan-blkfsdg-sdgfsfgd-sfg-sdfg-dfsg-gfs98-e8af2172caa7/zap-results.json?Expires=1601691232",
+      rawResultFile: "zap-results.json",
+      rawResultType: "zap-json",
+      state: "Done",
+    },
+  };
+
+  const trelloNotifier = new TrelloNotifier(channel, scan, [], []);
+  trelloNotifier.sendMessage();
+  expect(axios.post).toBeCalled();
+});
+
+test("Should Send Minimal Template For Empty Findings", async () => {
+  const scan: Scan = {
+    metadata: {
+      uid: "09988cdf-1fc7-4f85-95ee-1b1d65dbc7cc",
+      name: "demo-scan-1601086432",
+      namespace: "my-scans",
+      creationTimestamp: new Date("2021-01-01T14:29:25Z"),
+      labels: {
+        company: "iteratec",
+        "attack-surface": "external",
+      },
+    },
+    spec: {
+      scanType: "Nmap",
+      parameters: ["-Pn", "localhost"],
+    },
+    status: {
+      findingDownloadLink:
+        "https://my-secureCodeBox-instance.com/scan-b9as-sdweref--sadf-asdfsdf-dasdgf-asdffdsfa7/findings.json",
+      findings: {},
+      finishedAt: new Date("2020-05-25T02:38:13Z"),
+      rawResultDownloadLink:
+        "https://my-secureCodeBox-instance.com/scan-blkfsdg-sdgfsfgd-sfg-sdfg-dfsg-gfs98-e8af2172caa7/zap-results.json?Expires=1601691232",
+      rawResultFile: "zap-results.json",
+      rawResultType: "zap-json",
+      state: "Done",
+    },
+  };
+
+  const n = new TrelloNotifier(channel, scan, [], []);
+  n.sendMessage();
+  expect(axios.post).toBeCalled();
+})

--- a/hooks/notification/hook/Notifiers/TrelloNotifier.test.ts
+++ b/hooks/notification/hook/Notifiers/TrelloNotifier.test.ts
@@ -14,6 +14,16 @@ beforeEach(() => {
   jest.clearAllMocks();
 })
 
+const finding: Finding = {
+  name: "test finding",
+  description: "test finding description",
+  location: "hostname",
+  category: "Open Port",
+  severity: "high",
+  osi_layer: "asdf",
+  attributes: new Map(),
+};
+
 const channel: NotificationChannel = {
   name: "Channel Name",
   type: NotifierType.TRELLO,
@@ -65,7 +75,10 @@ test("Should Create Cards With Findings And Severities", async () => {
     },
   };
 
-  const trelloNotifier = new TrelloNotifier(channel, scan, [], []);
+  const findings: Finding[] = []
+  findings.push(finding)
+
+  const trelloNotifier = new TrelloNotifier(channel, scan, findings, []);
   trelloNotifier.sendMessage();
   expect(axios.post).toBeCalled();
 });
@@ -99,7 +112,10 @@ test("Should Send Minimal Template For Empty Findings", async () => {
     },
   };
 
-  const n = new TrelloNotifier(channel, scan, [], []);
-  n.sendMessage();
+  const findings: Finding[] = []
+  findings.push(finding)
+
+  const trelloNotifier = new TrelloNotifier(channel, scan, findings, []);
+  trelloNotifier.sendMessage();
   expect(axios.post).toBeCalled();
 })

--- a/hooks/notification/hook/Notifiers/TrelloNotifier.test.ts
+++ b/hooks/notification/hook/Notifiers/TrelloNotifier.test.ts
@@ -4,6 +4,7 @@
 
 import { TrelloNotifier } from "./TrelloNotifier";
 import axios from 'axios'
+import { Finding } from "../model/Finding";
 import { NotificationChannel } from "../model/NotificationChannel";
 import { NotifierType } from "../NotifierType";
 import { Scan } from "../model/Scan";

--- a/hooks/notification/hook/Notifiers/TrelloNotifier.ts
+++ b/hooks/notification/hook/Notifiers/TrelloNotifier.ts
@@ -34,7 +34,7 @@ export class TrelloNotifier extends AbstractWebHookNotifier {
     if(TrelloNotifier.TRELLO_CARDS_ENDPOINT in process.env) { 
       return super.resolveEndPoint(); 
     }
-    return "https://api.trello.com/1/cards"
+    return "https://api.trello.com/1/cards";
   }
 
   // The Trello hook will create a card for each finding
@@ -83,7 +83,7 @@ export class TrelloNotifier extends AbstractWebHookNotifier {
     if(TrelloNotifier.TRELLO_LABELS in process.env) { 
       return process.env[TrelloNotifier.TRELLO_LABELS];
     }
-    return ""
+    return "";
   }
 
   // If card pos env not defined return top
@@ -91,7 +91,7 @@ export class TrelloNotifier extends AbstractWebHookNotifier {
     if(TrelloNotifier.TRELLO_POS in process.env) { 
       return process.env[TrelloNotifier.TRELLO_POS];
     }
-    return "top"
+    return "top";
   }
 
   // Any user defined prefix to add to the card title
@@ -99,7 +99,7 @@ export class TrelloNotifier extends AbstractWebHookNotifier {
     if(TrelloNotifier.TRELLO_TITLE_PREFIX in process.env) { 
       return process.env[TrelloNotifier.TRELLO_TITLE_PREFIX];
     }
-    return ""
+    return "";
   }
 
   // Constructs the card name from the finding
@@ -108,7 +108,9 @@ export class TrelloNotifier extends AbstractWebHookNotifier {
   }
 
   private getCardDescription(finding: Finding): string {
-    let res = "Location: " + finding.location + "\n" +
+
+    let res = "Scan Type: " + this.scan.spec.scanType + "\n" +
+          "Location: " + finding.location + "\n" +
           "Description: " + finding.description + "\n";
 
     // Add Zap specific information if available

--- a/hooks/notification/hook/Notifiers/TrelloNotifier.ts
+++ b/hooks/notification/hook/Notifiers/TrelloNotifier.ts
@@ -1,0 +1,109 @@
+// SPDX-FileCopyrightText: the secureCodeBox authors
+//
+// SPDX-License-Identifier: Apache-2.0
+
+import { NotifierType } from "../NotifierType"
+import { AbstractWebHookNotifier } from "./AbstractWebHookNotifier"
+import { Finding } from "../model/Finding"
+import { matches } from "../hook";
+import axios from 'axios';
+import { NotificationChannel } from "../model/NotificationChannel";
+import { Scan } from "../model/Scan";
+
+export class TrelloNotifier extends AbstractWebHookNotifier {
+
+  public static readonly TRELLO_CARDS_ENDPOINT = 'TRELLO_CARDS_ENDPOINT';
+  public static readonly TRELLO_KEY = 'TRELLO_KEY';
+  public static readonly TRELLO_TOKEN = 'TRELLO_TOKEN';
+  public static readonly TRELLO_LIST = 'TRELLO_LIST';
+  public static readonly TRELLO_LABELS = 'TRELLO_LABELS';
+  public static readonly TRELLO_POS = 'TRELLO_POS';
+
+  protected type: NotifierType = NotifierType.TRELLO
+
+  constructor(channel: NotificationChannel, scan: Scan, findings: Finding[], args: Object) {
+    super(channel, scan, findings, args);
+  }
+
+  /**
+   * Trello cards API has a default endpoint https://api.trello.com/1/cards
+   * So if the TRELLO_CARDS_ENDPOINT env is not explicitly defined then default to that URL
+   */
+  public resolveEndPoint(): string {
+    if(TrelloNotifier.TRELLO_CARDS_ENDPOINT in process.env) { 
+      return super.resolveEndPoint(); 
+    }
+    return "https://api.trello.com/1/cards"
+  }
+
+  // The Trello hook will create a card for each finding
+  public async sendMessage(): Promise<void> {
+    for ( let idx in this.findings ) {
+      var jsonData = {
+          "key": this.getTrelloKey(),
+          "token": this.getTrelloToken(),
+          "idList": this.getTrelloList(),
+          "name": this.getCardName(this.findings[idx]),
+          "desc": this.getCardDescription(this.findings[idx]),
+          "pos": this.getTrelloPos()
+      }
+
+      // Add the labels only if defined    
+      if(this.getTrelloLabels().length > 0)
+        jsonData["idLabels"] = this.getTrelloLabels();
+
+      await this.sendJSONPostRequest(jsonData);
+    }
+  }
+
+  protected async sendJSONPostRequest( jsonData ) {
+    try {
+      await axios.post(this.resolveEndPoint(), jsonData)
+    } catch (e) {
+      console.log(`There was an Error sending the Message for the "${this.type}": "${this.channel.name}"`);
+      console.log(e);
+    }
+  }
+
+  private getTrelloKey(): string {
+    return process.env[TrelloNotifier.TRELLO_KEY];
+  }
+
+  private getTrelloToken(): string {
+    return process.env[TrelloNotifier.TRELLO_TOKEN];
+  }
+
+  private getTrelloList(): string {
+    return process.env[TrelloNotifier.TRELLO_LIST];
+  }
+
+  // If labels env not defined return empty string
+  private getTrelloLabels(): string {
+    if(TrelloNotifier.TRELLO_LABELS in process.env) { 
+      return process.env[TrelloNotifier.TRELLO_LABELS];
+    }
+    return ""
+  }
+
+  // If card pos env not defined return top
+  private getTrelloPos(): string {
+    if(TrelloNotifier.TRELLO_POS in process.env) { 
+      return process.env[TrelloNotifier.TRELLO_POS];
+    }
+    return "top"
+  }
+
+  // Constructs the card name from the finding
+  private getCardName(finding: Finding): string {
+    return "ZAP: " + finding.name + "(" + finding.severity + ")";
+  }
+
+  private getCardDescription(finding: Finding): string {
+    return  "Location: " + finding.location + "\n" +
+            "Description: " + finding.description + "\n" +
+            "Solution: " + finding.attributes["zap_solution"] + "\n" +
+            "Reference: " + finding.attributes["zap_reference"];
+  }
+
+
+}

--- a/hooks/notification/hook/Notifiers/TrelloNotifier.ts
+++ b/hooks/notification/hook/Notifiers/TrelloNotifier.ts
@@ -18,6 +18,7 @@ export class TrelloNotifier extends AbstractWebHookNotifier {
   public static readonly TRELLO_LIST = 'TRELLO_LIST';
   public static readonly TRELLO_LABELS = 'TRELLO_LABELS';
   public static readonly TRELLO_POS = 'TRELLO_POS';
+  public static readonly TRELLO_TITLE_PREFIX = 'TRELLO_TITLE_PREFIX';
 
   protected type: NotifierType = NotifierType.TRELLO
 
@@ -93,16 +94,32 @@ export class TrelloNotifier extends AbstractWebHookNotifier {
     return "top"
   }
 
+  // Any user defined prefix to add to the card title
+  private getTrelloTitlePrefix(): string {
+    if(TrelloNotifier.TRELLO_TITLE_PREFIX in process.env) { 
+      return process.env[TrelloNotifier.TRELLO_TITLE_PREFIX];
+    }
+    return ""
+  }
+
   // Constructs the card name from the finding
   private getCardName(finding: Finding): string {
-    return "ZAP: " + finding.name + "(" + finding.severity + ")";
+    return this.getTrelloTitlePrefix() + finding.name + "(" + finding.severity + ")";
   }
 
   private getCardDescription(finding: Finding): string {
-    return  "Location: " + finding.location + "\n" +
-            "Description: " + finding.description + "\n" +
-            "Solution: " + finding.attributes["zap_solution"] + "\n" +
-            "Reference: " + finding.attributes["zap_reference"];
+    let res = "Location: " + finding.location + "\n" +
+          "Description: " + finding.description + "\n";
+
+    // Add Zap specific information if available
+    if(finding.attributes.size > 0) {
+      if("zap_solution" in finding.attributes)
+        res += "Solution: " + finding.attributes["zap_solution"] + "\n";
+      if("zap_reference" in finding.attributes)
+        res += "Reference: " + finding.attributes["zap_reference"] + "\n";
+    }
+
+    return res;
   }
 
 

--- a/hooks/notification/hook/__testfiles__/trello.json
+++ b/hooks/notification/hook/__testfiles__/trello.json
@@ -1,0 +1,9 @@
+{
+    "key": "my_trello__key",
+    "token": "my_trello_token",
+    "idList": "109a221b30b4f8a5a4b679a7",
+    "name": "Test",
+    "desc": "TestRawData",
+    "pos": "top",
+    "idLabels": "11178a222bf5333c6e444804,1113f2222c3233308d444fc1"
+}

--- a/hooks/notification/hook/hook.test.ts
+++ b/hooks/notification/hook/hook.test.ts
@@ -11,6 +11,7 @@ import { NotifierType } from "./NotifierType";
 test("Should Match for High Severity Findings", async () => {
   const finding: Finding = {
     name: "test finding",
+    description: "test finding description",
     location: "hostname",
     category: "Open Port",
     severity: "high",
@@ -33,6 +34,7 @@ test("Should Match for High Severity Findings", async () => {
 test("Should Not Match for High Severity Findings", async () => {
   const finding: Finding = {
     name: "test finding",
+    description: "test finding description",
     location: "hostname",
     category: "Open Port",
     severity: "high",
@@ -56,6 +58,7 @@ test("Should Not Match for High Severity Findings", async () => {
 test("Should Match for Multiple 'anyOf' Rules", async () => {
   const finding: Finding = {
     name: "test finding",
+    description: "test finding description",
     location: "hostname",
     category: "Open Port",
     severity: "high",
@@ -81,6 +84,7 @@ test("Should Match for Multiple 'anyOf' Rules", async () => {
 test("Should NOT Match Multiple 'anyOf' Rules", async () => {
   const finding: Finding = {
     name: "test finding",
+    description: "test finding description",
     location: "hostname",
     category: "Open Port",
     severity: "high",
@@ -107,6 +111,7 @@ test("Should NOT Match Multiple 'anyOf' Rules", async () => {
 test("Should Match Multiple 'and' Rules", async () => {
   const finding: Finding = {
     name: "test finding",
+    description: "test finding description",
     location: "hostname",
     category: "Open Port",
     severity: "high",
@@ -141,6 +146,7 @@ test("Should Match Multiple 'and' Rules", async () => {
 test("Should Not Match Multiple 'and' Rules", async () => {
   const finding: Finding = {
     name: "test finding",
+    description: "test finding description",
     location: "hostname",
     category: "Open Port",
     severity: "high",
@@ -175,6 +181,7 @@ test("Should Not Match Multiple 'and' Rules", async () => {
 test("Should Match If No Rules Provided", async () => {
   const finding: Finding = {
     name: "test finding",
+    description: "test finding description",
     location: "hostname",
     category: "Open Port",
     severity: "high",

--- a/hooks/notification/hook/model/Finding.ts
+++ b/hooks/notification/hook/model/Finding.ts
@@ -4,6 +4,7 @@
 
 export interface Finding {
   name: string;
+  description: string;
   location: string;
   category: string;
   severity: string;


### PR DESCRIPTION
<!-- 
Thank you for your contribution to our Project 🙌 

Before submitting your Pull Request, please take the time to check the points below and provide some descriptive information.
* [ ] If this PR comes from a fork, please [Allow edits from maintainers](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork)
* [ ] Set a meaningful title. Format: {task_name} (closes #{issue_number}). For example: Use logger (closes #41)
* [ ] [Link your Pull Request to an issue](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) (if applicable)
* [ ] Create Draft pull requests if you need clarification or an explicit review before you can continue your work item.
* [ ] Make sure that your PR is not introducing _unnecessary_ reformatting (e.g., introduced by on-save hooks in your IDE)
* [ ] Make sure each new source file you add has a correct license header.
-->

## Description
<!-- Please be brief in describing which issue is solved by your PR or which enhancement it brings -->
Defines a new Trello notification type allowing the findings to be sent to Trello as cards. Implements issue secureCodeBox/secureCodeBox#1148. (https://github.com/secureCodeBox/secureCodeBox/issues/1148)

### Checklist

* [ x ] Test your changes as thoroughly as possible before you commit them. Preferably, automate your test by unit/integration tests.
* [ x ] Make sure `npm test` runs for the whole project. 

Sorry I was unable to run the "npm test" command as it kept throwing configuration errors. I think the problems originated here:
https://github.com/secureCodeBox/secureCodeBox/commit/3f001cf653514a6225960a6b7f29dcaf995e424c
https://github.com/secureCodeBox/secureCodeBox/runs/5836145105?check_suite_focus=true

When that change is removed the tests run fine.

However I have built the image and tested this code in a production level server and is working fine.
