### PR TITLE
Maintenance/defectdojo hook

### DIFF
--- a/hooks/persistence-defectdojo/Makefile
+++ b/hooks/persistence-defectdojo/Makefile
@@ -13,3 +13,7 @@ include ../../hooks.mk
 .PHONY: unit-tests
 unit-tests:
 	@$(MAKE) -s unit-test-java
+
+.PHONY: integration-tests
+integration-tests: ## 🩺 Start integration test for this module in the namespace "integration-tests"
+	@echo "No integration tests for $(hook) defined!"

--- a/hooks/persistence-defectdojo/hook/Dockerfile
+++ b/hooks/persistence-defectdojo/hook/Dockerfile
@@ -2,7 +2,7 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-FROM gradle:jdk11 as build
+FROM gradle:jdk17 as build
 COPY . /home/gradle/src
 WORKDIR /home/gradle/src
 RUN ./gradlew build -x test

--- a/hooks/persistence-defectdojo/hook/build.gradle
+++ b/hooks/persistence-defectdojo/hook/build.gradle
@@ -9,7 +9,7 @@ plugins {
 
 group = 'io.securecodebox'
 version = '0.1.0-SNAPSHOT'
-sourceCompatibility = '11'
+sourceCompatibility = '17'
 
 repositories {
 	mavenCentral()

--- a/hooks/persistence-defectdojo/hook/build.gradle
+++ b/hooks/persistence-defectdojo/hook/build.gradle
@@ -4,7 +4,7 @@
 
 plugins {
 	id 'java'
-  id "io.freefair.lombok" version "5.3.0"
+  id "io.freefair.lombok" version "6.5.0-rc1"
 }
 
 group = 'io.securecodebox'
@@ -46,6 +46,8 @@ test {
 def mainClassName = "io.securecodebox.persistence.DefectDojoPersistenceProvider"
 
 jar {
+  duplicatesStrategy = DuplicatesStrategy.EXCLUDE
+  
   manifest {
     attributes "Main-Class": "$mainClassName"
   }

--- a/hooks/persistence-defectdojo/hook/gradle/wrapper/gradle-wrapper.properties
+++ b/hooks/persistence-defectdojo/hook/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.6.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.4.2-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists


### PR DESCRIPTION
This PR updates the Defectdojo hook to JDK 17. Closes https://github.com/secureCodeBox/secureCodeBox/issues/1054

First I updated the Gradle Version we use to the newest because the version we use currently does not support JDK 17. Doing this I got an error regarding lombok about some unexported modules. 
```java.lang.IllegalAccessError: class lombok.javac.apt.LombokProcessor (in unnamed module @0x2c90820d) cannot access class com.sun.tools.javac.processing.JavacProcessingEnvironment (in module jdk.compiler) because module jdk.compiler does not export com.sun.tools.javac.processing to unnamed module @0x2c90820d```
I updated lombok to the newest version and it fixed the error. (I guess the old lombok version used some deprecated apis).

Another error occurred: `Entry META-INF/LICENSE is a duplicate but no duplicate handling strategy has been set`. I [used](https://stackoverflow.com/questions/67265308/gradle-entry-classpath-is-a-duplicate-but-no-duplicate-handling-strategy-has-b) this solution from Stackoverflow: `duplicatesStrategy = DuplicatesStrategy.EXCLUDE` in build.gradle.
Maybe there is a different solution but for now it works.

After this the build works. The unit test succeed and I also tested the hook locally and it successfully uploaded findings into a local Defectdojo instance.
Additionally I noticed that there are no integration tests defined (so no hook.test.js file is presented). Running `make test` which will run `make integration-tests` has weird behavior then. Jest will run the integration tests of all hooks which fails. I overwrote the `ìntegration-tests` target to stop this behavior. Now `make test`only runs the correct hook tests for the defectdojo hook.