### PR TITLE
Add Multi-Platform Builds for ARM Container Images

### DIFF
--- a/.github/workflows/release-build.yaml
+++ b/.github/workflows/release-build.yaml
@@ -367,6 +367,7 @@ jobs:
           - ncrack
           - nmap
           - nikto
+          - sslyze
           - typo3scan
           - whatweb
 
@@ -440,7 +441,6 @@ jobs:
           - screenshooter
           - test-scan
           - zap-advanced
-          - sslyze
     steps:
       - name: Checkout
         uses: actions/checkout@v2

--- a/.github/workflows/release-build.yaml
+++ b/.github/workflows/release-build.yaml
@@ -56,7 +56,7 @@ jobs:
         with:
           context: ./${{ matrix.component }}
           file: ./${{ matrix.component }}/Dockerfile
-          platforms: linux/amd64
+          platforms: linux/amd64,linux/arm64
           push: true
           tags: ${{ steps.docker_meta.outputs.tags }}
           labels: ${{ steps.docker_meta.outputs.labels }}
@@ -101,7 +101,7 @@ jobs:
         with:
           context: ./auto-discovery/kubernetes/
           file: ./auto-discovery/kubernetes/Dockerfile
-          platforms: linux/amd64
+          platforms: linux/amd64,linux/arm64
           push: true
           tags: ${{ steps.docker_meta.outputs.tags }}
           labels: ${{ steps.docker_meta.outputs.labels }}

--- a/.github/workflows/release-build.yaml
+++ b/.github/workflows/release-build.yaml
@@ -192,6 +192,8 @@ jobs:
             type=sha
             type=semver,pattern={{version}}
 
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v2
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v1
 
@@ -213,7 +215,7 @@ jobs:
           build-args: |
             namespace=${{ env.DOCKER_NAMESPACE }}
             baseImageTag=${{ env.baseImageTag }}
-          platforms: linux/amd64
+          platforms: linux/amd64,linux/arm64
           push: true
           tags: ${{ steps.docker_meta.outputs.tags }}
           labels: ${{ steps.docker_meta.outputs.labels }}

--- a/.github/workflows/release-build.yaml
+++ b/.github/workflows/release-build.yaml
@@ -42,6 +42,8 @@ jobs:
             type=sha
             type=semver,pattern={{version}}
 
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v2
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v1
 
@@ -87,6 +89,8 @@ jobs:
             type=sha
             type=semver,pattern={{version}}
 
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v2
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v1
 
@@ -137,6 +141,8 @@ jobs:
             type=sha
             type=semver,pattern={{version}}
 
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v2
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v1
 

--- a/.github/workflows/release-build.yaml
+++ b/.github/workflows/release-build.yaml
@@ -151,7 +151,7 @@ jobs:
         with:
           context: ./${{ matrix.sdk }}/nodejs
           file: ./${{ matrix.sdk }}/nodejs/Dockerfile
-          platforms: linux/amd64
+          platforms: linux/amd64,linux/arm64
           push: true
           tags: ${{ steps.docker_meta.outputs.tags }}
           labels: ${{ steps.docker_meta.outputs.labels }}

--- a/.github/workflows/release-build.yaml
+++ b/.github/workflows/release-build.yaml
@@ -381,6 +381,12 @@ jobs:
         with:
           cmd: echo scannerVersion=$(yq e .appVersion scanners/${{ matrix.scanner }}/Chart.yaml) >> $GITHUB_ENV
 
+      # extract the supported cpu architectures from the Chart.yaml
+      - name: Set ENV Var with Supported Platforms
+        uses: mikefarah/yq@v4.4.1
+        with:
+          cmd: echo supportedPlatforms=$(yq e .annotations.supported-platforms scanners/${{ matrix.scanner }}/Chart.yaml) >> $GITHUB_ENV
+
       - name: Docker Meta
         id: docker_meta
         uses: docker/metadata-action@v3
@@ -406,7 +412,7 @@ jobs:
           file: ./scanners/${{ matrix.scanner }}/scanner/Dockerfile
           build-args: |
             scannerVersion=${{ env.scannerVersion }}
-          platforms: linux/amd64
+          platforms: ${{ env.supportedPlatforms }}
           push: true
           tags: ${{ steps.docker_meta.outputs.tags }}
           labels: ${{ steps.docker_meta.outputs.labels }}

--- a/.github/workflows/release-build.yaml
+++ b/.github/workflows/release-build.yaml
@@ -307,6 +307,8 @@ jobs:
             type=sha
             type=semver,pattern={{version}}
 
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v2
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v1
 
@@ -328,7 +330,7 @@ jobs:
           build-args: |
             namespace=${{ env.DOCKER_NAMESPACE }}
             baseImageTag=${{ env.baseImageTag }}
-          platforms: linux/amd64
+          platforms: linux/amd64,linux/arm64
           push: true
           tags: ${{ steps.docker_meta.outputs.tags }}
           labels: ${{ steps.docker_meta.outputs.labels }}

--- a/.yamllint.yaml
+++ b/.yamllint.yaml
@@ -1,0 +1,2 @@
+rules:
+  document-start: disable

--- a/auto-discovery/kubernetes/Dockerfile
+++ b/auto-discovery/kubernetes/Dockerfile
@@ -20,7 +20,7 @@ COPY controllers/ controllers/
 COPY pkg/ pkg/
 
 # Build
-RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 GO111MODULE=on go build -a -o manager main.go
+RUN CGO_ENABLED=0 go build -a -o manager main.go
 
 # Use distroless as minimal base image to package the manager binary
 # Refer to https://github.com/GoogleContainerTools/distroless for more details

--- a/hooks/persistence-azure-monitor/hook/Dockerfile
+++ b/hooks/persistence-azure-monitor/hook/Dockerfile
@@ -1,4 +1,5 @@
 ARG baseImageTag
+ARG namespace
 FROM node:16-alpine as build
 RUN mkdir -p /home/app
 WORKDIR /home/app

--- a/hooks/persistence-azure-monitor/hook/Dockerfile
+++ b/hooks/persistence-azure-monitor/hook/Dockerfile
@@ -5,7 +5,7 @@ WORKDIR /home/app
 COPY package.json package-lock.json ./
 RUN npm ci --production
 
-FROM securecodebox/hook-sdk-nodejs:${baseImageTag:-latest}
+FROM ${namespace:-securecodebox}/hook-sdk-nodejs:${baseImageTag:-latest}
 WORKDIR /home/app/hook-wrapper/hook/
 COPY --from=build --chown=app:app /home/app/node_modules/ ./node_modules/
 COPY --chown=app:app ./hook.js ./hook.js

--- a/lurker/Dockerfile
+++ b/lurker/Dockerfile
@@ -17,7 +17,7 @@ RUN go mod download
 COPY main.go main.go
 
 # Build
-RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 GO111MODULE=on go build -a -o lurker main.go
+RUN CGO_ENABLED=0 go build -a -o lurker main.go
 
 # Use distroless as minimal base image to package the manager binary
 # Refer to https://github.com/GoogleContainerTools/distroless for more details

--- a/operator/Dockerfile
+++ b/operator/Dockerfile
@@ -21,7 +21,7 @@ COPY internal/ internal/
 COPY utils/ utils/
 
 # Build
-RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 GO111MODULE=on go build -a -o manager main.go
+RUN CGO_ENABLED=0 go build -a -o manager main.go
 
 # Use distroless as minimal base image to package the manager binary
 # Refer to https://github.com/GoogleContainerTools/distroless for more details

--- a/scanners/angularjs-csti-scanner/Chart.yaml
+++ b/scanners/angularjs-csti-scanner/Chart.yaml
@@ -13,7 +13,7 @@ appVersion: "3.0.6"
 kubeVersion: ">=v1.11.0-0"
 
 annotations:
-  versionApi : https://api.github.com/repos/tijme/angularjs-csti-scanner/releases/latest
+  versionApi: https://api.github.com/repos/tijme/angularjs-csti-scanner/releases/latest
   # supported cpu architectures for which docker images for the scanner should be build
   supported-platforms: linux/amd64
 

--- a/scanners/angularjs-csti-scanner/Chart.yaml
+++ b/scanners/angularjs-csti-scanner/Chart.yaml
@@ -14,6 +14,8 @@ kubeVersion: ">=v1.11.0-0"
 
 annotations:
   versionApi : https://api.github.com/repos/tijme/angularjs-csti-scanner/releases/latest
+  # supported cpu architectures for which docker images for the scanner should be build
+  supported-platforms: linux/amd64
 
 keywords:
   - security

--- a/scanners/cmseek/Chart.yaml
+++ b/scanners/cmseek/Chart.yaml
@@ -15,6 +15,8 @@ kubeVersion: ">=v1.11.0-0"
 
 annotations:
   versionApi: https://api.github.com/repos/Tuhinshubhra/CMSeeK/releases/latest
+  # supported cpu architectures for which docker images for the scanner should be build
+  supported-platforms: linux/amd64
 
 keywords:
   - security

--- a/scanners/cmseek/parser/Dockerfile
+++ b/scanners/cmseek/parser/Dockerfile
@@ -4,6 +4,6 @@
 
 ARG namespace
 ARG baseImageTag
-FROM securecodebox/parser-sdk-nodejs:${baseImageTag:-latest}
+FROM ${namespace:-securecodebox}/parser-sdk-nodejs:${baseImageTag:-latest}
 WORKDIR /home/app/parser-wrapper/parser/
 COPY --chown=app:app ./parser.js ./parser.js

--- a/scanners/kube-hunter/Chart.yaml
+++ b/scanners/kube-hunter/Chart.yaml
@@ -12,6 +12,8 @@ appVersion: "0.6.5"
 kubeVersion: ">=v1.11.0-0"
 annotations:
   versionApi: https://api.github.com/repos/aquasecurity/kube-hunter/releases/latest
+  # supported cpu architectures for which docker images for the scanner should be build
+  supported-platforms: linux/amd64
 keywords:
   - security
   - kube-hunter

--- a/scanners/kubeaudit/Chart.yaml
+++ b/scanners/kubeaudit/Chart.yaml
@@ -11,6 +11,8 @@ appVersion: "0.16.0"
 kubeVersion: ">=v1.11.0-0"
 annotations:
   versionApi: https://api.github.com/repos/Shopify/kubeaudit/releases/latest
+  # supported cpu architectures for which docker images for the scanner should be build
+  supported-platforms: linux/amd64
 keywords:
   - security
   - kubeaudit

--- a/scanners/ncrack/Chart.yaml
+++ b/scanners/ncrack/Chart.yaml
@@ -14,7 +14,8 @@ kubeVersion: ">=v1.11.0-0"
 
 annotations:
   versionApi: https://api.github.com/repos/nmap/ncrack/releases/latest 
-
+  # supported cpu architectures for which docker images for the scanner should be build
+  supported-platforms: linux/amd64
 keywords:
   - security
   - ncrack

--- a/scanners/ncrack/Chart.yaml
+++ b/scanners/ncrack/Chart.yaml
@@ -13,7 +13,7 @@ appVersion: "0.7"
 kubeVersion: ">=v1.11.0-0"
 
 annotations:
-  versionApi: https://api.github.com/repos/nmap/ncrack/releases/latest 
+  versionApi: https://api.github.com/repos/nmap/ncrack/releases/latest
   # supported cpu architectures for which docker images for the scanner should be build
   supported-platforms: linux/amd64
 keywords:

--- a/scanners/nikto/Chart.yaml
+++ b/scanners/nikto/Chart.yaml
@@ -13,6 +13,10 @@ version: v3.1.0-alpha1
 appVersion: 2.5.0
 kubeVersion: ">=v1.11.0-0"
 
+annotations:
+  # supported cpu architectures for which docker images for the scanner should be build
+  supported-platforms: linux/amd64
+
 keywords:
   - security
   - nikto

--- a/scanners/nmap/Chart.yaml
+++ b/scanners/nmap/Chart.yaml
@@ -11,7 +11,9 @@ type: application
 version: v3.1.0-alpha1
 appVersion: "7.92-r2"
 kubeVersion: ">=v1.11.0-0"
-
+annotations:
+  # supported cpu architectures for which docker images for the scanner should be build
+  supported-platforms: linux/amd64
 keywords:
   - security
   - nmap

--- a/scanners/nmap/Chart.yaml
+++ b/scanners/nmap/Chart.yaml
@@ -13,7 +13,7 @@ appVersion: "7.92-r2"
 kubeVersion: ">=v1.11.0-0"
 annotations:
   # supported cpu architectures for which docker images for the scanner should be build
-  supported-platforms: linux/amd64
+  supported-platforms: linux/amd64,linux/arm64
 keywords:
   - security
   - nmap

--- a/scanners/semgrep/parser/Dockerfile
+++ b/scanners/semgrep/parser/Dockerfile
@@ -1,5 +1,5 @@
 ARG namespace
 ARG baseImageTag
-FROM securecodebox/parser-sdk-nodejs:${baseImageTag:-latest}
+FROM ${namespace:-securecodebox}/parser-sdk-nodejs:${baseImageTag:-latest}
 WORKDIR /home/app/parser-wrapper/parser/
 COPY --chown=app:app ./parser.js ./parser.js

--- a/scanners/sslyze/Chart.yaml
+++ b/scanners/sslyze/Chart.yaml
@@ -12,7 +12,7 @@ appVersion: "5.0.4"
 kubeVersion: ">=v1.11.0-0"
 annotations:
   versionApi: https://api.github.com/repos/nabla-c0d3/sslyze/releases/latest
-  supportedPlatforms: linux/amd64
+  supported-platforms: linux/amd64
 keywords:
   - security
   - ssl

--- a/scanners/sslyze/Chart.yaml
+++ b/scanners/sslyze/Chart.yaml
@@ -12,6 +12,7 @@ appVersion: "5.0.4"
 kubeVersion: ">=v1.11.0-0"
 annotations:
   versionApi: https://api.github.com/repos/nabla-c0d3/sslyze/releases/latest
+  supportedPlatforms: linux/amd64
 keywords:
   - security
   - ssl

--- a/scanners/typo3scan/Chart.yaml
+++ b/scanners/typo3scan/Chart.yaml
@@ -12,6 +12,8 @@ appVersion: "v1.0.1"
 kubeVersion: ">=v1.11.0-0"
 annotations:
   versionApi: https://api.github.com/repos/whoot/Typo3Scan/releases/latest
+  # supported cpu architectures for which docker images for the scanner should be build
+  supported-platforms: linux/amd64
 keywords:
   - security
   - typo3scan

--- a/scanners/typo3scan/parser/Dockerfile
+++ b/scanners/typo3scan/parser/Dockerfile
@@ -4,6 +4,6 @@
 
 ARG namespace
 ARG baseImageTag
-FROM securecodebox/parser-sdk-nodejs:${baseImageTag:-latest}
+FROM ${namespace:-securecodebox}/parser-sdk-nodejs:${baseImageTag:-latest}
 WORKDIR /home/app/parser-wrapper/parser/
 COPY --chown=app:app ./parser.js ./parser.js

--- a/scanners/whatweb/Chart.yaml
+++ b/scanners/whatweb/Chart.yaml
@@ -14,6 +14,8 @@ kubeVersion: ">=v1.11.0-0"
 
 annotations:
   versionApi: https://api.github.com/repos/urbanadventurer/WhatWeb/releases/latest
+  # supported cpu architectures for which docker images for the scanner should be build
+  supported-platforms: linux/amd64
 
 keywords:
   - security


### PR DESCRIPTION
Closes #1026

## Description

This PR add multi platform builds for both x86 and arm based docker images for all central components (operator / lurker / auto discovery, parser & hook sdk) and also for all our parsers and hooks.

At the moment not all scanners support arm images. Amass, Nuclei & Trivy already have multi platform images pushed so these already work nicely. 

I've updated our builds for the 3rd party scanners we build to make it configurable for which architectures we are building the image. This is set via the annotations.supported-platforms annotation in the helm chart. This is currently only enabled for nmap. It might work directly with more images, but I haven't tested them yet. I think this is already enough as a starting point and can be expended as needed.

I've tested the builds on my fork and run a few builds to test this. Looks good :)
Images build during the test can be found in my own docker hub account, e.g. the operator image: https://hub.docker.com/r/j12934/operator/tags

### Checklist

* [x] Test your changes as thoroughly as possible before you commit them. Preferably, automate your test by unit/integration tests.
* [x] Make sure `npm test` runs for the whole project.
