### PR TITLE
Fixed Generic WebHook API Key not working correctly

### DIFF
--- a/hooks/generic-webhook/.helm-docs.gotmpl
+++ b/hooks/generic-webhook/.helm-docs.gotmpl
@@ -30,8 +30,40 @@ Installing the Generic WebHook hook will add a ReadOnly Hook to your namespace w
 
 {{- define "extra.chartConfigurationSection" -}}
 ## Additional Chart Configurations
+The webhook URL is set as follows:
 
-> ✍ This documentation is currently work-in-progress.
+```bash
+helm upgrade --install generic-webhook secureCodeBox/generic-webhook \
+    --set="webhookUrl=http://http-webhook/hello-world"
+```
+Two authentication methods exist for the Generic WebHook Hook. You can either use  Basic authentication or API authentication.
+The authentication method is set by creating the corresponding secret as follows:
+
+##### Basic authentication:
+    
+```bash
+kubectl create secret generic generic-webhook-credentials \
+--from-literal=username='admin' \
+--from-literal=password='ThisIsAPassword'
+```
+##### API authentication:
+
+```bash
+kubectl create secret generic generic-webhook-credentials \
+--from-literal=headerName='X-Example-Header' \
+--from-literal=headerValue='ThisIsAnAPIkeyValue'
+```
+
+Only one authentication method can be used at a time.
+
+The keys for your secret mapping can also be renamed if necessary, for example `headerName` and `headerValue` can be renamed to `name` and `value` respectively.
+
+This is usually done to reuse existing secrets.
+```bash
+helm upgrade --install generic-webhook secureCodeBox/generic-webhook \
+--set="hook.authentication.apikey.headerNameKey=name"  \
+--set="hook.authentication.apikey.headerValueKey=value"
+```
 {{- end }}
 
 {{- define "extra.scannerLinksSection" -}}

--- a/hooks/generic-webhook/README.md
+++ b/hooks/generic-webhook/README.md
@@ -48,17 +48,50 @@ helm upgrade --install generic-webhook secureCodeBox/generic-webhook
 Kubernetes: `>=v1.11.0-0`
 
 ## Additional Chart Configurations
+The webhook URL is set as follows:
 
-> ✍ This documentation is currently work-in-progress.
+```bash
+helm upgrade --install generic-webhook secureCodeBox/generic-webhook \
+    --set="webhookUrl=http://http-webhook/hello-world"
+```
+Two authentication methods exist for the Generic WebHook Hook. You can either use  Basic authentication or API authentication.
+The authentication method is set by creating the corresponding secret as follows:
+
+##### Basic authentication:
+   
+```bash
+kubectl create secret generic generic-webhook-credentials \
+--from-literal=username='admin' \
+--from-literal=password='ThisIsAPassword'
+```
+##### API authentication:
+
+```bash
+kubectl create secret generic generic-webhook-credentials \
+--from-literal=headerName='X-Example-Header' \
+--from-literal=headerValue='ThisIsAnAPIkeyValue'
+```
+
+Only one authentication method can be used at a time.
+
+The keys for your secret mapping can also be renamed if necessary, for example `headerName` and `headerValue` can be renamed to `name` and `value` respectively.
+
+This is usually done to reuse existing secrets.
+```bash
+helm upgrade --install generic-webhook secureCodeBox/generic-webhook \
+--set="hook.authentication.apikey.headerNameKey=name"  \
+--set="hook.authentication.apikey.headerValueKey=value"
+```
 
 ## Values
 
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
 | hook.affinity | object | `{}` | Optional affinity settings that control how the hook job is scheduled (see: https://kubernetes.io/docs/tasks/configure-pod-container/assign-pods-nodes-using-node-affinity/) |
-| hook.authentication | object | `{"apikey":{"headerName":"X-Example-Header","headerValue":"example","userSecret":"generic-webhook-credentials"},"basic":{"passwordKey":"password","userSecret":"generic-webhook-credentials","usernameKey":"username"}}` | Optional basic authentication credentials or apikey |
-| hook.authentication.apikey.headerName | string | `"X-Example-Header"` | Customize header name as per your needs ex: X-Api-Key |
-| hook.authentication.apikey.userSecret | string | `"generic-webhook-credentials"` | Link a pre-existing generic secret with `usernameKey` and `passwordKey` key / value pairs |
+| hook.authentication | object | `{"apikey":{"headerNameKey":"headerName","headerValueKey":"headerValue","userSecret":"generic-webhook-credentials"},"basic":{"passwordKey":"password","userSecret":"generic-webhook-credentials","usernameKey":"username"}}` | Optional basic authentication credentials or apikey |
+| hook.authentication.apikey.headerNameKey | string | `"headerName"` | Name of the header name key in the `userSecret` secret. Use this if you already have a secret with different key / value pairs |
+| hook.authentication.apikey.headerValueKey | string | `"headerValue"` | Name of the header value key in the `userSecret` secret. Use this if you already have a secret with different key / value pairs |
+| hook.authentication.apikey.userSecret | string | `"generic-webhook-credentials"` | Link a pre-existing generic secret with `headerNameKey` and `headerValueKey` key / value pairs |
 | hook.authentication.basic.passwordKey | string | `"password"` | Name of the password key in the `userSecret` secret. Use this if you already have a secret with different key / value pairs |
 | hook.authentication.basic.userSecret | string | `"generic-webhook-credentials"` | Link a pre-existing generic secret with `usernameKey` and `passwordKey` key / value pairs |
 | hook.authentication.basic.usernameKey | string | `"username"` | Name of the username key in the `userSecret` secret. Use this if you already have a secret with different key / value pairs |

--- a/hooks/generic-webhook/hook/hook.js
+++ b/hooks/generic-webhook/hook/hook.js
@@ -8,19 +8,19 @@ async function handle({
   webhookUrl = process.env["WEBHOOK_URL"],
   webhookUser = process.env["WEBHOOK_USER"],
   webhookPassword = process.env["WEBHOOK_PASSWORD"],
-  webhookApikey = process.env["WEBHOOK_APIKEY"],
-  webhookApikeySecret = process.env["WEBHOOK_APIKEY_SECRET"],
+  webhookApikeyHeaderName = process.env["WEBHOOK_APIKEY_HEADER_NAME"],
+  webhookApikeyHeaderValue = process.env["WEBHOOK_APIKEY_HEADER_VALUE"],
   axios = require('axios')
 }) {
   const findings = await getFindings();
 
   console.log(`Sending ${findings.length} findings to ${webhookUrl}`);
 
-  if (webhookApikey && webhookApikeySecret){
-    await axios.post(webhookUrl, {scan, findings }, {headers: { [webhookApikey]: webhookApikeySecret}});
-  }else if (webhookUser && webhookPassword){
+  if (webhookApikeyHeaderName && webhookApikeyHeaderValue){
+    await axios.post(webhookUrl, {scan, findings }, {headers: { [webhookApikeyHeaderName]: webhookApikeyHeaderValue}});
+  } else if (webhookUser && webhookPassword){
     await axios.post(webhookUrl, {scan, findings }, {auth: {username: webhookUser, password: webhookPassword}});
-  }else{
+  } else {
     await axios.post(webhookUrl, {scan, findings });
   }
 }

--- a/hooks/generic-webhook/templates/webhook-hook.yaml
+++ b/hooks/generic-webhook/templates/webhook-hook.yaml
@@ -31,17 +31,17 @@ spec:
           name: {{ .Values.hook.authentication.basic.userSecret }}
           key: {{ .Values.hook.authentication.basic.passwordKey }}
           optional: true
-    - name: WEBHOOK_APIKEY
+    - name: WEBHOOK_APIKEY_HEADER_NAME
       valueFrom:
         secretKeyRef:
           name: {{ .Values.hook.authentication.apikey.userSecret }}
-          key: {{ .Values.hook.authentication.apikey.headerName }}
+          key: {{ .Values.hook.authentication.apikey.headerNameKey }}
           optional: true
-    - name: WEBHOOK_APIKEY_SECRET
+    - name: WEBHOOK_APIKEY_HEADER_VALUE
       valueFrom:
         secretKeyRef:
           name: {{ .Values.hook.authentication.apikey.userSecret }}
-          key: {{ .Values.hook.authentication.apikey.headerValue }}
+          key: {{ .Values.hook.authentication.apikey.headerValueKey }}
           optional: true
   affinity:
     {{- toYaml .Values.hook.affinity | nindent 4 }}

--- a/hooks/generic-webhook/values.yaml
+++ b/hooks/generic-webhook/values.yaml
@@ -38,11 +38,12 @@ hook:
   # hook.authentication -- Optional basic authentication credentials or apikey
   authentication:
     apikey:
-      # -- Link a pre-existing generic secret with `usernameKey` and `passwordKey` key / value pairs
+      # -- Link a pre-existing generic secret with `headerNameKey` and `headerValueKey` key / value pairs
       userSecret: generic-webhook-credentials
-      # -- Customize header name as per your needs ex: X-Api-Key
-      headerName: X-Example-Header
-      headerValue: example
+      # -- Name of the header name key in the `userSecret` secret. Use this if you already have a secret with different key / value pairs
+      headerNameKey: headerName
+      # -- Name of the header value key in the `userSecret` secret. Use this if you already have a secret with different key / value pairs
+      headerValueKey: headerValue
     basic:
       # -- Link a pre-existing generic secret with `usernameKey` and `passwordKey` key / value pairs
       userSecret: generic-webhook-credentials


### PR DESCRIPTION
## Description
<!-- Please describe briefly which issue is solved by your PR or which enhancement it brings -->
closes #1664
Renamed the values.yaml API key authentication to correspond to the name of the key of the secret instead of the value. Changed template and hook.js accordingly

POC:
Create secret:
```bash
kubectl create secret generic generic-webhook-credentials -n integration-tests \
--from-literal=headerName='X-Example-Header' \
--from-literal=headerValue='ThisIsAnAPIkeyValue'
```

Webhook Event:
```json
{
  "event": {
    "method": "POST",
    "path": "/",
    "query": {},
    "client_ip": "192.168.0.1",
    "url": "https://redacted.m.pipedream.net/",
    "headers": {
      "host": "redacted.m.pipedream.net",
      "content-length": "4057",
      "accept": "application/json, text/plain, */*",
      "content-type": "application/json",
      "x-example-header": "ThisIsAnAPIkeyValue",
      "user-agent": "axios/0.27.2"
    },
    "body": {...}
    }
}
```

### Checklist

* [x] Test your changes as thoroughly as possible before you commit them. Preferably, automate your test by unit/integration tests.
* [x] Make sure that all your commits are signed-off and that you are added to the [Contributors](https://github.com/secureCodeBox/secureCodeBox/blob/main/CONTRIBUTORS.md) file.
* [ ] Make sure that all CI finish successfully.
* [x] Optional (but appreciated): Make sure that all commits are [Verified](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits).
