### PR TITLE
Generate S3 URLs from go template

### DIFF
--- a/operator/controllers/execution/scans/hook_reconciler.go
+++ b/operator/controllers/execution/scans/hook_reconciler.go
@@ -198,12 +198,12 @@ func (r *ScanReconciler) processPendingHook(scan *executionv1.Scan, status *exec
 	}
 
 	var rawFileURL string
-	rawFileURL, err = r.PresignedGetURL(scan.UID, scan.Status.RawResultFile, defaultPresignDuration)
+	rawFileURL, err = r.PresignedGetURL(*scan, scan.Status.RawResultFile, defaultPresignDuration)
 	if err != nil {
 		return err
 	}
 	var findingsFileURL string
-	findingsFileURL, err = r.PresignedGetURL(scan.UID, "findings.json", defaultPresignDuration)
+	findingsFileURL, err = r.PresignedGetURL(*scan, "findings.json", defaultPresignDuration)
 	if err != nil {
 		return err
 	}
@@ -214,12 +214,12 @@ func (r *ScanReconciler) processPendingHook(scan *executionv1.Scan, status *exec
 	}
 	if hook.Spec.Type == executionv1.ReadAndWrite {
 		var rawFileUploadURL string
-		rawFileUploadURL, err = r.PresignedPutURL(scan.UID, scan.Status.RawResultFile, defaultPresignDuration)
+		rawFileUploadURL, err = r.PresignedPutURL(*scan, scan.Status.RawResultFile, defaultPresignDuration)
 		if err != nil {
 			return err
 		}
 		var findingsUploadURL string
-		findingsUploadURL, err = r.PresignedPutURL(scan.UID, "findings.json", defaultPresignDuration)
+		findingsUploadURL, err = r.PresignedPutURL(*scan, "findings.json", defaultPresignDuration)
 		if err != nil {
 			return err
 		}

--- a/operator/controllers/execution/scans/parse_reconciler.go
+++ b/operator/controllers/execution/scans/parse_reconciler.go
@@ -53,12 +53,12 @@ func (r *ScanReconciler) startParser(scan *executionv1.Scan) error {
 	}
 	log.Info("Matching ParseDefinition Found", "ParseDefinition", parseType)
 
-	findingsUploadURL, err := r.PresignedPutURL(scan.UID, "findings.json", defaultPresignDuration)
+	findingsUploadURL, err := r.PresignedPutURL(*scan, "findings.json", defaultPresignDuration)
 	if err != nil {
 		r.Log.Error(err, "Could not get presigned url from s3 or compatible storage provider")
 		return err
 	}
-	rawResultDownloadURL, err := r.PresignedGetURL(scan.UID, scan.Status.RawResultFile, defaultPresignDuration)
+	rawResultDownloadURL, err := r.PresignedGetURL(*scan, scan.Status.RawResultFile, defaultPresignDuration)
 	if err != nil {
 		return err
 	}

--- a/operator/controllers/execution/scans/scan_controller.go
+++ b/operator/controllers/execution/scans/scan_controller.go
@@ -16,7 +16,6 @@ import (
 	batch "k8s.io/api/batch/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
-	"k8s.io/apimachinery/pkg/types"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
@@ -127,11 +126,15 @@ func (r *ScanReconciler) handleFinalizer(scan *executionv1.Scan) error {
 	if containsString(scan.ObjectMeta.Finalizers, s3StorageFinalizer) {
 		bucketName := os.Getenv("S3_BUCKET")
 		r.Log.V(3).Info("Deleting External Files from FileStorage", "ScanUID", scan.UID)
-		err := r.MinioClient.RemoveObject(context.Background(), bucketName, fmt.Sprintf("scan-%s/%s", scan.UID, scan.Status.RawResultFile), minio.RemoveObjectOptions{})
+
+		rawResultUrl := getPresignedUrlPath(*scan, scan.Status.RawResultFile)
+		err := r.MinioClient.RemoveObject(context.Background(), bucketName, rawResultUrl, minio.RemoveObjectOptions{})
 		if err != nil && err.Error() != errNotFound {
 			return err
 		}
-		err = r.MinioClient.RemoveObject(context.Background(), bucketName, fmt.Sprintf("scan-%s/findings.json", scan.UID), minio.RemoveObjectOptions{})
+
+		findingsJsonUrl := getPresignedUrlPath(*scan, "findings.json")
+		err = r.MinioClient.RemoveObject(context.Background(), bucketName, findingsJsonUrl, minio.RemoveObjectOptions{})
 
 		if err != nil && err.Error() != errNotFound {
 			return err
@@ -146,11 +149,12 @@ func (r *ScanReconciler) handleFinalizer(scan *executionv1.Scan) error {
 }
 
 // PresignedGetURL returns a presigned URL from the s3 (or compatible) serice.
-func (r *ScanReconciler) PresignedGetURL(scanID types.UID, filename string, duration time.Duration) (string, error) {
+func (r *ScanReconciler) PresignedGetURL(scan executionv1.Scan, filename string, duration time.Duration) (string, error) {
 	bucketName := os.Getenv("S3_BUCKET")
 
+	fileUrl := getPresignedUrlPath(scan, filename)
 	reqParams := make(url.Values)
-	rawResultDownloadURL, err := r.MinioClient.PresignedGetObject(context.Background(), bucketName, fmt.Sprintf("scan-%s/%s", string(scanID), filename), duration, reqParams)
+	rawResultDownloadURL, err := r.MinioClient.PresignedGetObject(context.Background(), bucketName, fileUrl, duration, reqParams)
 	if err != nil {
 		r.Log.Error(err, "Could not get presigned url from s3 or compatible storage provider")
 		return "", err
@@ -159,10 +163,11 @@ func (r *ScanReconciler) PresignedGetURL(scanID types.UID, filename string, dura
 }
 
 // PresignedPutURL returns a presigned URL from the s3 (or compatible) serice.
-func (r *ScanReconciler) PresignedPutURL(scanID types.UID, filename string, duration time.Duration) (string, error) {
+func (r *ScanReconciler) PresignedPutURL(scan executionv1.Scan, filename string, duration time.Duration) (string, error) {
 	bucketName := os.Getenv("S3_BUCKET")
+	fileUrl := getPresignedUrlPath(scan, filename)
 
-	rawResultDownloadURL, err := r.MinioClient.PresignedPutObject(context.Background(), bucketName, fmt.Sprintf("scan-%s/%s", string(scanID), filename), duration)
+	rawResultDownloadURL, err := r.MinioClient.PresignedPutObject(context.Background(), bucketName, fileUrl, duration)
 	if err != nil {
 		r.Log.Error(err, "Could not get presigned url from s3 or compatible storage provider")
 		return "", err
@@ -171,10 +176,11 @@ func (r *ScanReconciler) PresignedPutURL(scanID types.UID, filename string, dura
 }
 
 // PresignedHeadURL returns a presigned URL from the s3 (or compatible) serice.
-func (r *ScanReconciler) PresignedHeadURL(scanID types.UID, filename string, duration time.Duration) (string, error) {
+func (r *ScanReconciler) PresignedHeadURL(scan executionv1.Scan, filename string, duration time.Duration) (string, error) {
 	bucketName := os.Getenv("S3_BUCKET")
+	fileUrl := getPresignedUrlPath(scan, filename)
 
-	rawResultHeadURL, err := r.MinioClient.PresignedHeadObject(context.Background(), bucketName, fmt.Sprintf("scan-%s/%s", string(scanID), filename), duration, nil)
+	rawResultHeadURL, err := r.MinioClient.PresignedHeadObject(context.Background(), bucketName, fileUrl, duration, nil)
 	if err != nil {
 		r.Log.Error(err, "Could not get presigned url from s3 or compatible storage provider")
 		return "", err
@@ -269,4 +275,8 @@ func containsString(slice []string, s string) bool {
 		}
 	}
 	return false
+}
+
+func getPresignedUrlPath(scan executionv1.Scan, filename string) string {
+	return fmt.Sprintf("scan-%s/%s", scan.UID, filename)
 }

--- a/operator/controllers/execution/scans/scan_controller.go
+++ b/operator/controllers/execution/scans/scan_controller.go
@@ -281,12 +281,11 @@ func containsString(slice []string, s string) bool {
 
 func getPresignedUrlPath(scan executionv1.Scan, filename string) string {
 	urlTemplate, ok := os.LookupEnv("S3_URL_TEMPLATE")
-	if ok {
-		return executeUrlTemplate(urlTemplate, scan, filename)
-	} else {
-		// use default when env variable is not defined
-		return fmt.Sprintf("scan-%s/%s", scan.UID, filename)
+	if !ok {
+		// use default when environment variable is not set
+		urlTemplate = "scan-{{ .Scan.UID }}/{{ .Filename }}"
 	}
+	return executeUrlTemplate(urlTemplate, scan, filename)
 }
 
 func executeUrlTemplate(urlTemplate string, scan executionv1.Scan, filename string) string {

--- a/operator/controllers/execution/scans/scan_reconciler.go
+++ b/operator/controllers/execution/scans/scan_reconciler.go
@@ -95,26 +95,26 @@ func (r *ScanReconciler) startScan(scan *executionv1.Scan) error {
 	scan.Status.RawResultType = scanType.Spec.ExtractResults.Type
 	scan.Status.RawResultFile = filepath.Base(scanType.Spec.ExtractResults.Location)
 
-	findingsDownloadURL, err := r.PresignedGetURL(scan.UID, "findings.json", 7*24*time.Hour)
+	findingsDownloadURL, err := r.PresignedGetURL(*scan, "findings.json", 7*24*time.Hour)
 	if err != nil {
 		r.Log.Error(err, "Could not get presigned url from s3 or compatible storage provider")
 		return err
 	}
 	scan.Status.FindingDownloadLink = findingsDownloadURL
-	rawResultDownloadURL, err := r.PresignedGetURL(scan.UID, scan.Status.RawResultFile, 7*24*time.Hour)
+	rawResultDownloadURL, err := r.PresignedGetURL(*scan, scan.Status.RawResultFile, 7*24*time.Hour)
 	if err != nil {
 		return err
 	}
 	scan.Status.RawResultDownloadLink = rawResultDownloadURL
 
-	findingsHeadURL, err := r.PresignedHeadURL(scan.UID, "findings.json", 7*24*time.Hour)
+	findingsHeadURL, err := r.PresignedHeadURL(*scan, "findings.json", 7*24*time.Hour)
 	if err != nil {
 		r.Log.Error(err, "Could not get presigned head url from s3 or compatible storage provider")
 		return err
 	}
 	scan.Status.FindingHeadLink = findingsHeadURL
 
-	rawResultsHeadURL, err := r.PresignedHeadURL(scan.UID, scan.Status.RawResultFile, 7*24*time.Hour)
+	rawResultsHeadURL, err := r.PresignedHeadURL(*scan, scan.Status.RawResultFile, 7*24*time.Hour)
 	if err != nil {
 		r.Log.Error(err, "Could not get presigned head url from s3 or compatible storage provider")
 		return err
@@ -161,7 +161,7 @@ func (r *ScanReconciler) checkIfScanIsCompleted(scan *executionv1.Scan) error {
 
 func (r *ScanReconciler) constructJobForScan(scan *executionv1.Scan, scanType *executionv1.ScanType) (*batch.Job, error) {
 	filename := filepath.Base(scanType.Spec.ExtractResults.Location)
-	resultUploadURL, err := r.PresignedPutURL(scan.UID, filename, defaultPresignDuration)
+	resultUploadURL, err := r.PresignedPutURL(*scan, filename, defaultPresignDuration)
 	if err != nil {
 		r.Log.Error(err, "Could not get presigned url from s3 or compatible storage provider")
 		return nil, err

--- a/operator/templates/manager/manager.yaml
+++ b/operator/templates/manager/manager.yaml
@@ -124,6 +124,10 @@ spec:
             - name: CUSTOM_CA_CERTIFICATE_NAME
               value: {{ .Values.customCACertificate.certificate | quote }}
             {{ end }}
+            {{- if .Values.s3UrlTemplate }}
+            - name: S3_URL_TEMPLATE
+              value: {{ .Values.s3UrlTemplate }}
+            {{ end }}
           resources:
             {{- toYaml .Values.resources | nindent 12 }}
           securityContext:

--- a/operator/values.yaml
+++ b/operator/values.yaml
@@ -109,3 +109,6 @@ resources:
   requests:
     cpu: 100m
     memory: 20Mi
+# s3FileUrlTemplate -- Template that generates the url to access the result files of a scan
+# @default -- scan-{{ .Scan.UID }}/{{ .Filename }}
+s3UrlTemplate: null


### PR DESCRIPTION
fixes #1137

This PR adds a config option to the operator where the user can provide a go template to change the default filenames for s3. The default itself did not change compared to previous operators.