### PR TITLE
Create zap config map even when config is empty

### DIFF
--- a/scanners/zap-advanced/templates/zap-advanced-scan-type.yaml
+++ b/scanners/zap-advanced/templates/zap-advanced-scan-type.yaml
@@ -3,7 +3,6 @@
 # SPDX-License-Identifier: Apache-2.0
 
 ---
-{{- if not (empty .Values.zapConfiguration) }}
 kind: ConfigMap
 apiVersion: v1
 metadata:
@@ -12,8 +11,12 @@ metadata:
     {{- include "zap.labels" . | nindent 4 }}
 data:
   1-zap-advanced-scantype.yaml: |
-    {{- .Values.zapConfiguration | toYaml | nindent 4 -}}
-{{- end }}
+    {{- if not (empty .Values.zapConfiguration) }}
+      {{- .Values.zapConfiguration | toYaml | nindent 4 -}}
+    {{- end }}
+    {{- if (empty .Values.zapConfiguration) }}
+      {}
+    {{- end }}
 ---
 apiVersion: "execution.securecodebox.io/v1"
 kind: ScanType


### PR DESCRIPTION
Zap-advanced does not create the `zap-advanced-scantype-config` configmap when it is installed with default values (`zapConfiguration` is not set). Per default zap-advaned tries to mount this configmap though.
https://github.com/secureCodeBox/secureCodeBox/blob/bfd6c45f18e7e3c44a20778760d6f0214ed454a5/scanners/zap-advanced/templates/zap-advanced-scan-type.yaml#L6-L16
https://github.com/secureCodeBox/secureCodeBox/blob/bfd6c45f18e7e3c44a20778760d6f0214ed454a5/scanners/zap-advanced/values.yaml#L68-L84
This mean that the [tutorial](https://docs.securecodebox.io/docs/how-tos/scanning-web-applications) on our website does not work, as it does not create the `zap-advanced-scantype-config` configmap manually. It fails with the following error:  `MountVolume.SetUp failed for volume "zap-advanced-scantype-config" : configmap "zap-advanced-scantype-config" not found`.
This PR will change this behavior. Zap-advanded will create an empty `zap-advanced-scantype-config` configmap if no `zapConfiguration` is provided to ensure that the mounting of the volume works.