### PR TITLE
Allow Email Notification Hook To Pick Email Recipient From a Scan Annotation

### DIFF
--- a/hooks/notification/.helm-docs.gotmpl
+++ b/hooks/notification/.helm-docs.gotmpl
@@ -274,6 +274,21 @@ env:
     value: secureCodeBox
 ```
 
+You can overwrite the default email recipient of the notification mail for every scan by setting a `notification.securecodebox.io/email-recipient` annotation on the scan to another email address:
+
+```yaml
+apiVersion: "execution.securecodebox.io/v1"
+kind: Scan
+metadata:
+  name: "nmap-juice-shop"
+  annotations:
+    notification.securecodebox.io/email-recipient: "foo@example.com"
+spec:
+  scanType: "nmap"
+  parameters:
+    - juice-shop.default.svc
+```
+
 #### Configuration Of A MS Teams Notification
 
 To configure a MS Teams notification you need to set the type to `ms-teams`.

--- a/hooks/notification/.helm-docs.gotmpl
+++ b/hooks/notification/.helm-docs.gotmpl
@@ -250,7 +250,7 @@ notificationChannels:
     type: email
     template: email
     rules: []
-    endPoint: "someone@somewhere.xyz"
+    endPoint: "someone@example.com"
 env:
   - name: SMTP_CONFIG
     # you can create the secret via: kubectl create secret generic email-credentials --from-literal="smtp-config=smtp://user:pass@smtp.domain.tld/"
@@ -310,7 +310,7 @@ notificationChannels:
     type: ms-teams
     template: msteams-messageCard
     rules: []
-    endPoint: "https://somewhere.xyz/sadf12"
+    endPoint: "https://example/sadf12"
 env:
   - name: VULNMANAG_ENABLED
     value: true

--- a/hooks/notification/README.md
+++ b/hooks/notification/README.md
@@ -293,6 +293,21 @@ env:
     value: secureCodeBox
 ```
 
+You can overwrite the default email recipient of the notification mail for every scan by setting a `notification.securecodebox.io/email-recipient` annotation on the scan to another email address:
+
+```yaml
+apiVersion: "execution.securecodebox.io/v1"
+kind: Scan
+metadata:
+  name: "nmap-juice-shop"
+  annotations:
+    notification.securecodebox.io/email-recipient: "foo@example.com"
+spec:
+  scanType: "nmap"
+  parameters:
+    - juice-shop.default.svc
+```
+
 #### Configuration Of A MS Teams Notification
 
 To configure a MS Teams notification you need to set the type to `ms-teams`.

--- a/hooks/notification/README.md
+++ b/hooks/notification/README.md
@@ -269,7 +269,7 @@ notificationChannels:
     type: email
     template: email
     rules: []
-    endPoint: "someone@somewhere.xyz"
+    endPoint: "someone@example.com"
 env:
   - name: SMTP_CONFIG
     # you can create the secret via: kubectl create secret generic email-credentials --from-literal="smtp-config=smtp://user:pass@smtp.domain.tld/"
@@ -329,7 +329,7 @@ notificationChannels:
     type: ms-teams
     template: msteams-messageCard
     rules: []
-    endPoint: "https://somewhere.xyz/sadf12"
+    endPoint: "https://example/sadf12"
 env:
   - name: VULNMANAG_ENABLED
     value: true

--- a/hooks/notification/docs/README.ArtifactHub.md
+++ b/hooks/notification/docs/README.ArtifactHub.md
@@ -277,7 +277,7 @@ notificationChannels:
     type: email
     template: email
     rules: []
-    endPoint: "someone@somewhere.xyz"
+    endPoint: "someone@example.com"
 env:
   - name: SMTP_CONFIG
     # you can create the secret via: kubectl create secret generic email-credentials --from-literal="smtp-config=smtp://user:pass@smtp.domain.tld/"
@@ -337,7 +337,7 @@ notificationChannels:
     type: ms-teams
     template: msteams-messageCard
     rules: []
-    endPoint: "https://somewhere.xyz/sadf12"
+    endPoint: "https://example/sadf12"
 env:
   - name: VULNMANAG_ENABLED
     value: true

--- a/hooks/notification/docs/README.ArtifactHub.md
+++ b/hooks/notification/docs/README.ArtifactHub.md
@@ -301,6 +301,21 @@ env:
     value: secureCodeBox
 ```
 
+You can overwrite the default email recipient of the notification mail for every scan by setting a `notification.securecodebox.io/email-recipient` annotation on the scan to another email address:
+
+```yaml
+apiVersion: "execution.securecodebox.io/v1"
+kind: Scan
+metadata:
+  name: "nmap-juice-shop"
+  annotations:
+    notification.securecodebox.io/email-recipient: "foo@example.com"
+spec:
+  scanType: "nmap"
+  parameters:
+    - juice-shop.default.svc
+```
+
 #### Configuration Of A MS Teams Notification
 
 To configure a MS Teams notification you need to set the type to `ms-teams`.

--- a/hooks/notification/hook/Notifiers/EMailNotifier.test.ts
+++ b/hooks/notification/hook/Notifiers/EMailNotifier.test.ts
@@ -68,14 +68,14 @@ function createExampleScan(): Scan {
 
 test("Should Send Mail", async () => {
   const from = "secureCodeBox";
-  const smtp = "smtp://user:pass@smtp.ethereal.email/";
+  const smtp = "smtp://user:pass@smtp.example.com/";
   process.env[EMailNotifier.SMTP_CONFIG] = smtp;
   const channel: NotificationChannel = {
     name: "Channel Name",
     type: NotifierType.EMAIL,
     template: "email",
     rules: [],
-    endPoint: "mail@some.email",
+    endPoint: "mail@example.com",
   };
   const scan: Scan = createExampleScan();
 
@@ -119,21 +119,21 @@ A Client Error response code was returned by the server: 1
 Information Disclosure - Sensitive Information in URL: 1
 Strict-Transport-Security Header Not Set: 1
 `,
-    to: "mail@some.email",
+    to: "mail@example.com",
   });
   expect(close).toBeCalled();
 });
 
 test("should send mail to recipient overwritten in scan annotation", async () => {
   const from = "secureCodeBox";
-  const smtp = "smtp://user:pass@smtp.ethereal.email/";
+  const smtp = "smtp://user:pass@smtp.example.com/";
   process.env[EMailNotifier.SMTP_CONFIG] = smtp;
   const channel: NotificationChannel = {
     name: "Channel Name",
     type: NotifierType.EMAIL,
     template: "email",
     rules: [],
-    endPoint: "mail@some.email",
+    endPoint: "mail@example.com",
   };
   const scan: Scan = createExampleScan();
   scan.metadata.annotations = {

--- a/hooks/notification/hook/Notifiers/EMailNotifier.ts
+++ b/hooks/notification/hook/Notifiers/EMailNotifier.ts
@@ -42,7 +42,10 @@ export class EMailNotifier extends AbstractNotifier {
 
   private prepareMessage(): any {
     const message = JSON.parse(this.renderMessage());
-    message.to = this.resolveEndPoint();
+    if(!message.to) {
+      // only use fixed endpoint / mail address if it isn't already defined by the template
+      message.to = this.resolveEndPoint();
+    }
     message.from = this.args[EMailNotifier.EMAIL_FROM];
     return message;
   }

--- a/hooks/notification/hook/notification-templates/email.njk
+++ b/hooks/notification/hook/notification-templates/email.njk
@@ -3,6 +3,7 @@ SPDX-FileCopyrightText: the secureCodeBox authors
 
 SPDX-License-Identifier: Apache-2.0
 #}
+to: {{ scan.metadata.annotations["notification.securecodebox.io/email-recipient"] | default(null, true) | safe}}
 subject: New {{ scan.spec.scanType }} security scan results are available!
 text: |
   *Scan {{ scan.metadata.name }}*


### PR DESCRIPTION
This PR add the ability to configure the email recipient of the notification hook on a scan per scan basis.
Before the recipient always had to be hardcoded in the hook configuration when you installed the hook.

This still preserves the existing default behavior to use the endpoint as email if not annotation is set, so this should not be breaking.

Also noticed some places where we've referenced to external domains in our docs and tests, changed them to example.com just to be sure that these will never be actually be used by anybody.

### Checklist

* [x] Test your changes as thoroughly as possible before you commit them. Preferably, automate your test by unit/integration tests.
* [x] Make sure that all your commits are signed-off and that you are added to the [Contributors](https://github.com/secureCodeBox/secureCodeBox/blob/main/CONTRIBUTORS.md) file.
* [x] Make sure that all CI finish successfully.
* [x] Optional (but appreciated): Make sure that all commits are [Verified](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits).
