### PR TITLE
Add Megalinter output to Gitignore file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,9 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
+# Megalinter output
+megalinter-reports/
+
 .DS_Store
 **/node_modules
 **/coverage/


### PR DESCRIPTION
Add the megalinter reports folder to the Gitignore file so Git does not remind you to check it in.