### PR TITLE
Fixed the path for dashboard-importer in release-build.yaml

### DIFF
--- a/.github/workflows/release-build.yaml
+++ b/.github/workflows/release-build.yaml
@@ -258,8 +258,8 @@ jobs:
       - name: Build and Push
         uses: docker/build-push-action@v2
         with:
-          context: ./hooks/persistence-elastic/dashboardImporter
-          file: ./hooks/persistence-elastic/dashboardImporter/Dockerfile
+          context: ./hooks/persistence-elastic/dashboard-importer/
+          file: ./hooks/persistence-elastic/dashboard-importer/Dockerfile
           platforms: linux/amd64
           push: true
           tags: ${{ steps.docker_meta.outputs.tags }}


### PR DESCRIPTION
Release build of dashboard-importer of v3.11.0 failed. This fixes the causing issue.

The failed image can be built and pushed manually to dockerhub through the following:
```bash
cd hooks/persistence-elastic/
make dashboard-importer-docker-build
docker tag securecodebox/persistence-elastic-dashboard-importer:sha-e521002e securecodebox/persistence-elastic-dashboard-importer:3.11.0
docker push securecodebox/persistence-elastic-dashboard-importer:3.11.0
```

Signed-off-by: Ilyes Ben Dlala <ilyes.bendlala@iteratec.com>

<!-- 
Thank you for your contribution to our Project 🙌 

Before submitting your Pull Request, please take the time to check the points below and provide some descriptive information.
* [ ] If this PR comes from a fork, please [Allow edits from maintainers](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork)
* [ ] Set a meaningful title. Format: {task_name} (closes #{issue_number}). For example: Use logger (closes #41)
* [ ] [Link your Pull Request to an issue](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) (if applicable)
* [ ] Create Draft pull requests if you need clarification or an explicit review before you can continue your work item.
* [ ] Make sure that your PR is not introducing _unnecessary_ reformatting (e.g., introduced by on-save hooks in your IDE)
* [ ] Make sure each new source file you add has a correct license header.
-->
