### PR TITLE
Increase nuclei integration test timeout

### DIFF
--- a/scanners/nuclei/integration-tests/nuclei.test.js
+++ b/scanners/nuclei/integration-tests/nuclei.test.js
@@ -33,11 +33,11 @@ test(
       "nuclei-scb",
       "nuclei",
       ["-no-interactsh", "-u", "http://www.secureCodeBox.io"],
-      180
+      300
     );
 
     expect(count).toBeGreaterThanOrEqual(1);
     expect(severities["informational"]).toBeGreaterThanOrEqual(1);
   },
-  3 * 60 * 1000
+  5 * 60 * 1000
 );


### PR DESCRIPTION
It seems that nuclei sometimes fails because of a timeout defined in the integration test. The current timeout is 3 minutes. On my machine the integration tests need ~130-150 seconds, so the tests are approaching the timeout.
I increased the timeout to 5 minutes. This should fix the failing nuclei tests in the CI.