### PR TITLE
#1460 Change ADR-0007 State to DRAFT

### DIFF
--- a/docs/adr/adr_0007.md
+++ b/docs/adr/adr_0007.md
@@ -10,7 +10,7 @@ sidebar_label: "ADR-0007"
 
 | <!-- -->       | <!-- -->                                           |
 |----------------|----------------------------------------------------|
-| **Status**:    | DEPRECATED                                         |
+| **Status**:    | DRAFT                                         |
 | **Date**:      | 2020-11-25                                         |
 | **Author(s)**: | Sven Strittmatter <Sven.Strittmatter@iteratec.com> |
 
@@ -18,12 +18,13 @@ sidebar_label: "ADR-0007"
 
 ## Context
 
-We need the possibility to find duplicate findings. One use case is that we want to accept a finding and want to ignore the same finding in the future.
+The secureCodeBox should support the possibility to find duplicate findings easily out of the box. 
+One use case is that a user want to accept a existing finding and want to ignore the same finding in the future.
 
 ### Assumptions
 
 - The execution order of *hooks* is unspecified.
-- The information if a finding’s hash is a duplicate MUST NOT be stored or maintained in the *SCB* S3 storage.
+- The information if a finding’s *hash* is a duplicate MUST NOT be stored or maintained in the *SCB* S3 storage.
 - The *SCB* MUST NOT remove findings: *read-write-hooks* may alter them, but never delete or filter them out.
   - Maybe a *read-hooks* MAY decide to not store a finding into an external system.
 

--- a/docs/adr/adr_0007.md
+++ b/docs/adr/adr_0007.md
@@ -10,7 +10,7 @@ sidebar_label: "ADR-0007"
 
 | <!-- -->       | <!-- -->                                           |
 |----------------|----------------------------------------------------|
-| **Status**:    | PROPOSED                                           |
+| **Status**:    | DEPRECATED                                         |
 | **Date**:      | 2020-11-25                                         |
 | **Author(s)**: | Sven Strittmatter <Sven.Strittmatter@iteratec.com> |
 
@@ -29,12 +29,12 @@ We need the possibility to find duplicate findings. One use case is that we want
 
 ## Decision
 
-- We generate a hash for each finding so we can compare findings by the hash and identify duplicates.
-- This hash MUST be mutable and MAY be altered by *read-write-hooks* because we don’t want to introduce an exceptions to what a *read-write-hooks* can alter.
-- The *parser* MUST generate the initial hash of a finding from some of it’s attributes (e.g. name, lication, category …).
+- We generate a hash for each finding, so we can compare findings by the hash and identify duplicates.
+- This hash MUST be mutable and MAY be altered by *read-write-hooks* because we don’t want to introduce an exception to what a *read-write-hooks* can alter.
+- The *parser* MUST generate the initial hash of a finding from some of its attributes (e.g. name, location, category …).
   - Each *scanner* MUST define a default set of attributes used for the hashing.
   - This set of hashed attributes MAY be overwritten.
-- Each *read-write-hooks* MUST update the hash as last step because the *hook* MAY changed a hashed attribute.
+- Each *read-write-hook* MUST update the hash as last step because the *hook* MAY change a hashed attribute.
 
 We implement the hashing step in the *parser* first with feature flag to evaluate this proposal.
 


### PR DESCRIPTION
Since we use DefectDojo for duplicate handling this is obsolete for now.

Signed-off-by: Sven Strittmatter <sven.strittmatter@iteratec.com>

<!-- 
Thank you for your contribution to our Project 🙌 

Before submitting your Pull Request, please take the time to check the points below and provide some descriptive information.
* [ ] If this PR comes from a fork, please [Allow edits from maintainers](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork)
* [ ] Set a meaningful title. Format: {task_name} (closes #{issue_number}). For example: Use logger (closes #41)
* [ ] [Link your Pull Request to an issue](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) (if applicable)
* [ ] Create Draft pull requests if you need clarification or an explicit review before you can continue your work item.
* [ ] Make sure that your PR is not introducing _unnecessary_ reformatting (e.g., introduced by on-save hooks in your IDE)
* [ ] Make sure each new source file you add has a correct license header.

For more information on content related and formal acceptance criteria for PRs, please have a look at our 
[docs](https://www.securecodebox.io/docs/contributing/contribution-criteria). 
-->

## Description
<!-- Please describe briefly which issue is solved by your PR or which enhancement it brings -->


### Checklist

* [ ] Test your changes as thoroughly as possible before you commit them. Preferably, automate your test by unit/integration tests.
* [ ] Make sure that all your commits are signed-off and that you are added to the [Contributors](https://github.com/secureCodeBox/secureCodeBox/blob/main/CONTRIBUTORS.md) file.
* [ ] Make sure that all CI finish successfully.
* [ ] Optional (but appreciated): Make sure that all commits are [Verified](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits).
