### PR TITLE
Removed module type from hooks/package.json

### DIFF
--- a/hooks/package.json
+++ b/hooks/package.json
@@ -2,7 +2,6 @@
   "name": "@securecodebox/hooks",
   "version": "1.0.0",
   "description": "NPM library to easily set up new hooks for the secureCodeBox",
-  "type": "module",
   "homepage": "https://www.secureCodeBox.io",
   "repository": {
     "type": "git",


### PR DESCRIPTION
This is a remnant from previous testing. It should be removed since it results into the npm tests failing as discovered in PR #1153.

Signed-off-by: Ilyes Ben Dlala <ilyes.bendlala@iteratec.com>

<!-- 
Thank you for your contribution to our Project 🙌 

Before submitting your Pull Request, please take the time to check the points below and provide some descriptive information.
* [ ] If this PR comes from a fork, please [Allow edits from maintainers](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork)
* [ ] Set a meaningful title. Format: {task_name} (closes #{issue_number}). For example: Use logger (closes #41)
* [ ] [Link your Pull Request to an issue](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) (if applicable)
* [ ] Create Draft pull requests if you need clarification or an explicit review before you can continue your work item.
* [ ] Make sure that your PR is not introducing _unnecessary_ reformatting (e.g., introduced by on-save hooks in your IDE)
* [ ] Make sure each new source file you add has a correct license header.
-->