### PR TITLE
Add Wpscan wrapper

### DIFF
--- a/scanners/wpscan/Makefile
+++ b/scanners/wpscan/Makefile
@@ -7,6 +7,7 @@
 
 include_guard = set
 scanner = wpscan
+custom_scanner = set
 
 include ../../scanners.mk
 

--- a/scanners/wpscan/scanner/Dockerfile
+++ b/scanners/wpscan/scanner/Dockerfile
@@ -1,0 +1,18 @@
+
+# SPDX-FileCopyrightText: 2021 iteratec GmbH
+#
+# SPDX-License-Identifier: Apache-2.0
+
+ARG scannerVersion
+
+FROM wpscanteam/wpscan:$scannerVersion
+
+COPY wrapper.sh /wrapper.sh
+
+USER root
+
+RUN mkdir /home/securecodebox/
+
+USER wpscan
+
+ENTRYPOINT [ "sh", "/wrapper.sh" ]

--- a/scanners/wpscan/scanner/wrapper.sh
+++ b/scanners/wpscan/scanner/wrapper.sh
@@ -1,0 +1,7 @@
+# SPDX-FileCopyrightText: 2021 iteratec GmbH
+#
+# SPDX-License-Identifier: Apache-2.0
+
+wpscan $@
+echo "wpscan exited with $?"
+exit 0

--- a/scanners/wpscan/scanner/wrapper.sh
+++ b/scanners/wpscan/scanner/wrapper.sh
@@ -4,4 +4,7 @@
 
 wpscan $@
 echo "wpscan exited with $?"
+
+# wpscan returns a non zero exit code when it finds vulnerabilitys
+# see https://github.com/wpscanteam/CMSScanner/blob/master/lib/cms_scanner/exit_code.rb
 exit 0

--- a/scanners/wpscan/scanner/wrapper.sh
+++ b/scanners/wpscan/scanner/wrapper.sh
@@ -3,8 +3,16 @@
 # SPDX-License-Identifier: Apache-2.0
 
 wpscan $@
-echo "wpscan exited with $?"
+wpscan_exit=$?
+echo "wpscan exited with $wpscan_exit"
 
 # wpscan returns a non zero exit code when it finds vulnerabilitys
+# exit codes 1, 2 and 3 are errors, 5 means vulnerabilitys were found
 # see https://github.com/wpscanteam/CMSScanner/blob/master/lib/cms_scanner/exit_code.rb
-exit 0
+fake_exit_code=0
+if [[ $wpscan_exit -eq 1 ]] || [[ $wpscan_exit -eq 2 ]] || [[ $wpscan_exit -eq 3 ]]
+then
+    fake_exit_code=$wpscan_exit
+fi
+
+exit $fake_exit_code

--- a/scanners/wpscan/templates/wpscan-scan-type.yaml
+++ b/scanners/wpscan/templates/wpscan-scan-type.yaml
@@ -35,7 +35,8 @@ spec:
               image: "{{ .Values.scanner.image.repository }}:{{ .Values.scanner.image.tag | default .Chart.AppVersion }}"
               imagePullPolicy: {{ .Values.scanner.image.pullPolicy }}
               command:
-                - "wpscan"
+                - "sh"
+                - "/wrapper.sh"
                 - "-o"
                 - "/home/securecodebox/wpscan-results.json"
                 - "-f"


### PR DESCRIPTION
Solves https://github.com/secureCodeBox/secureCodeBox/issues/1083

Adds a wrapper to wpscan because wpscan does return non 0 values when it find vulnerability's.