### PR TITLE
Run Helm docs generation only on main branch

### DIFF
--- a/.github/workflows/helm-docs.yaml
+++ b/.github/workflows/helm-docs.yaml
@@ -6,7 +6,8 @@ name: "Update Helm Docs"
 
 on:
   push:
-
+    branches:
+      - main
 jobs:
   helm-docs:
     runs-on: ubuntu-latest
@@ -15,6 +16,7 @@ jobs:
       - uses: actions/checkout@v2
         with:
           ref: ${{ github.head_ref }}
+          token: ${{ secrets.PAT_WITH_ADMIN }} ## Placeholder for PAT with Admin Access.
 
       - name: Import GPG key
         uses: crazy-max/ghaction-import-gpg@v3


### PR DESCRIPTION
## Description
<!-- Please describe briefly which issue is solved by your PR or which enhancement it brings -->

Changed the trigger to only the main branch.
To allow pushing to main. a PAT with admin privileges is required.
secrets.PAT_WITH_ADMIN is currently a placeholder.
closes https://github.com/secureCodeBox/internal/issues/62

A different “solution” would be to disable PGP signing for the helm-bot. This would no longer require access to main repo secrets and allow helm-bot to run on forks.

I tried the suggestions mentioned in the [git-auto-commit Action documentation](https://github.com/marketplace/actions/git-auto-commit#advanced-uses). AFAIK, they do not fit our use-case. (#1294) 