### PR TITLE
Fix semgrep helm linting error

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -40,3 +40,4 @@ Committing with `git commit -s` will add the sign-off at the end of the commit m
 - Mateusz Majcher <m.majcher91@gmail.com>
 - Guillermo Rodriguez <guimo.spritekin@gmail.com>
 - Lyuben Dimitrov <ldimitrov070@gmail.com>
+- Matthew Cascio <cascio@cybercapsicum.com>

--- a/scanners/semgrep/Chart.yaml
+++ b/scanners/semgrep/Chart.yaml
@@ -28,7 +28,7 @@ sources:
   - https://github.com/secureCodeBox/secureCodeBox
 maintainers:
   - name: iteratec GmbH
-  - email: secureCodeBox@iteratec.com
+    email: secureCodeBox@iteratec.com
 keywords:
   - security
   - semgrep


### PR DESCRIPTION
<!-- 
Thank you for your contribution to our Project 🙌 

Before submitting your Pull Request, please take the time to check the points below and provide some descriptive information.
* [ ] If this PR comes from a fork, please [Allow edits from maintainers](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork)
* [ ] Set a meaningful title. Format: {task_name} (closes #{issue_number}). For example: Use logger (closes #41)
* [ ] [Link your Pull Request to an issue](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) (if applicable)
* [ ] Create Draft pull requests if you need clarification or an explicit review before you can continue your work item.
* [ ] Make sure that your PR is not introducing _unnecessary_ reformatting (e.g., introduced by on-save hooks in your IDE)
* [ ] Make sure each new source file you add has a correct license header.

For more information on content related and formal acceptance criteria for PRs, please have a look at our 
[docs](https://www.securecodebox.io/docs/contributing/contribution-criteria). 
-->

## Description
<!-- Please describe briefly which issue is solved by your PR or which enhancement it brings -->

When I tried to run `helm lint` on the semgrep scanner chart, it failed with the following message.

```
[ERROR] Chart.yaml: each maintainer requires a name
```

The fix applied here adds `email` to the same list item as the `name` field. The `Chart.yaml` for semgrep should now have an identical maintainer section to the other `Chart.yaml` files.

I have verified `helm lint` no longer fails for semgrep after making this change. I have also verified that no other helm charts in the scanners folder have this issue. It is maybe worth noting that [MegaLinter](https://oxsecurity.github.io/megalinter/latest/supported-linters/) does not support helm charts. I would be willing to write an issue for adding helm linting to the project. I would also be willing to open a PR to add this feature, but I am not so familiar with the project and CI tools.

### Checklist

* [x] Test your changes as thoroughly as possible before you commit them. Preferably, automate your test by unit/integration tests.
* [x] Make sure that all your commits are signed-off and that you are added to the [Contributors](https://github.com/secureCodeBox/secureCodeBox/blob/main/CONTRIBUTORS.md) file.
* [ ] Make sure that all CI finish successfully.
* [x] Optional (but appreciated): Make sure that all commits are [Verified](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits).

Signed-off-by: Matthew Cascio <cascio@cybercapsicum.com>