### PR TITLE
ZAP Advanced: Add support for additional report types

### DIFF
--- a/parser-sdk/nodejs/parser-wrapper.js
+++ b/parser-sdk/nodejs/parser-wrapper.js
@@ -27,6 +27,7 @@ async function uploadResultToFileStorageService(
   return axios
     .put(resultUploadUrl, findingsWithIdsAndDates, {
       headers: { "content-type": "" },
+      maxBodyLength: Infinity,
     })
     .catch(function (error) {
       if (error.response) {

--- a/scanners/zap-advanced/.helm-docs.gotmpl
+++ b/scanners/zap-advanced/.helm-docs.gotmpl
@@ -40,7 +40,7 @@ Listed below are the arguments supported by the `zap-advanced-scan` script.
 The command line interface can be used to easily run server scans: `-t www.example.com`
 
 ```bash
-usage: zap-client [-h] -z ZAP_URL [-a API_KEY] [-c CONFIG_FOLDER] -t TARGET [-o OUTPUT_FOLDER] [-r {XML,JSON,HTML,MD}]
+usage: zap-client [-h] -z ZAP_URL [-a API_KEY] [-c CONFIG_FOLDER] -t TARGET [-o OUTPUT_FOLDER] [-r {XML,XML-plus,JSON,JSON-plus,HTML,HTML-plus,MD}]
 
 OWASP secureCodeBox OWASP ZAP Client  (can be used to automate OWASP ZAP instances based on YAML configuration files.)
 
@@ -56,7 +56,7 @@ optional arguments:
                         The target to scan with OWASP ZAP.
   -o OUTPUT_FOLDER, --output-folder OUTPUT_FOLDER
                         The path to a local folder used to store the output files, eg. the ZAP Report or logfiles.
-  -r {XML,JSON,HTML,MD}, --report-type {XML,JSON,HTML,MD}
+  -r {XML,XML-plus,JSON,JSON-plus,HTML,HTML-plus,MD}, --report-type {XML,XML-plus,JSON,JSON-plus,HTML,HTML-plus,MD}
                         The OWASP ZAP Report Type.
 ```
 {{- end }}

--- a/scanners/zap-advanced/README.md
+++ b/scanners/zap-advanced/README.md
@@ -56,7 +56,7 @@ Listed below are the arguments supported by the `zap-advanced-scan` script.
 The command line interface can be used to easily run server scans: `-t www.example.com`
 
 ```bash
-usage: zap-client [-h] -z ZAP_URL [-a API_KEY] [-c CONFIG_FOLDER] -t TARGET [-o OUTPUT_FOLDER] [-r {XML,JSON,HTML,MD}]
+usage: zap-client [-h] -z ZAP_URL [-a API_KEY] [-c CONFIG_FOLDER] -t TARGET [-o OUTPUT_FOLDER] [-r {XML,XML-plus,JSON,JSON-plus,HTML,HTML-plus,MD}]
 
 OWASP secureCodeBox OWASP ZAP Client  (can be used to automate OWASP ZAP instances based on YAML configuration files.)
 
@@ -72,7 +72,7 @@ optional arguments:
                         The target to scan with OWASP ZAP.
   -o OUTPUT_FOLDER, --output-folder OUTPUT_FOLDER
                         The path to a local folder used to store the output files, eg. the ZAP Report or logfiles.
-  -r {XML,JSON,HTML,MD}, --report-type {XML,JSON,HTML,MD}
+  -r {XML,XML-plus,JSON,JSON-plus,HTML,HTML-plus,MD}, --report-type {XML,XML-plus,JSON,JSON-plus,HTML,HTML-plus,MD}
                         The OWASP ZAP Report Type.
 ```
 

--- a/scanners/zap-advanced/docs/README.ArtifactHub.md
+++ b/scanners/zap-advanced/docs/README.ArtifactHub.md
@@ -61,7 +61,7 @@ Listed below are the arguments supported by the `zap-advanced-scan` script.
 The command line interface can be used to easily run server scans: `-t www.example.com`
 
 ```bash
-usage: zap-client [-h] -z ZAP_URL [-a API_KEY] [-c CONFIG_FOLDER] -t TARGET [-o OUTPUT_FOLDER] [-r {XML,JSON,HTML,MD}]
+usage: zap-client [-h] -z ZAP_URL [-a API_KEY] [-c CONFIG_FOLDER] -t TARGET [-o OUTPUT_FOLDER] [-r {XML,XML-plus,JSON,JSON-plus,HTML,HTML-plus,MD}]
 
 OWASP secureCodeBox OWASP ZAP Client  (can be used to automate OWASP ZAP instances based on YAML configuration files.)
 
@@ -77,7 +77,7 @@ optional arguments:
                         The target to scan with OWASP ZAP.
   -o OUTPUT_FOLDER, --output-folder OUTPUT_FOLDER
                         The path to a local folder used to store the output files, eg. the ZAP Report or logfiles.
-  -r {XML,JSON,HTML,MD}, --report-type {XML,JSON,HTML,MD}
+  -r {XML,XML-plus,JSON,JSON-plus,HTML,HTML-plus,MD}, --report-type {XML,XML-plus,JSON,JSON-plus,HTML,HTML-plus,MD}
                         The OWASP ZAP Report Type.
 ```
 

--- a/scanners/zap-advanced/docs/README.DockerHub-Scanner.md
+++ b/scanners/zap-advanced/docs/README.DockerHub-Scanner.md
@@ -64,7 +64,7 @@ Listed below are the arguments supported by the `zap-advanced-scan` script.
 The command line interface can be used to easily run server scans: `-t www.example.com`
 
 ```bash
-usage: zap-client [-h] -z ZAP_URL [-a API_KEY] [-c CONFIG_FOLDER] -t TARGET [-o OUTPUT_FOLDER] [-r {XML,JSON,HTML,MD}]
+usage: zap-client [-h] -z ZAP_URL [-a API_KEY] [-c CONFIG_FOLDER] -t TARGET [-o OUTPUT_FOLDER] [-r {XML,XML-plus,JSON,JSON-plus,HTML,HTML-plus,MD}]
 
 OWASP secureCodeBox OWASP ZAP Client  (can be used to automate OWASP ZAP instances based on YAML configuration files.)
 
@@ -80,7 +80,7 @@ optional arguments:
                         The target to scan with OWASP ZAP.
   -o OUTPUT_FOLDER, --output-folder OUTPUT_FOLDER
                         The path to a local folder used to store the output files, eg. the ZAP Report or logfiles.
-  -r {XML,JSON,HTML,MD}, --report-type {XML,JSON,HTML,MD}
+  -r {XML,XML-plus,JSON,JSON-plus,HTML,HTML-plus,MD}, --report-type {XML,XML-plus,JSON,JSON-plus,HTML,HTML-plus,MD}
                         The OWASP ZAP Report Type.
 ```
 

--- a/scanners/zap-advanced/scanner/zapclient/__main__.py
+++ b/scanners/zap-advanced/scanner/zapclient/__main__.py
@@ -116,7 +116,7 @@ def get_parser_args(args=None):
     parser.add_argument("-r",
                         "--report-type",
                         help='The OWASP ZAP Report Type.',
-                        choices=['XML', 'JSON', 'HTML', 'MD'],
+                        choices=['XML', 'XML-plus', 'JSON', 'JSON-plus', 'HTML', 'HTML-plus', 'MD'],
                         default=None,
                         required=False)
     return parser.parse_args(args)

--- a/scanners/zap-advanced/scanner/zapclient/zap_automation.py
+++ b/scanners/zap-advanced/scanner/zapclient/zap_automation.py
@@ -146,15 +146,21 @@ class ZapAutomation:
     def get_report_template_for_file_type(self, file_type: str):
         if file_type == "XML":
             return "traditional-xml"
+        elif file_type == "XML-plus":
+            return "traditional-xml-plus"
         elif file_type == "JSON":
             return "traditional-json"
+        elif file_type == "JSON-plus":
+            return "traditional-json-plus"
         elif file_type == "HTML":
             return "traditional-html"
+        elif file_type == "HTML-plus":
+            return "traditional-html-plus"
         elif file_type == "MD":
             return "traditional-md"
         else:
             raise RuntimeError(
-                "Report file type: '" + file_type + "' hasn't been implemented. Available: XML, JSON, HTML or MD")
+                "Report file type: '" + file_type + "' hasn't been implemented. Available: XML, XML-plus, JSON, JSON-plus, HTML, HTML-plus, or MD")
 
     def generate_report_file(self, file_path: str, report_type: str):
         # To retrieve ZAP report in XML or HTML format
@@ -163,7 +169,9 @@ class ZapAutomation:
         if report_type is None:
             report_type = "XML"
 
-        report_file = "zap-results." + report_type.lower()
+        # Remove any trailing "-plus" from the file ending, as this is an artifact of the
+        # XML-plus / JSON-plus / HTML-plus report format selector.
+        report_file = "zap-results." + report_type.lower().replace('-plus', '')
         self.__zap.reports.generate(
             title="ZAP Report",
             template=self.get_report_template_for_file_type(report_type),


### PR DESCRIPTION
ZAP Advanced can be parameterized to return different types of reports. This PR adds the "*-plus" formats that have been added to ZAP (including the [XML-plus format](https://github.com/zaproxy/zap-extensions/pull/3983) that currently has an open pull request against the ZAP Extensions repo). The "plus" reports contain all information of the normal report, plus the full request and response headers and payloads.

While the new format has not yet been approved and merged, it can still be used as follows:
1. Add the following snippet to the values.yaml of the ZAP advanced scanner, under the `extraVolumes` key:
```yaml
    - name: zap-report-format
      configMap:
        name: zap-report-format
        optional: true
```
2. Add the following snippet under the `extraVolumeMounts` of the `zapContainer` section in the same file:
```yaml
    - name: zap-report-format
      mountPath: /home/zap/.ZAP/reports/traditional-xml-plus/
      readOnly: true
```
3. Create a configmap in the scan namespace with the following contents:
```yaml
apiVersion: v1
kind: ConfigMap
metadata:
  name: zap-report-format
data:
  report.xml: |-
    <?xml version="1.0"?>
    <OWASPZAPReport
      th:attr="version=${zapVersion}, generated=${generatedString}">
      <th:block th:each="site: ${reportData.sites}">
        <site th:name="${site}"
          th:attr="host=${helper.getHostForSite(site)}, port=${helper.getPortForSite(site)}, ssl=${helper.isSslSite(site)}">
          <alerts>
            <th:block
              th:each="alert: ${helper.getAlertsForSite(alertTree, site)}"
              th:with="instances=${helper.getAlertInstancesForSite(alertTree, site, alert.name, alert.risk)}">
              <alertitem>
                <pluginid th:text="${alert.pluginId}"></pluginid>
                <alertRef th:text="${alert.alertRef}"></alertRef>
                <alert th:text="${alert.name}"></alert>
                <name th:text="${alert.name}"></name>
                <riskcode th:text="${alert.risk}"></riskcode>
                <confidence th:text="${alert.confidence}"></confidence>
                <riskdesc
                  th:text="${helper.getRiskString(alert.risk) + ' (' + helper.getConfidenceString(alert.confidence) + ')'}"></riskdesc>
                <confidencedesc
                  th:text="${helper.getConfidenceString(alert.confidence)}"></confidencedesc>
                <desc
                  th:text="${helper.legacyEscapeParagraph(alert.description)}"></desc>
                <instances>
                  <th:block th:each="instance: ${instances}">
                    <instance>
                      <uri th:text="${instance.uri}"></uri>
                      <method th:text="${instance.method}"></method>
                      <param th:text="${instance.param}"></param>
                      <attack th:text="${instance.attack}"></attack>
                      <evidence th:text="${instance.evidence}"></evidence>
                      <requestheader th:text="${helper.legacyEscapeText(instance.message.requestHeader, true)}"></requestheader>
                      <requestbody th:text="${helper.legacyEscapeText(instance.message.requestBody, true)}"></requestbody>
                      <responseheader th:text="${helper.legacyEscapeText(instance.message.responseHeader, true)}"></responseheader>
                      <responsebody th:text="${helper.legacyEscapeText(instance.message.responseBody, true)}"></responsebody>
                    </instance>
                  </th:block>
                </instances>
                <count th:text="${instances.size()}"></count>
                <solution
                  th:text="${helper.legacyEscapeParagraph(alert.solution)}"></solution>
                <otherinfo
                  th:text="${helper.legacyEscapeParagraph(alert.otherinfo)}"></otherinfo>
                <reference
                  th:text="${helper.legacyEscapeParagraph(alert.reference)}"></reference>
                <cweid th:text="${alert.cweid}"></cweid>
                <wascid th:text="${alert.wascid}"></wascid>
                <sourceid th:text="${alert.sourceHistoryId}"></sourceid>
              </alertitem>
            </th:block>
          </alerts>
        </site>
      </th:block>
    </OWASPZAPReport>
  template.yaml: |
    name: Traditional XML Report with requests and responses
    format: XML
    mode: XML
    extension: xml
```

4. Add `-r XML-plus` to the scan parameters of your ZAP-advanced scan

**Note that this will break all other report types**, as it will lead to Kubernetes creating the folder `/home/zap/.ZAP/reports/traditional-xml-plus/`, which will prevent ZAP from unpacking its own set of reports. This issue will go away once the XML-plus report type is officially supported by ZAP and this workaround with the ConfigMap is no longer necessary.

The XML-plus report type is compatible with the existing parser. All other report types are (obviously) incompatible, since the parser expects XML.

### Checklist

* [x] Test your changes as thoroughly as possible before you commit them. Preferably, automate your test by unit/integration tests.
* [x] Make sure that all your commits are signed-off and that you are added to the [Contributors](https://github.com/secureCodeBox/secureCodeBox/blob/main/CONTRIBUTORS.md) file.
* [x] Make sure that all CI finish successfully.
* [x] Optional (but appreciated): Make sure that all commits are [Verified](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits).
