### PR TITLE
Add missing annotation for "supported-platforms"

### DIFF
--- a/scanners/git-repo-scanner/Chart.yaml
+++ b/scanners/git-repo-scanner/Chart.yaml
@@ -11,6 +11,9 @@ type: application
 version: v3.1.0-alpha1
 appVersion: "1.1"
 kubeVersion: ">=v1.11.0-0"
+annotations:
+  # supported cpu architectures for which docker images for the scanner should be build
+  supported-platforms: linux/amd64
 
 keywords:
   - git

--- a/scanners/wpscan/Chart.yaml
+++ b/scanners/wpscan/Chart.yaml
@@ -12,6 +12,7 @@ appVersion: "v3.8.22"
 kubeVersion: ">=v1.11.0-0"
 annotations:
   versionApi: https://api.github.com/repos/wpscanteam/wpscan/releases/latest
+  supported-platforms: linux/amd64,linux/arm64
 keywords:
   - security
   - wpscan


### PR DESCRIPTION
Release 3.14.0 has failed as WPScan Chart didn't indicate for which platforms the container should be build.
