### PR TITLE
Fixing broken link in ADR 0012 to ADR 0009.

### DIFF
--- a/docs/adr/adr_0012.md
+++ b/docs/adr/adr_0012.md
@@ -53,7 +53,7 @@ Some features of normal scanTypes will not function normally with ClusterScanTyp
 When deploying cluster scans types you have to make sure that either:
 
 1. All referenced ConfigMaps / Secrets exist in all namespaces. This will likely be done by a script / operator generating these configmaps and persisting them into every namespace. These scripts and operator will likely differ greatly from user to user as the ConfigMaps and Secrets will likely have to be configured differently for every team (e.g. different access tokens used by scanners). If they should all be the same, users can use third party tools like the [Cluster Secret Operator](https://github.com/zakkg3/ClusterSecret) and similar to sync their configs across namespaces.
-2. All dependencies to ConfigMaps / Secrets are removed from your scanTypes and either moved into the container image of the scanner, or are specified by an initContainer in the ScanType. The initContainer copies these files over to volumes shared with the scanner container. Some more references and discussions on ways to improve this in the future can be found in [ADR-0009: Architecture for pre-populating the file system of scanners](./adr-0009)
+2. All dependencies to ConfigMaps / Secrets are removed from your scanTypes and either moved into the container image of the scanner, or are specified by an initContainer in the ScanType. The initContainer copies these files over to volumes shared with the scanner container. Some more references and discussions on ways to improve this in the future can be found in [ADR-0009: Architecture for pre-populating the file system of scanners](./adr_0009)
 
 #### `ClusterParseDefinition`
 
@@ -172,7 +172,7 @@ Some features of normal scanTypes will not function normally with ClusterScanTyp
 When deploying cluster scans types you have to make sure that either:
 
 1. All referenced ConfigMaps / Secrets exist in all namespaces. This will likely be done by a script / operator generating these configmaps and persisting them into every namespace. These scripts and operator will likely differ greatly from user to user as the ConfigMaps and Secrets will likely have to be configured differently for every team (e.g. different access tokens used by scanners). If they should all be the same, users can use third party tools like the [Cluster Secret Operator](https://github.com/zakkg3/ClusterSecret) and similar to sync their configs across namespaces.
-2. All dependencies to ConfigMaps / Secrets are removed from your scanTypes and either moved into the container image of the scanner, or are specified by an initContainer in the ScanType. The initContainer copies these files over to volumes shared with the scanner container. Some more references and discussions on ways to improve this in the future can be found in [ADR-0009: Architecture for pre-populating the file system of scanners](./adr-0009)
+2. All dependencies to ConfigMaps / Secrets are removed from your scanTypes and either moved into the container image of the scanner, or are specified by an initContainer in the ScanType. The initContainer copies these files over to volumes shared with the scanner container. Some more references and discussions on ways to improve this in the future can be found in [ADR-0009: Architecture for pre-populating the file system of scanners](./adr_0009)
 
 #### `ClusterParseDefinition`
 


### PR DESCRIPTION
## Description
<!-- Please describe briefly which issue is solved by your PR or which enhancement it brings -->

This PR fixes 2 broken links in ADR 0012 to ADR 0009, that make Netlify fail in the documentation repo.

### Checklist

* [x] Test your changes as thoroughly as possible before you commit them. Preferably, automate your test by unit/integration tests.
* [x] Make sure that all your commits are signed-off and that you are added to the [Contributors](https://github.com/secureCodeBox/secureCodeBox/blob/main/CONTRIBUTORS.md) file.
* [x] Make sure that all CI finish successfully.
* [x] Optional (but appreciated): Make sure that all commits are [Verified](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits).
