### PR TITLE
Docs: Make separation between cluster- and namespace modes more explicit in ADR12 (Cluster-wide resources)

### DIFF
--- a/docs/adr/adr_0012.md
+++ b/docs/adr/adr_0012.md
@@ -184,11 +184,11 @@ When a cluster-mode scan job has completed and the results need to be parsed, th
 
 Other than being cluster scoped, `ClusterCascadingRule`s are identical to the existing `CascadingRule` CRD.
 
-When the cascading scans hook is installed as a `ClusterScanCompletionHook`, it only uses `ClusterCascadingRule`s to create cascading scans. They are evaluated against the scan just like it is now. All scans started from it have to be in the same namespace as the original Scan.
+When the cascading scans hook is installed as a `ClusterScanCompletionHook`, it only uses `ClusterCascadingRule`s to create cascading scans. They are evaluated against the cluster-mode scan like normal, and ignore namespace-mode scans entirely. All scans started from it have to be in the same namespace as the original Scan.
 
 #### `ClusterScanCompletionHook`
 
-Other than being cluster scoped, `ClusterScanCompletionHook`s are identical to the existing `ClusterScanCompletionHook` CRD, except for the addition of a new setting called namespaceMode which allows users to configure to either run the hook in the same namespace as the scan it is getting executed for, or to provide a fixed namespace where all executions for this `ClusterScanCompletionHook` will be run in.
+Other than being cluster scoped, `ClusterScanCompletionHook`s are identical to the existing `ClusterScanCompletionHook` CRD, except for the addition of a new setting called namespaceMode which allows users to configure to either run the hook in the same namespace as the scan it is getting executed for, or to provide a fixed namespace where all executions for this `ClusterScanCompletionHook` will be run in. Like all other cluster-scoped resources, `ClusterScanCompletionHook`s will only be executed on scans running in the `cluster` mode, not those in `namespace` mode.
 
 Example ClusterScanCompletionHook which gets executed inside the scans namespace:
 


### PR DESCRIPTION
We found that the separation in the description of one of the proposals for the cluster-wide resources was insufficiently clear. With this PR, I'm adding some more explicit notes in some places.