### PR TITLE
ZAP Makefile: Set parser image tag to IMG_TAG

### DIFF
--- a/scanners/zap/Makefile
+++ b/scanners/zap/Makefile
@@ -19,6 +19,6 @@ integration-tests:
 	kubectl -n integration-tests delete configmaps --all
 	helm -n integration-tests upgrade --install $(scanner) ./ --wait \
 		--set="parser.image.repository=docker.io/$(IMG_NS)/$(parser-prefix)-zap" \
-		--set="parser.image.tag=3.1.0"
+		--set="parser.image.tag=$(IMG_TAG)"
 	kubectl apply -f ./integration-tests/automation-framework-configMap.yaml -n integration-tests
 	cd $(SCANNERS_DIR) && npm ci && cd $(scanner)/integration-tests && npm run test --yes --package jest@$(JEST_VERSION) $(scanner)/integration-tests


### PR DESCRIPTION
Signed-off-by: fphoer <107252742+fphoer@users.noreply.github.com>

## Description
The image parser tag in the Makefile of ZAP is hardcoded. This PR fixes that.
