### PR TITLE
Fix yq compatibility

### DIFF
--- a/common.mk
+++ b/common.mk
@@ -110,7 +110,7 @@ unit-test-java:
 common-docker-build:
 	@echo ".: ⚙️ Build '$(name)' $(module) with BASE_IMG_TAG: '$(BASE_IMG_TAG)'."
 	docker build \
-		--build-arg=scannerVersion=$(shell yq e .appVersion ./Chart.yaml) \
+		--build-arg=scannerVersion=$(shell yq -e .appVersion ./Chart.yaml) \
 		--build-arg=baseImageTag=$(BASE_IMG_TAG) \
 		--build-arg=namespace=$(IMG_NS) \
 		-t $(IMG_NS)/$(module)-$(name):$(IMG_TAG) \


### PR DESCRIPTION
This PR fixes compatibilty with `yq`. There are (at least) two implementations of yq.
https://github.com/kislyuk/yq (Arch linux uses this, unless one installs `go-yq`)
https://github.com/mikefarah/yq (our CI uses this)

Our makefiles use `yq e`. The second yq implementation reads this as `yq -e` the first one doesnt. I changed it to `yq -e` to be compatible with both implementations.