### PR TITLE
Added references attribute to findings

### DIFF
--- a/parser-sdk/nodejs/findings-schema.json
+++ b/parser-sdk/nodejs/findings-schema.json
@@ -53,6 +53,22 @@
           "type": "string",
           "nullable": true
         },
+        "references": {
+          "nullable": true,
+          "type": "array",
+          "items": {
+            "type": "object",
+            "properties": {
+              "type": {
+                "type": "string"
+              },
+              "value": {
+                "type": "string"
+              }
+            },
+            "required": ["type", "value"]
+          }
+        },
         "attributes": {
           "description": "Attributes are not standardized. They differ from Scanner to Scanner.",
           "type": "object"

--- a/scanners/cmseek/parser/__snapshots__/parser.test.js.snap
+++ b/scanners/cmseek/parser/__snapshots__/parser.test.js.snap
@@ -20,6 +20,18 @@ exports[`parser parses result of Joomla scan with core vulnerabilities successfu
     "osi_layer": "APPLICATION",
     "references": [
       {
+        "type": "url",
+        "value": "https://www.rapid7.com/db/modules/exploit/multi/http/phpmailer_arg_injection",
+      },
+      {
+        "type": "url",
+        "value": "https://github.com/opsxcq/exploit-CVE-2016-10033",
+      },
+      {
+        "type": "url",
+        "value": "https://www.exploit-db.com/exploits/40969/",
+      },
+      {
         "type": "cve",
         "value": "CVE-2016-10033",
       },
@@ -47,6 +59,14 @@ exports[`parser parses result of Joomla scan with core vulnerabilities successfu
     "osi_layer": "APPLICATION",
     "references": [
       {
+        "type": "url",
+        "value": "https://www.rapid7.com/db/modules/exploit/multi/http/phpmailer_arg_injection",
+      },
+      {
+        "type": "url",
+        "value": "https://www.exploit-db.com/exploits/40969/",
+      },
+      {
         "type": "cve",
         "value": "CVE-2016-10045",
       },
@@ -66,10 +86,33 @@ exports[`parser parses result of Joomla scan with core vulnerabilities successfu
       ],
     },
     "category": "Vulnerability",
-    "description": "Vulnerability of type PPHPMailer Incomplete Fix Remote Code Execution Vulnerability found",
+    "description": "Vulnerability of type PPHPMailer Incomplete Fix Remote Code Execution Vulnerability **without CVE** found",
     "identified_at": "2021-09-22T10:29:01.721Z",
     "location": "http://172.26.0.3/",
-    "name": "PPHPMailer Incomplete Fix Remote Code Execution Vulnerability",
+    "name": "PPHPMailer Incomplete Fix Remote Code Execution Vulnerability **without CVE**",
+    "osi_layer": "APPLICATION",
+    "references": [
+      {
+        "type": "url",
+        "value": "https://www.rapid7.com/db/modules/exploit/multi/http/phpmailer_arg_injection",
+      },
+      {
+        "type": "url",
+        "value": "https://www.exploit-db.com/exploits/40969/",
+      },
+    ],
+    "severity": "HIGH",
+  },
+  {
+    "attributes": {
+      "joomla_version": "3.6.5",
+      "references": [],
+    },
+    "category": "Vulnerability",
+    "description": "Vulnerability of type PPHPMailer Incomplete Fix Remote Code Execution Vulnerability **without references** found",
+    "identified_at": "2021-09-22T10:29:01.721Z",
+    "location": "http://172.26.0.3/",
+    "name": "PPHPMailer Incomplete Fix Remote Code Execution Vulnerability **without references**",
     "osi_layer": "APPLICATION",
     "references": null,
     "severity": "HIGH",

--- a/scanners/cmseek/parser/__snapshots__/parser.test.js.snap
+++ b/scanners/cmseek/parser/__snapshots__/parser.test.js.snap
@@ -18,6 +18,16 @@ exports[`parser parses result of Joomla scan with core vulnerabilities successfu
     "location": "http://172.26.0.3/",
     "name": "PHPMailer Remote Code Execution Vulnerability",
     "osi_layer": "APPLICATION",
+    "references": [
+      {
+        "type": "cve",
+        "value": "CVE-2016-10033",
+      },
+      {
+        "type": "url",
+        "value": "https://www.cve.org/CVERecord?id=CVE-2016-10033",
+      },
+    ],
     "severity": "HIGH",
   },
   {
@@ -35,6 +45,33 @@ exports[`parser parses result of Joomla scan with core vulnerabilities successfu
     "location": "http://172.26.0.3/",
     "name": "PPHPMailer Incomplete Fix Remote Code Execution Vulnerability",
     "osi_layer": "APPLICATION",
+    "references": [
+      {
+        "type": "cve",
+        "value": "CVE-2016-10045",
+      },
+      {
+        "type": "url",
+        "value": "https://www.cve.org/CVERecord?id=CVE-2016-10045",
+      },
+    ],
+    "severity": "HIGH",
+  },
+  {
+    "attributes": {
+      "joomla_version": "3.6.5",
+      "references": [
+        "https://www.rapid7.com/db/modules/exploit/multi/http/phpmailer_arg_injection",
+        "EDB : https://www.exploit-db.com/exploits/40969/",
+      ],
+    },
+    "category": "Vulnerability",
+    "description": "Vulnerability of type PPHPMailer Incomplete Fix Remote Code Execution Vulnerability found",
+    "identified_at": "2021-09-22T10:29:01.721Z",
+    "location": "http://172.26.0.3/",
+    "name": "PPHPMailer Incomplete Fix Remote Code Execution Vulnerability",
+    "osi_layer": "APPLICATION",
+    "references": null,
     "severity": "HIGH",
   },
   {

--- a/scanners/cmseek/parser/__snapshots__/parser.test.js.snap
+++ b/scanners/cmseek/parser/__snapshots__/parser.test.js.snap
@@ -20,23 +20,23 @@ exports[`parser parses result of Joomla scan with core vulnerabilities successfu
     "osi_layer": "APPLICATION",
     "references": [
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://www.rapid7.com/db/modules/exploit/multi/http/phpmailer_arg_injection",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://github.com/opsxcq/exploit-CVE-2016-10033",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://www.exploit-db.com/exploits/40969/",
       },
       {
-        "type": "cve",
+        "type": "CVE",
         "value": "CVE-2016-10033",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://www.cve.org/CVERecord?id=CVE-2016-10033",
       },
     ],
@@ -59,19 +59,19 @@ exports[`parser parses result of Joomla scan with core vulnerabilities successfu
     "osi_layer": "APPLICATION",
     "references": [
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://www.rapid7.com/db/modules/exploit/multi/http/phpmailer_arg_injection",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://www.exploit-db.com/exploits/40969/",
       },
       {
-        "type": "cve",
+        "type": "CVE",
         "value": "CVE-2016-10045",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://www.cve.org/CVERecord?id=CVE-2016-10045",
       },
     ],
@@ -93,11 +93,11 @@ exports[`parser parses result of Joomla scan with core vulnerabilities successfu
     "osi_layer": "APPLICATION",
     "references": [
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://www.rapid7.com/db/modules/exploit/multi/http/phpmailer_arg_injection",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://www.exploit-db.com/exploits/40969/",
       },
     ],

--- a/scanners/cmseek/parser/__testFiles__/joomla_with_core_vulns.json
+++ b/scanners/cmseek/parser/__testFiles__/joomla_with_core_vulns.json
@@ -37,7 +37,15 @@
                 "https://www.rapid7.com/db/modules/exploit/multi/http/phpmailer_arg_injection",
                 "EDB : https://www.exploit-db.com/exploits/40969/"
             ]
+        },
+        {
+            "name": "PPHPMailer Incomplete Fix Remote Code Execution Vulnerability **without CVE**",
+            "references": [
+                "https://www.rapid7.com/db/modules/exploit/multi/http/phpmailer_arg_injection",
+                "EDB : https://www.exploit-db.com/exploits/40969/"
+            ]
         }
+
     ],
     "vulnerabilities_count": "2"
 }

--- a/scanners/cmseek/parser/__testFiles__/joomla_with_core_vulns.json
+++ b/scanners/cmseek/parser/__testFiles__/joomla_with_core_vulns.json
@@ -44,8 +44,13 @@
                 "https://www.rapid7.com/db/modules/exploit/multi/http/phpmailer_arg_injection",
                 "EDB : https://www.exploit-db.com/exploits/40969/"
             ]
+        },
+        {
+            "name": "PPHPMailer Incomplete Fix Remote Code Execution Vulnerability **without references**",
+            "references": [
+            ]
         }
 
     ],
-    "vulnerabilities_count": "2"
+    "vulnerabilities_count": "4"
 }

--- a/scanners/cmseek/parser/parser.js
+++ b/scanners/cmseek/parser/parser.js
@@ -54,7 +54,7 @@ async function parse(findings) {
 
       const cve_reference = cve ? [
         {
-          "type": "cve",
+          "type": "CVE",
           "value": cve
         },
         {

--- a/scanners/cmseek/parser/parser.js
+++ b/scanners/cmseek/parser/parser.js
@@ -58,7 +58,7 @@ async function parse(findings) {
           "value": cve
         },
         {
-          "type": "url",
+          "type": "URL",
           "value": `https://www.cve.org/CVERecord?id=${cve}`
         }
       ] : []
@@ -74,7 +74,7 @@ async function parse(findings) {
 
       const urls_references = urls.map((url) => {
         return {
-          "type": "url",
+          "type": "URL",
           "value": url
         };
       });

--- a/scanners/nikto/parser/__snapshots__/parser.test.js.snap
+++ b/scanners/nikto/parser/__snapshots__/parser.test.js.snap
@@ -10,6 +10,7 @@ exports[`parses OWASP Juice Shop result file into findings 1`] = `
       "method": "GET",
       "niktoId": 999986,
       "port": 3000,
+      "references": null,
     },
     "category": "Nikto Finding",
     "description": null,
@@ -26,6 +27,12 @@ exports[`parses OWASP Juice Shop result file into findings 1`] = `
       "method": "GET",
       "niktoId": 999997,
       "port": 3000,
+      "references": [
+        {
+          "type": "URL",
+          "value": "https://portswigger.net/kb/issues/00600600_robots-txt-file",
+        },
+      ],
     },
     "category": "Nikto Finding",
     "description": null,
@@ -42,6 +49,12 @@ exports[`parses OWASP Juice Shop result file into findings 1`] = `
       "method": "GET",
       "niktoId": 999996,
       "port": 3000,
+      "references": [
+        {
+          "type": "URL",
+          "value": "https://developer.mozilla.org/en-US/docs/Glossary/Robots.txt",
+        },
+      ],
     },
     "category": "robots.txt",
     "description": null,
@@ -58,6 +71,12 @@ exports[`parses OWASP Juice Shop result file into findings 1`] = `
       "method": "GET",
       "niktoId": 999103,
       "port": 3000,
+      "references": [
+        {
+          "type": "URL",
+          "value": "https://www.netsparker.com/web-vulnerability-scanner/vulnerabilities/missing-content-type-header/",
+        },
+      ],
     },
     "category": "X-Content-Type-Options Header",
     "description": null,
@@ -74,6 +93,16 @@ exports[`parses OWASP Juice Shop result file into findings 1`] = `
       "method": "HEAD",
       "niktoId": 740001,
       "port": 3000,
+      "references": [
+        {
+          "type": "URL",
+          "value": "https://cwe.mitre.org/data/definitions/530.html",
+        },
+        {
+          "type": "CWE",
+          "value": "CWE-530",
+        },
+      ],
     },
     "category": "Potential Backup File",
     "description": null,
@@ -90,6 +119,16 @@ exports[`parses OWASP Juice Shop result file into findings 1`] = `
       "method": "HEAD",
       "niktoId": 740001,
       "port": 3000,
+      "references": [
+        {
+          "type": "URL",
+          "value": "https://cwe.mitre.org/data/definitions/530.html",
+        },
+        {
+          "type": "CWE",
+          "value": "CWE-530",
+        },
+      ],
     },
     "category": "Potential Backup File",
     "description": null,
@@ -106,6 +145,16 @@ exports[`parses OWASP Juice Shop result file into findings 1`] = `
       "method": "HEAD",
       "niktoId": 740001,
       "port": 3000,
+      "references": [
+        {
+          "type": "URL",
+          "value": "https://cwe.mitre.org/data/definitions/530.html",
+        },
+        {
+          "type": "CWE",
+          "value": "CWE-530",
+        },
+      ],
     },
     "category": "Potential Backup File",
     "description": null,
@@ -122,6 +171,16 @@ exports[`parses OWASP Juice Shop result file into findings 1`] = `
       "method": "HEAD",
       "niktoId": 740001,
       "port": 3000,
+      "references": [
+        {
+          "type": "URL",
+          "value": "https://cwe.mitre.org/data/definitions/530.html",
+        },
+        {
+          "type": "CWE",
+          "value": "CWE-530",
+        },
+      ],
     },
     "category": "Potential Backup File",
     "description": null,
@@ -138,6 +197,16 @@ exports[`parses OWASP Juice Shop result file into findings 1`] = `
       "method": "HEAD",
       "niktoId": 740001,
       "port": 3000,
+      "references": [
+        {
+          "type": "URL",
+          "value": "https://cwe.mitre.org/data/definitions/530.html",
+        },
+        {
+          "type": "CWE",
+          "value": "CWE-530",
+        },
+      ],
     },
     "category": "Potential Backup File",
     "description": null,
@@ -154,6 +223,16 @@ exports[`parses OWASP Juice Shop result file into findings 1`] = `
       "method": "HEAD",
       "niktoId": 740001,
       "port": 3000,
+      "references": [
+        {
+          "type": "URL",
+          "value": "https://cwe.mitre.org/data/definitions/530.html",
+        },
+        {
+          "type": "CWE",
+          "value": "CWE-530",
+        },
+      ],
     },
     "category": "Potential Backup File",
     "description": null,
@@ -170,6 +249,16 @@ exports[`parses OWASP Juice Shop result file into findings 1`] = `
       "method": "HEAD",
       "niktoId": 740001,
       "port": 3000,
+      "references": [
+        {
+          "type": "URL",
+          "value": "https://cwe.mitre.org/data/definitions/530.html",
+        },
+        {
+          "type": "CWE",
+          "value": "CWE-530",
+        },
+      ],
     },
     "category": "Potential Backup File",
     "description": null,
@@ -186,6 +275,16 @@ exports[`parses OWASP Juice Shop result file into findings 1`] = `
       "method": "HEAD",
       "niktoId": 740001,
       "port": 3000,
+      "references": [
+        {
+          "type": "URL",
+          "value": "https://cwe.mitre.org/data/definitions/530.html",
+        },
+        {
+          "type": "CWE",
+          "value": "CWE-530",
+        },
+      ],
     },
     "category": "Potential Backup File",
     "description": null,
@@ -202,6 +301,16 @@ exports[`parses OWASP Juice Shop result file into findings 1`] = `
       "method": "HEAD",
       "niktoId": 740001,
       "port": 3000,
+      "references": [
+        {
+          "type": "URL",
+          "value": "https://cwe.mitre.org/data/definitions/530.html",
+        },
+        {
+          "type": "CWE",
+          "value": "CWE-530",
+        },
+      ],
     },
     "category": "Potential Backup File",
     "description": null,
@@ -218,6 +327,16 @@ exports[`parses OWASP Juice Shop result file into findings 1`] = `
       "method": "HEAD",
       "niktoId": 740001,
       "port": 3000,
+      "references": [
+        {
+          "type": "URL",
+          "value": "https://cwe.mitre.org/data/definitions/530.html",
+        },
+        {
+          "type": "CWE",
+          "value": "CWE-530",
+        },
+      ],
     },
     "category": "Potential Backup File",
     "description": null,
@@ -234,6 +353,16 @@ exports[`parses OWASP Juice Shop result file into findings 1`] = `
       "method": "HEAD",
       "niktoId": 740001,
       "port": 3000,
+      "references": [
+        {
+          "type": "URL",
+          "value": "https://cwe.mitre.org/data/definitions/530.html",
+        },
+        {
+          "type": "CWE",
+          "value": "CWE-530",
+        },
+      ],
     },
     "category": "Potential Backup File",
     "description": null,
@@ -250,6 +379,16 @@ exports[`parses OWASP Juice Shop result file into findings 1`] = `
       "method": "HEAD",
       "niktoId": 740001,
       "port": 3000,
+      "references": [
+        {
+          "type": "URL",
+          "value": "https://cwe.mitre.org/data/definitions/530.html",
+        },
+        {
+          "type": "CWE",
+          "value": "CWE-530",
+        },
+      ],
     },
     "category": "Potential Backup File",
     "description": null,
@@ -266,6 +405,16 @@ exports[`parses OWASP Juice Shop result file into findings 1`] = `
       "method": "HEAD",
       "niktoId": 740001,
       "port": 3000,
+      "references": [
+        {
+          "type": "URL",
+          "value": "https://cwe.mitre.org/data/definitions/530.html",
+        },
+        {
+          "type": "CWE",
+          "value": "CWE-530",
+        },
+      ],
     },
     "category": "Potential Backup File",
     "description": null,
@@ -282,6 +431,16 @@ exports[`parses OWASP Juice Shop result file into findings 1`] = `
       "method": "HEAD",
       "niktoId": 740001,
       "port": 3000,
+      "references": [
+        {
+          "type": "URL",
+          "value": "https://cwe.mitre.org/data/definitions/530.html",
+        },
+        {
+          "type": "CWE",
+          "value": "CWE-530",
+        },
+      ],
     },
     "category": "Potential Backup File",
     "description": null,
@@ -298,6 +457,16 @@ exports[`parses OWASP Juice Shop result file into findings 1`] = `
       "method": "HEAD",
       "niktoId": 740001,
       "port": 3000,
+      "references": [
+        {
+          "type": "URL",
+          "value": "https://cwe.mitre.org/data/definitions/530.html",
+        },
+        {
+          "type": "CWE",
+          "value": "CWE-530",
+        },
+      ],
     },
     "category": "Potential Backup File",
     "description": null,
@@ -314,6 +483,16 @@ exports[`parses OWASP Juice Shop result file into findings 1`] = `
       "method": "HEAD",
       "niktoId": 740001,
       "port": 3000,
+      "references": [
+        {
+          "type": "URL",
+          "value": "https://cwe.mitre.org/data/definitions/530.html",
+        },
+        {
+          "type": "CWE",
+          "value": "CWE-530",
+        },
+      ],
     },
     "category": "Potential Backup File",
     "description": null,
@@ -330,6 +509,16 @@ exports[`parses OWASP Juice Shop result file into findings 1`] = `
       "method": "HEAD",
       "niktoId": 740001,
       "port": 3000,
+      "references": [
+        {
+          "type": "URL",
+          "value": "https://cwe.mitre.org/data/definitions/530.html",
+        },
+        {
+          "type": "CWE",
+          "value": "CWE-530",
+        },
+      ],
     },
     "category": "Potential Backup File",
     "description": null,
@@ -346,6 +535,16 @@ exports[`parses OWASP Juice Shop result file into findings 1`] = `
       "method": "HEAD",
       "niktoId": 740001,
       "port": 3000,
+      "references": [
+        {
+          "type": "URL",
+          "value": "https://cwe.mitre.org/data/definitions/530.html",
+        },
+        {
+          "type": "CWE",
+          "value": "CWE-530",
+        },
+      ],
     },
     "category": "Potential Backup File",
     "description": null,
@@ -362,6 +561,16 @@ exports[`parses OWASP Juice Shop result file into findings 1`] = `
       "method": "HEAD",
       "niktoId": 740001,
       "port": 3000,
+      "references": [
+        {
+          "type": "URL",
+          "value": "https://cwe.mitre.org/data/definitions/530.html",
+        },
+        {
+          "type": "CWE",
+          "value": "CWE-530",
+        },
+      ],
     },
     "category": "Potential Backup File",
     "description": null,
@@ -378,6 +587,16 @@ exports[`parses OWASP Juice Shop result file into findings 1`] = `
       "method": "HEAD",
       "niktoId": 740001,
       "port": 3000,
+      "references": [
+        {
+          "type": "URL",
+          "value": "https://cwe.mitre.org/data/definitions/530.html",
+        },
+        {
+          "type": "CWE",
+          "value": "CWE-530",
+        },
+      ],
     },
     "category": "Potential Backup File",
     "description": null,
@@ -394,6 +613,16 @@ exports[`parses OWASP Juice Shop result file into findings 1`] = `
       "method": "HEAD",
       "niktoId": 740001,
       "port": 3000,
+      "references": [
+        {
+          "type": "URL",
+          "value": "https://cwe.mitre.org/data/definitions/530.html",
+        },
+        {
+          "type": "CWE",
+          "value": "CWE-530",
+        },
+      ],
     },
     "category": "Potential Backup File",
     "description": null,
@@ -410,6 +639,16 @@ exports[`parses OWASP Juice Shop result file into findings 1`] = `
       "method": "HEAD",
       "niktoId": 740001,
       "port": 3000,
+      "references": [
+        {
+          "type": "URL",
+          "value": "https://cwe.mitre.org/data/definitions/530.html",
+        },
+        {
+          "type": "CWE",
+          "value": "CWE-530",
+        },
+      ],
     },
     "category": "Potential Backup File",
     "description": null,
@@ -426,6 +665,16 @@ exports[`parses OWASP Juice Shop result file into findings 1`] = `
       "method": "HEAD",
       "niktoId": 740001,
       "port": 3000,
+      "references": [
+        {
+          "type": "URL",
+          "value": "https://cwe.mitre.org/data/definitions/530.html",
+        },
+        {
+          "type": "CWE",
+          "value": "CWE-530",
+        },
+      ],
     },
     "category": "Potential Backup File",
     "description": null,
@@ -442,6 +691,16 @@ exports[`parses OWASP Juice Shop result file into findings 1`] = `
       "method": "HEAD",
       "niktoId": 740001,
       "port": 3000,
+      "references": [
+        {
+          "type": "URL",
+          "value": "https://cwe.mitre.org/data/definitions/530.html",
+        },
+        {
+          "type": "CWE",
+          "value": "CWE-530",
+        },
+      ],
     },
     "category": "Potential Backup File",
     "description": null,
@@ -458,6 +717,16 @@ exports[`parses OWASP Juice Shop result file into findings 1`] = `
       "method": "HEAD",
       "niktoId": 740001,
       "port": 3000,
+      "references": [
+        {
+          "type": "URL",
+          "value": "https://cwe.mitre.org/data/definitions/530.html",
+        },
+        {
+          "type": "CWE",
+          "value": "CWE-530",
+        },
+      ],
     },
     "category": "Potential Backup File",
     "description": null,
@@ -474,6 +743,16 @@ exports[`parses OWASP Juice Shop result file into findings 1`] = `
       "method": "HEAD",
       "niktoId": 740001,
       "port": 3000,
+      "references": [
+        {
+          "type": "URL",
+          "value": "https://cwe.mitre.org/data/definitions/530.html",
+        },
+        {
+          "type": "CWE",
+          "value": "CWE-530",
+        },
+      ],
     },
     "category": "Potential Backup File",
     "description": null,
@@ -490,6 +769,16 @@ exports[`parses OWASP Juice Shop result file into findings 1`] = `
       "method": "HEAD",
       "niktoId": 740001,
       "port": 3000,
+      "references": [
+        {
+          "type": "URL",
+          "value": "https://cwe.mitre.org/data/definitions/530.html",
+        },
+        {
+          "type": "CWE",
+          "value": "CWE-530",
+        },
+      ],
     },
     "category": "Potential Backup File",
     "description": null,
@@ -506,6 +795,16 @@ exports[`parses OWASP Juice Shop result file into findings 1`] = `
       "method": "HEAD",
       "niktoId": 740001,
       "port": 3000,
+      "references": [
+        {
+          "type": "URL",
+          "value": "https://cwe.mitre.org/data/definitions/530.html",
+        },
+        {
+          "type": "CWE",
+          "value": "CWE-530",
+        },
+      ],
     },
     "category": "Potential Backup File",
     "description": null,
@@ -522,6 +821,16 @@ exports[`parses OWASP Juice Shop result file into findings 1`] = `
       "method": "HEAD",
       "niktoId": 740001,
       "port": 3000,
+      "references": [
+        {
+          "type": "URL",
+          "value": "https://cwe.mitre.org/data/definitions/530.html",
+        },
+        {
+          "type": "CWE",
+          "value": "CWE-530",
+        },
+      ],
     },
     "category": "Potential Backup File",
     "description": null,
@@ -538,6 +847,16 @@ exports[`parses OWASP Juice Shop result file into findings 1`] = `
       "method": "HEAD",
       "niktoId": 740001,
       "port": 3000,
+      "references": [
+        {
+          "type": "URL",
+          "value": "https://cwe.mitre.org/data/definitions/530.html",
+        },
+        {
+          "type": "CWE",
+          "value": "CWE-530",
+        },
+      ],
     },
     "category": "Potential Backup File",
     "description": null,
@@ -554,6 +873,16 @@ exports[`parses OWASP Juice Shop result file into findings 1`] = `
       "method": "HEAD",
       "niktoId": 740001,
       "port": 3000,
+      "references": [
+        {
+          "type": "URL",
+          "value": "https://cwe.mitre.org/data/definitions/530.html",
+        },
+        {
+          "type": "CWE",
+          "value": "CWE-530",
+        },
+      ],
     },
     "category": "Potential Backup File",
     "description": null,
@@ -570,6 +899,16 @@ exports[`parses OWASP Juice Shop result file into findings 1`] = `
       "method": "HEAD",
       "niktoId": 740001,
       "port": 3000,
+      "references": [
+        {
+          "type": "URL",
+          "value": "https://cwe.mitre.org/data/definitions/530.html",
+        },
+        {
+          "type": "CWE",
+          "value": "CWE-530",
+        },
+      ],
     },
     "category": "Potential Backup File",
     "description": null,
@@ -586,6 +925,16 @@ exports[`parses OWASP Juice Shop result file into findings 1`] = `
       "method": "HEAD",
       "niktoId": 740001,
       "port": 3000,
+      "references": [
+        {
+          "type": "URL",
+          "value": "https://cwe.mitre.org/data/definitions/530.html",
+        },
+        {
+          "type": "CWE",
+          "value": "CWE-530",
+        },
+      ],
     },
     "category": "Potential Backup File",
     "description": null,
@@ -602,6 +951,16 @@ exports[`parses OWASP Juice Shop result file into findings 1`] = `
       "method": "HEAD",
       "niktoId": 740001,
       "port": 3000,
+      "references": [
+        {
+          "type": "URL",
+          "value": "https://cwe.mitre.org/data/definitions/530.html",
+        },
+        {
+          "type": "CWE",
+          "value": "CWE-530",
+        },
+      ],
     },
     "category": "Potential Backup File",
     "description": null,
@@ -618,6 +977,16 @@ exports[`parses OWASP Juice Shop result file into findings 1`] = `
       "method": "HEAD",
       "niktoId": 740001,
       "port": 3000,
+      "references": [
+        {
+          "type": "URL",
+          "value": "https://cwe.mitre.org/data/definitions/530.html",
+        },
+        {
+          "type": "CWE",
+          "value": "CWE-530",
+        },
+      ],
     },
     "category": "Potential Backup File",
     "description": null,
@@ -634,6 +1003,16 @@ exports[`parses OWASP Juice Shop result file into findings 1`] = `
       "method": "HEAD",
       "niktoId": 740001,
       "port": 3000,
+      "references": [
+        {
+          "type": "URL",
+          "value": "https://cwe.mitre.org/data/definitions/530.html",
+        },
+        {
+          "type": "CWE",
+          "value": "CWE-530",
+        },
+      ],
     },
     "category": "Potential Backup File",
     "description": null,
@@ -650,6 +1029,16 @@ exports[`parses OWASP Juice Shop result file into findings 1`] = `
       "method": "HEAD",
       "niktoId": 740001,
       "port": 3000,
+      "references": [
+        {
+          "type": "URL",
+          "value": "https://cwe.mitre.org/data/definitions/530.html",
+        },
+        {
+          "type": "CWE",
+          "value": "CWE-530",
+        },
+      ],
     },
     "category": "Potential Backup File",
     "description": null,
@@ -666,6 +1055,16 @@ exports[`parses OWASP Juice Shop result file into findings 1`] = `
       "method": "HEAD",
       "niktoId": 740001,
       "port": 3000,
+      "references": [
+        {
+          "type": "URL",
+          "value": "https://cwe.mitre.org/data/definitions/530.html",
+        },
+        {
+          "type": "CWE",
+          "value": "CWE-530",
+        },
+      ],
     },
     "category": "Potential Backup File",
     "description": null,
@@ -682,6 +1081,16 @@ exports[`parses OWASP Juice Shop result file into findings 1`] = `
       "method": "HEAD",
       "niktoId": 740001,
       "port": 3000,
+      "references": [
+        {
+          "type": "URL",
+          "value": "https://cwe.mitre.org/data/definitions/530.html",
+        },
+        {
+          "type": "CWE",
+          "value": "CWE-530",
+        },
+      ],
     },
     "category": "Potential Backup File",
     "description": null,
@@ -698,6 +1107,16 @@ exports[`parses OWASP Juice Shop result file into findings 1`] = `
       "method": "HEAD",
       "niktoId": 740001,
       "port": 3000,
+      "references": [
+        {
+          "type": "URL",
+          "value": "https://cwe.mitre.org/data/definitions/530.html",
+        },
+        {
+          "type": "CWE",
+          "value": "CWE-530",
+        },
+      ],
     },
     "category": "Potential Backup File",
     "description": null,
@@ -714,6 +1133,16 @@ exports[`parses OWASP Juice Shop result file into findings 1`] = `
       "method": "HEAD",
       "niktoId": 740001,
       "port": 3000,
+      "references": [
+        {
+          "type": "URL",
+          "value": "https://cwe.mitre.org/data/definitions/530.html",
+        },
+        {
+          "type": "CWE",
+          "value": "CWE-530",
+        },
+      ],
     },
     "category": "Potential Backup File",
     "description": null,
@@ -730,6 +1159,16 @@ exports[`parses OWASP Juice Shop result file into findings 1`] = `
       "method": "HEAD",
       "niktoId": 740001,
       "port": 3000,
+      "references": [
+        {
+          "type": "URL",
+          "value": "https://cwe.mitre.org/data/definitions/530.html",
+        },
+        {
+          "type": "CWE",
+          "value": "CWE-530",
+        },
+      ],
     },
     "category": "Potential Backup File",
     "description": null,
@@ -746,6 +1185,16 @@ exports[`parses OWASP Juice Shop result file into findings 1`] = `
       "method": "HEAD",
       "niktoId": 740001,
       "port": 3000,
+      "references": [
+        {
+          "type": "URL",
+          "value": "https://cwe.mitre.org/data/definitions/530.html",
+        },
+        {
+          "type": "CWE",
+          "value": "CWE-530",
+        },
+      ],
     },
     "category": "Potential Backup File",
     "description": null,
@@ -762,6 +1211,16 @@ exports[`parses OWASP Juice Shop result file into findings 1`] = `
       "method": "HEAD",
       "niktoId": 740001,
       "port": 3000,
+      "references": [
+        {
+          "type": "URL",
+          "value": "https://cwe.mitre.org/data/definitions/530.html",
+        },
+        {
+          "type": "CWE",
+          "value": "CWE-530",
+        },
+      ],
     },
     "category": "Potential Backup File",
     "description": null,
@@ -778,6 +1237,16 @@ exports[`parses OWASP Juice Shop result file into findings 1`] = `
       "method": "HEAD",
       "niktoId": 740001,
       "port": 3000,
+      "references": [
+        {
+          "type": "URL",
+          "value": "https://cwe.mitre.org/data/definitions/530.html",
+        },
+        {
+          "type": "CWE",
+          "value": "CWE-530",
+        },
+      ],
     },
     "category": "Potential Backup File",
     "description": null,
@@ -794,6 +1263,16 @@ exports[`parses OWASP Juice Shop result file into findings 1`] = `
       "method": "HEAD",
       "niktoId": 740001,
       "port": 3000,
+      "references": [
+        {
+          "type": "URL",
+          "value": "https://cwe.mitre.org/data/definitions/530.html",
+        },
+        {
+          "type": "CWE",
+          "value": "CWE-530",
+        },
+      ],
     },
     "category": "Potential Backup File",
     "description": null,
@@ -810,6 +1289,16 @@ exports[`parses OWASP Juice Shop result file into findings 1`] = `
       "method": "HEAD",
       "niktoId": 740001,
       "port": 3000,
+      "references": [
+        {
+          "type": "URL",
+          "value": "https://cwe.mitre.org/data/definitions/530.html",
+        },
+        {
+          "type": "CWE",
+          "value": "CWE-530",
+        },
+      ],
     },
     "category": "Potential Backup File",
     "description": null,
@@ -826,6 +1315,16 @@ exports[`parses OWASP Juice Shop result file into findings 1`] = `
       "method": "HEAD",
       "niktoId": 740001,
       "port": 3000,
+      "references": [
+        {
+          "type": "URL",
+          "value": "https://cwe.mitre.org/data/definitions/530.html",
+        },
+        {
+          "type": "CWE",
+          "value": "CWE-530",
+        },
+      ],
     },
     "category": "Potential Backup File",
     "description": null,
@@ -842,6 +1341,16 @@ exports[`parses OWASP Juice Shop result file into findings 1`] = `
       "method": "HEAD",
       "niktoId": 740001,
       "port": 3000,
+      "references": [
+        {
+          "type": "URL",
+          "value": "https://cwe.mitre.org/data/definitions/530.html",
+        },
+        {
+          "type": "CWE",
+          "value": "CWE-530",
+        },
+      ],
     },
     "category": "Potential Backup File",
     "description": null,
@@ -858,6 +1367,16 @@ exports[`parses OWASP Juice Shop result file into findings 1`] = `
       "method": "HEAD",
       "niktoId": 740001,
       "port": 3000,
+      "references": [
+        {
+          "type": "URL",
+          "value": "https://cwe.mitre.org/data/definitions/530.html",
+        },
+        {
+          "type": "CWE",
+          "value": "CWE-530",
+        },
+      ],
     },
     "category": "Potential Backup File",
     "description": null,
@@ -874,6 +1393,16 @@ exports[`parses OWASP Juice Shop result file into findings 1`] = `
       "method": "HEAD",
       "niktoId": 740001,
       "port": 3000,
+      "references": [
+        {
+          "type": "URL",
+          "value": "https://cwe.mitre.org/data/definitions/530.html",
+        },
+        {
+          "type": "CWE",
+          "value": "CWE-530",
+        },
+      ],
     },
     "category": "Potential Backup File",
     "description": null,
@@ -890,6 +1419,16 @@ exports[`parses OWASP Juice Shop result file into findings 1`] = `
       "method": "HEAD",
       "niktoId": 740001,
       "port": 3000,
+      "references": [
+        {
+          "type": "URL",
+          "value": "https://cwe.mitre.org/data/definitions/530.html",
+        },
+        {
+          "type": "CWE",
+          "value": "CWE-530",
+        },
+      ],
     },
     "category": "Potential Backup File",
     "description": null,
@@ -906,6 +1445,16 @@ exports[`parses OWASP Juice Shop result file into findings 1`] = `
       "method": "HEAD",
       "niktoId": 740001,
       "port": 3000,
+      "references": [
+        {
+          "type": "URL",
+          "value": "https://cwe.mitre.org/data/definitions/530.html",
+        },
+        {
+          "type": "CWE",
+          "value": "CWE-530",
+        },
+      ],
     },
     "category": "Potential Backup File",
     "description": null,
@@ -922,6 +1471,16 @@ exports[`parses OWASP Juice Shop result file into findings 1`] = `
       "method": "HEAD",
       "niktoId": 740001,
       "port": 3000,
+      "references": [
+        {
+          "type": "URL",
+          "value": "https://cwe.mitre.org/data/definitions/530.html",
+        },
+        {
+          "type": "CWE",
+          "value": "CWE-530",
+        },
+      ],
     },
     "category": "Potential Backup File",
     "description": null,
@@ -938,6 +1497,16 @@ exports[`parses OWASP Juice Shop result file into findings 1`] = `
       "method": "HEAD",
       "niktoId": 740001,
       "port": 3000,
+      "references": [
+        {
+          "type": "URL",
+          "value": "https://cwe.mitre.org/data/definitions/530.html",
+        },
+        {
+          "type": "CWE",
+          "value": "CWE-530",
+        },
+      ],
     },
     "category": "Potential Backup File",
     "description": null,
@@ -954,6 +1523,16 @@ exports[`parses OWASP Juice Shop result file into findings 1`] = `
       "method": "HEAD",
       "niktoId": 740001,
       "port": 3000,
+      "references": [
+        {
+          "type": "URL",
+          "value": "https://cwe.mitre.org/data/definitions/530.html",
+        },
+        {
+          "type": "CWE",
+          "value": "CWE-530",
+        },
+      ],
     },
     "category": "Potential Backup File",
     "description": null,
@@ -970,6 +1549,16 @@ exports[`parses OWASP Juice Shop result file into findings 1`] = `
       "method": "HEAD",
       "niktoId": 740001,
       "port": 3000,
+      "references": [
+        {
+          "type": "URL",
+          "value": "https://cwe.mitre.org/data/definitions/530.html",
+        },
+        {
+          "type": "CWE",
+          "value": "CWE-530",
+        },
+      ],
     },
     "category": "Potential Backup File",
     "description": null,
@@ -986,6 +1575,16 @@ exports[`parses OWASP Juice Shop result file into findings 1`] = `
       "method": "HEAD",
       "niktoId": 740001,
       "port": 3000,
+      "references": [
+        {
+          "type": "URL",
+          "value": "https://cwe.mitre.org/data/definitions/530.html",
+        },
+        {
+          "type": "CWE",
+          "value": "CWE-530",
+        },
+      ],
     },
     "category": "Potential Backup File",
     "description": null,
@@ -1002,6 +1601,16 @@ exports[`parses OWASP Juice Shop result file into findings 1`] = `
       "method": "HEAD",
       "niktoId": 740001,
       "port": 3000,
+      "references": [
+        {
+          "type": "URL",
+          "value": "https://cwe.mitre.org/data/definitions/530.html",
+        },
+        {
+          "type": "CWE",
+          "value": "CWE-530",
+        },
+      ],
     },
     "category": "Potential Backup File",
     "description": null,
@@ -1018,6 +1627,16 @@ exports[`parses OWASP Juice Shop result file into findings 1`] = `
       "method": "HEAD",
       "niktoId": 740001,
       "port": 3000,
+      "references": [
+        {
+          "type": "URL",
+          "value": "https://cwe.mitre.org/data/definitions/530.html",
+        },
+        {
+          "type": "CWE",
+          "value": "CWE-530",
+        },
+      ],
     },
     "category": "Potential Backup File",
     "description": null,
@@ -1034,6 +1653,16 @@ exports[`parses OWASP Juice Shop result file into findings 1`] = `
       "method": "HEAD",
       "niktoId": 740001,
       "port": 3000,
+      "references": [
+        {
+          "type": "URL",
+          "value": "https://cwe.mitre.org/data/definitions/530.html",
+        },
+        {
+          "type": "CWE",
+          "value": "CWE-530",
+        },
+      ],
     },
     "category": "Potential Backup File",
     "description": null,
@@ -1050,6 +1679,16 @@ exports[`parses OWASP Juice Shop result file into findings 1`] = `
       "method": "HEAD",
       "niktoId": 740001,
       "port": 3000,
+      "references": [
+        {
+          "type": "URL",
+          "value": "https://cwe.mitre.org/data/definitions/530.html",
+        },
+        {
+          "type": "CWE",
+          "value": "CWE-530",
+        },
+      ],
     },
     "category": "Potential Backup File",
     "description": null,
@@ -1066,6 +1705,16 @@ exports[`parses OWASP Juice Shop result file into findings 1`] = `
       "method": "HEAD",
       "niktoId": 740001,
       "port": 3000,
+      "references": [
+        {
+          "type": "URL",
+          "value": "https://cwe.mitre.org/data/definitions/530.html",
+        },
+        {
+          "type": "CWE",
+          "value": "CWE-530",
+        },
+      ],
     },
     "category": "Potential Backup File",
     "description": null,
@@ -1082,6 +1731,16 @@ exports[`parses OWASP Juice Shop result file into findings 1`] = `
       "method": "HEAD",
       "niktoId": 740001,
       "port": 3000,
+      "references": [
+        {
+          "type": "URL",
+          "value": "https://cwe.mitre.org/data/definitions/530.html",
+        },
+        {
+          "type": "CWE",
+          "value": "CWE-530",
+        },
+      ],
     },
     "category": "Potential Backup File",
     "description": null,
@@ -1098,6 +1757,16 @@ exports[`parses OWASP Juice Shop result file into findings 1`] = `
       "method": "HEAD",
       "niktoId": 740001,
       "port": 3000,
+      "references": [
+        {
+          "type": "URL",
+          "value": "https://cwe.mitre.org/data/definitions/530.html",
+        },
+        {
+          "type": "CWE",
+          "value": "CWE-530",
+        },
+      ],
     },
     "category": "Potential Backup File",
     "description": null,
@@ -1114,6 +1783,16 @@ exports[`parses OWASP Juice Shop result file into findings 1`] = `
       "method": "HEAD",
       "niktoId": 740001,
       "port": 3000,
+      "references": [
+        {
+          "type": "URL",
+          "value": "https://cwe.mitre.org/data/definitions/530.html",
+        },
+        {
+          "type": "CWE",
+          "value": "CWE-530",
+        },
+      ],
     },
     "category": "Potential Backup File",
     "description": null,
@@ -1130,6 +1809,16 @@ exports[`parses OWASP Juice Shop result file into findings 1`] = `
       "method": "HEAD",
       "niktoId": 740001,
       "port": 3000,
+      "references": [
+        {
+          "type": "URL",
+          "value": "https://cwe.mitre.org/data/definitions/530.html",
+        },
+        {
+          "type": "CWE",
+          "value": "CWE-530",
+        },
+      ],
     },
     "category": "Potential Backup File",
     "description": null,
@@ -1146,6 +1835,16 @@ exports[`parses OWASP Juice Shop result file into findings 1`] = `
       "method": "HEAD",
       "niktoId": 740001,
       "port": 3000,
+      "references": [
+        {
+          "type": "URL",
+          "value": "https://cwe.mitre.org/data/definitions/530.html",
+        },
+        {
+          "type": "CWE",
+          "value": "CWE-530",
+        },
+      ],
     },
     "category": "Potential Backup File",
     "description": null,
@@ -1162,6 +1861,16 @@ exports[`parses OWASP Juice Shop result file into findings 1`] = `
       "method": "HEAD",
       "niktoId": 740001,
       "port": 3000,
+      "references": [
+        {
+          "type": "URL",
+          "value": "https://cwe.mitre.org/data/definitions/530.html",
+        },
+        {
+          "type": "CWE",
+          "value": "CWE-530",
+        },
+      ],
     },
     "category": "Potential Backup File",
     "description": null,
@@ -1178,6 +1887,16 @@ exports[`parses OWASP Juice Shop result file into findings 1`] = `
       "method": "HEAD",
       "niktoId": 740001,
       "port": 3000,
+      "references": [
+        {
+          "type": "URL",
+          "value": "https://cwe.mitre.org/data/definitions/530.html",
+        },
+        {
+          "type": "CWE",
+          "value": "CWE-530",
+        },
+      ],
     },
     "category": "Potential Backup File",
     "description": null,
@@ -1194,6 +1913,16 @@ exports[`parses OWASP Juice Shop result file into findings 1`] = `
       "method": "HEAD",
       "niktoId": 740001,
       "port": 3000,
+      "references": [
+        {
+          "type": "URL",
+          "value": "https://cwe.mitre.org/data/definitions/530.html",
+        },
+        {
+          "type": "CWE",
+          "value": "CWE-530",
+        },
+      ],
     },
     "category": "Potential Backup File",
     "description": null,
@@ -1210,6 +1939,16 @@ exports[`parses OWASP Juice Shop result file into findings 1`] = `
       "method": "HEAD",
       "niktoId": 740001,
       "port": 3000,
+      "references": [
+        {
+          "type": "URL",
+          "value": "https://cwe.mitre.org/data/definitions/530.html",
+        },
+        {
+          "type": "CWE",
+          "value": "CWE-530",
+        },
+      ],
     },
     "category": "Potential Backup File",
     "description": null,
@@ -1226,6 +1965,16 @@ exports[`parses OWASP Juice Shop result file into findings 1`] = `
       "method": "HEAD",
       "niktoId": 740001,
       "port": 3000,
+      "references": [
+        {
+          "type": "URL",
+          "value": "https://cwe.mitre.org/data/definitions/530.html",
+        },
+        {
+          "type": "CWE",
+          "value": "CWE-530",
+        },
+      ],
     },
     "category": "Potential Backup File",
     "description": null,
@@ -1242,6 +1991,16 @@ exports[`parses OWASP Juice Shop result file into findings 1`] = `
       "method": "HEAD",
       "niktoId": 740001,
       "port": 3000,
+      "references": [
+        {
+          "type": "URL",
+          "value": "https://cwe.mitre.org/data/definitions/530.html",
+        },
+        {
+          "type": "CWE",
+          "value": "CWE-530",
+        },
+      ],
     },
     "category": "Potential Backup File",
     "description": null,
@@ -1258,6 +2017,16 @@ exports[`parses OWASP Juice Shop result file into findings 1`] = `
       "method": "HEAD",
       "niktoId": 740001,
       "port": 3000,
+      "references": [
+        {
+          "type": "URL",
+          "value": "https://cwe.mitre.org/data/definitions/530.html",
+        },
+        {
+          "type": "CWE",
+          "value": "CWE-530",
+        },
+      ],
     },
     "category": "Potential Backup File",
     "description": null,
@@ -1274,6 +2043,16 @@ exports[`parses OWASP Juice Shop result file into findings 1`] = `
       "method": "HEAD",
       "niktoId": 740001,
       "port": 3000,
+      "references": [
+        {
+          "type": "URL",
+          "value": "https://cwe.mitre.org/data/definitions/530.html",
+        },
+        {
+          "type": "CWE",
+          "value": "CWE-530",
+        },
+      ],
     },
     "category": "Potential Backup File",
     "description": null,
@@ -1290,6 +2069,16 @@ exports[`parses OWASP Juice Shop result file into findings 1`] = `
       "method": "HEAD",
       "niktoId": 740001,
       "port": 3000,
+      "references": [
+        {
+          "type": "URL",
+          "value": "https://cwe.mitre.org/data/definitions/530.html",
+        },
+        {
+          "type": "CWE",
+          "value": "CWE-530",
+        },
+      ],
     },
     "category": "Potential Backup File",
     "description": null,
@@ -1306,6 +2095,16 @@ exports[`parses OWASP Juice Shop result file into findings 1`] = `
       "method": "HEAD",
       "niktoId": 740001,
       "port": 3000,
+      "references": [
+        {
+          "type": "URL",
+          "value": "https://cwe.mitre.org/data/definitions/530.html",
+        },
+        {
+          "type": "CWE",
+          "value": "CWE-530",
+        },
+      ],
     },
     "category": "Potential Backup File",
     "description": null,
@@ -1322,6 +2121,16 @@ exports[`parses OWASP Juice Shop result file into findings 1`] = `
       "method": "HEAD",
       "niktoId": 740001,
       "port": 3000,
+      "references": [
+        {
+          "type": "URL",
+          "value": "https://cwe.mitre.org/data/definitions/530.html",
+        },
+        {
+          "type": "CWE",
+          "value": "CWE-530",
+        },
+      ],
     },
     "category": "Potential Backup File",
     "description": null,
@@ -1338,6 +2147,16 @@ exports[`parses OWASP Juice Shop result file into findings 1`] = `
       "method": "HEAD",
       "niktoId": 740001,
       "port": 3000,
+      "references": [
+        {
+          "type": "URL",
+          "value": "https://cwe.mitre.org/data/definitions/530.html",
+        },
+        {
+          "type": "CWE",
+          "value": "CWE-530",
+        },
+      ],
     },
     "category": "Potential Backup File",
     "description": null,
@@ -1354,6 +2173,16 @@ exports[`parses OWASP Juice Shop result file into findings 1`] = `
       "method": "HEAD",
       "niktoId": 740001,
       "port": 3000,
+      "references": [
+        {
+          "type": "URL",
+          "value": "https://cwe.mitre.org/data/definitions/530.html",
+        },
+        {
+          "type": "CWE",
+          "value": "CWE-530",
+        },
+      ],
     },
     "category": "Potential Backup File",
     "description": null,
@@ -1370,6 +2199,16 @@ exports[`parses OWASP Juice Shop result file into findings 1`] = `
       "method": "HEAD",
       "niktoId": 740001,
       "port": 3000,
+      "references": [
+        {
+          "type": "URL",
+          "value": "https://cwe.mitre.org/data/definitions/530.html",
+        },
+        {
+          "type": "CWE",
+          "value": "CWE-530",
+        },
+      ],
     },
     "category": "Potential Backup File",
     "description": null,
@@ -1386,6 +2225,16 @@ exports[`parses OWASP Juice Shop result file into findings 1`] = `
       "method": "HEAD",
       "niktoId": 740001,
       "port": 3000,
+      "references": [
+        {
+          "type": "URL",
+          "value": "https://cwe.mitre.org/data/definitions/530.html",
+        },
+        {
+          "type": "CWE",
+          "value": "CWE-530",
+        },
+      ],
     },
     "category": "Potential Backup File",
     "description": null,
@@ -1402,6 +2251,16 @@ exports[`parses OWASP Juice Shop result file into findings 1`] = `
       "method": "HEAD",
       "niktoId": 740001,
       "port": 3000,
+      "references": [
+        {
+          "type": "URL",
+          "value": "https://cwe.mitre.org/data/definitions/530.html",
+        },
+        {
+          "type": "CWE",
+          "value": "CWE-530",
+        },
+      ],
     },
     "category": "Potential Backup File",
     "description": null,
@@ -1418,6 +2277,16 @@ exports[`parses OWASP Juice Shop result file into findings 1`] = `
       "method": "HEAD",
       "niktoId": 740001,
       "port": 3000,
+      "references": [
+        {
+          "type": "URL",
+          "value": "https://cwe.mitre.org/data/definitions/530.html",
+        },
+        {
+          "type": "CWE",
+          "value": "CWE-530",
+        },
+      ],
     },
     "category": "Potential Backup File",
     "description": null,
@@ -1434,6 +2303,16 @@ exports[`parses OWASP Juice Shop result file into findings 1`] = `
       "method": "HEAD",
       "niktoId": 740001,
       "port": 3000,
+      "references": [
+        {
+          "type": "URL",
+          "value": "https://cwe.mitre.org/data/definitions/530.html",
+        },
+        {
+          "type": "CWE",
+          "value": "CWE-530",
+        },
+      ],
     },
     "category": "Potential Backup File",
     "description": null,
@@ -1450,6 +2329,16 @@ exports[`parses OWASP Juice Shop result file into findings 1`] = `
       "method": "HEAD",
       "niktoId": 740001,
       "port": 3000,
+      "references": [
+        {
+          "type": "URL",
+          "value": "https://cwe.mitre.org/data/definitions/530.html",
+        },
+        {
+          "type": "CWE",
+          "value": "CWE-530",
+        },
+      ],
     },
     "category": "Potential Backup File",
     "description": null,
@@ -1466,6 +2355,16 @@ exports[`parses OWASP Juice Shop result file into findings 1`] = `
       "method": "HEAD",
       "niktoId": 740001,
       "port": 3000,
+      "references": [
+        {
+          "type": "URL",
+          "value": "https://cwe.mitre.org/data/definitions/530.html",
+        },
+        {
+          "type": "CWE",
+          "value": "CWE-530",
+        },
+      ],
     },
     "category": "Potential Backup File",
     "description": null,
@@ -1482,6 +2381,16 @@ exports[`parses OWASP Juice Shop result file into findings 1`] = `
       "method": "HEAD",
       "niktoId": 740001,
       "port": 3000,
+      "references": [
+        {
+          "type": "URL",
+          "value": "https://cwe.mitre.org/data/definitions/530.html",
+        },
+        {
+          "type": "CWE",
+          "value": "CWE-530",
+        },
+      ],
     },
     "category": "Potential Backup File",
     "description": null,
@@ -1498,6 +2407,16 @@ exports[`parses OWASP Juice Shop result file into findings 1`] = `
       "method": "HEAD",
       "niktoId": 740001,
       "port": 3000,
+      "references": [
+        {
+          "type": "URL",
+          "value": "https://cwe.mitre.org/data/definitions/530.html",
+        },
+        {
+          "type": "CWE",
+          "value": "CWE-530",
+        },
+      ],
     },
     "category": "Potential Backup File",
     "description": null,
@@ -1514,6 +2433,16 @@ exports[`parses OWASP Juice Shop result file into findings 1`] = `
       "method": "HEAD",
       "niktoId": 740001,
       "port": 3000,
+      "references": [
+        {
+          "type": "URL",
+          "value": "https://cwe.mitre.org/data/definitions/530.html",
+        },
+        {
+          "type": "CWE",
+          "value": "CWE-530",
+        },
+      ],
     },
     "category": "Potential Backup File",
     "description": null,
@@ -1530,6 +2459,16 @@ exports[`parses OWASP Juice Shop result file into findings 1`] = `
       "method": "HEAD",
       "niktoId": 740001,
       "port": 3000,
+      "references": [
+        {
+          "type": "URL",
+          "value": "https://cwe.mitre.org/data/definitions/530.html",
+        },
+        {
+          "type": "CWE",
+          "value": "CWE-530",
+        },
+      ],
     },
     "category": "Potential Backup File",
     "description": null,
@@ -1546,6 +2485,16 @@ exports[`parses OWASP Juice Shop result file into findings 1`] = `
       "method": "HEAD",
       "niktoId": 740001,
       "port": 3000,
+      "references": [
+        {
+          "type": "URL",
+          "value": "https://cwe.mitre.org/data/definitions/530.html",
+        },
+        {
+          "type": "CWE",
+          "value": "CWE-530",
+        },
+      ],
     },
     "category": "Potential Backup File",
     "description": null,
@@ -1562,6 +2511,16 @@ exports[`parses OWASP Juice Shop result file into findings 1`] = `
       "method": "HEAD",
       "niktoId": 740001,
       "port": 3000,
+      "references": [
+        {
+          "type": "URL",
+          "value": "https://cwe.mitre.org/data/definitions/530.html",
+        },
+        {
+          "type": "CWE",
+          "value": "CWE-530",
+        },
+      ],
     },
     "category": "Potential Backup File",
     "description": null,
@@ -1578,6 +2537,16 @@ exports[`parses OWASP Juice Shop result file into findings 1`] = `
       "method": "HEAD",
       "niktoId": 740001,
       "port": 3000,
+      "references": [
+        {
+          "type": "URL",
+          "value": "https://cwe.mitre.org/data/definitions/530.html",
+        },
+        {
+          "type": "CWE",
+          "value": "CWE-530",
+        },
+      ],
     },
     "category": "Potential Backup File",
     "description": null,
@@ -1594,6 +2563,16 @@ exports[`parses OWASP Juice Shop result file into findings 1`] = `
       "method": "HEAD",
       "niktoId": 740001,
       "port": 3000,
+      "references": [
+        {
+          "type": "URL",
+          "value": "https://cwe.mitre.org/data/definitions/530.html",
+        },
+        {
+          "type": "CWE",
+          "value": "CWE-530",
+        },
+      ],
     },
     "category": "Potential Backup File",
     "description": null,
@@ -1610,6 +2589,16 @@ exports[`parses OWASP Juice Shop result file into findings 1`] = `
       "method": "HEAD",
       "niktoId": 740001,
       "port": 3000,
+      "references": [
+        {
+          "type": "URL",
+          "value": "https://cwe.mitre.org/data/definitions/530.html",
+        },
+        {
+          "type": "CWE",
+          "value": "CWE-530",
+        },
+      ],
     },
     "category": "Potential Backup File",
     "description": null,
@@ -1626,6 +2615,16 @@ exports[`parses OWASP Juice Shop result file into findings 1`] = `
       "method": "HEAD",
       "niktoId": 740001,
       "port": 3000,
+      "references": [
+        {
+          "type": "URL",
+          "value": "https://cwe.mitre.org/data/definitions/530.html",
+        },
+        {
+          "type": "CWE",
+          "value": "CWE-530",
+        },
+      ],
     },
     "category": "Potential Backup File",
     "description": null,
@@ -1642,6 +2641,16 @@ exports[`parses OWASP Juice Shop result file into findings 1`] = `
       "method": "HEAD",
       "niktoId": 740001,
       "port": 3000,
+      "references": [
+        {
+          "type": "URL",
+          "value": "https://cwe.mitre.org/data/definitions/530.html",
+        },
+        {
+          "type": "CWE",
+          "value": "CWE-530",
+        },
+      ],
     },
     "category": "Potential Backup File",
     "description": null,
@@ -1658,6 +2667,16 @@ exports[`parses OWASP Juice Shop result file into findings 1`] = `
       "method": "HEAD",
       "niktoId": 740001,
       "port": 3000,
+      "references": [
+        {
+          "type": "URL",
+          "value": "https://cwe.mitre.org/data/definitions/530.html",
+        },
+        {
+          "type": "CWE",
+          "value": "CWE-530",
+        },
+      ],
     },
     "category": "Potential Backup File",
     "description": null,
@@ -1674,6 +2693,16 @@ exports[`parses OWASP Juice Shop result file into findings 1`] = `
       "method": "HEAD",
       "niktoId": 740001,
       "port": 3000,
+      "references": [
+        {
+          "type": "URL",
+          "value": "https://cwe.mitre.org/data/definitions/530.html",
+        },
+        {
+          "type": "CWE",
+          "value": "CWE-530",
+        },
+      ],
     },
     "category": "Potential Backup File",
     "description": null,
@@ -1690,6 +2719,16 @@ exports[`parses OWASP Juice Shop result file into findings 1`] = `
       "method": "HEAD",
       "niktoId": 740001,
       "port": 3000,
+      "references": [
+        {
+          "type": "URL",
+          "value": "https://cwe.mitre.org/data/definitions/530.html",
+        },
+        {
+          "type": "CWE",
+          "value": "CWE-530",
+        },
+      ],
     },
     "category": "Potential Backup File",
     "description": null,
@@ -1706,6 +2745,16 @@ exports[`parses OWASP Juice Shop result file into findings 1`] = `
       "method": "HEAD",
       "niktoId": 740001,
       "port": 3000,
+      "references": [
+        {
+          "type": "URL",
+          "value": "https://cwe.mitre.org/data/definitions/530.html",
+        },
+        {
+          "type": "CWE",
+          "value": "CWE-530",
+        },
+      ],
     },
     "category": "Potential Backup File",
     "description": null,
@@ -1722,6 +2771,16 @@ exports[`parses OWASP Juice Shop result file into findings 1`] = `
       "method": "HEAD",
       "niktoId": 740001,
       "port": 3000,
+      "references": [
+        {
+          "type": "URL",
+          "value": "https://cwe.mitre.org/data/definitions/530.html",
+        },
+        {
+          "type": "CWE",
+          "value": "CWE-530",
+        },
+      ],
     },
     "category": "Potential Backup File",
     "description": null,
@@ -1738,6 +2797,16 @@ exports[`parses OWASP Juice Shop result file into findings 1`] = `
       "method": "HEAD",
       "niktoId": 740001,
       "port": 3000,
+      "references": [
+        {
+          "type": "URL",
+          "value": "https://cwe.mitre.org/data/definitions/530.html",
+        },
+        {
+          "type": "CWE",
+          "value": "CWE-530",
+        },
+      ],
     },
     "category": "Potential Backup File",
     "description": null,
@@ -1754,6 +2823,16 @@ exports[`parses OWASP Juice Shop result file into findings 1`] = `
       "method": "HEAD",
       "niktoId": 740001,
       "port": 3000,
+      "references": [
+        {
+          "type": "URL",
+          "value": "https://cwe.mitre.org/data/definitions/530.html",
+        },
+        {
+          "type": "CWE",
+          "value": "CWE-530",
+        },
+      ],
     },
     "category": "Potential Backup File",
     "description": null,
@@ -1770,6 +2849,16 @@ exports[`parses OWASP Juice Shop result file into findings 1`] = `
       "method": "HEAD",
       "niktoId": 740001,
       "port": 3000,
+      "references": [
+        {
+          "type": "URL",
+          "value": "https://cwe.mitre.org/data/definitions/530.html",
+        },
+        {
+          "type": "CWE",
+          "value": "CWE-530",
+        },
+      ],
     },
     "category": "Potential Backup File",
     "description": null,
@@ -1786,6 +2875,16 @@ exports[`parses OWASP Juice Shop result file into findings 1`] = `
       "method": "HEAD",
       "niktoId": 740001,
       "port": 3000,
+      "references": [
+        {
+          "type": "URL",
+          "value": "https://cwe.mitre.org/data/definitions/530.html",
+        },
+        {
+          "type": "CWE",
+          "value": "CWE-530",
+        },
+      ],
     },
     "category": "Potential Backup File",
     "description": null,
@@ -1802,6 +2901,16 @@ exports[`parses OWASP Juice Shop result file into findings 1`] = `
       "method": "HEAD",
       "niktoId": 740001,
       "port": 3000,
+      "references": [
+        {
+          "type": "URL",
+          "value": "https://cwe.mitre.org/data/definitions/530.html",
+        },
+        {
+          "type": "CWE",
+          "value": "CWE-530",
+        },
+      ],
     },
     "category": "Potential Backup File",
     "description": null,
@@ -1818,6 +2927,16 @@ exports[`parses OWASP Juice Shop result file into findings 1`] = `
       "method": "HEAD",
       "niktoId": 740001,
       "port": 3000,
+      "references": [
+        {
+          "type": "URL",
+          "value": "https://cwe.mitre.org/data/definitions/530.html",
+        },
+        {
+          "type": "CWE",
+          "value": "CWE-530",
+        },
+      ],
     },
     "category": "Potential Backup File",
     "description": null,
@@ -1834,6 +2953,16 @@ exports[`parses OWASP Juice Shop result file into findings 1`] = `
       "method": "HEAD",
       "niktoId": 740001,
       "port": 3000,
+      "references": [
+        {
+          "type": "URL",
+          "value": "https://cwe.mitre.org/data/definitions/530.html",
+        },
+        {
+          "type": "CWE",
+          "value": "CWE-530",
+        },
+      ],
     },
     "category": "Potential Backup File",
     "description": null,
@@ -1850,6 +2979,16 @@ exports[`parses OWASP Juice Shop result file into findings 1`] = `
       "method": "HEAD",
       "niktoId": 740001,
       "port": 3000,
+      "references": [
+        {
+          "type": "URL",
+          "value": "https://cwe.mitre.org/data/definitions/530.html",
+        },
+        {
+          "type": "CWE",
+          "value": "CWE-530",
+        },
+      ],
     },
     "category": "Potential Backup File",
     "description": null,
@@ -1866,6 +3005,16 @@ exports[`parses OWASP Juice Shop result file into findings 1`] = `
       "method": "HEAD",
       "niktoId": 740001,
       "port": 3000,
+      "references": [
+        {
+          "type": "URL",
+          "value": "https://cwe.mitre.org/data/definitions/530.html",
+        },
+        {
+          "type": "CWE",
+          "value": "CWE-530",
+        },
+      ],
     },
     "category": "Potential Backup File",
     "description": null,
@@ -1882,6 +3031,16 @@ exports[`parses OWASP Juice Shop result file into findings 1`] = `
       "method": "HEAD",
       "niktoId": 740001,
       "port": 3000,
+      "references": [
+        {
+          "type": "URL",
+          "value": "https://cwe.mitre.org/data/definitions/530.html",
+        },
+        {
+          "type": "CWE",
+          "value": "CWE-530",
+        },
+      ],
     },
     "category": "Potential Backup File",
     "description": null,
@@ -1898,6 +3057,16 @@ exports[`parses OWASP Juice Shop result file into findings 1`] = `
       "method": "HEAD",
       "niktoId": 740001,
       "port": 3000,
+      "references": [
+        {
+          "type": "URL",
+          "value": "https://cwe.mitre.org/data/definitions/530.html",
+        },
+        {
+          "type": "CWE",
+          "value": "CWE-530",
+        },
+      ],
     },
     "category": "Potential Backup File",
     "description": null,
@@ -1914,6 +3083,16 @@ exports[`parses OWASP Juice Shop result file into findings 1`] = `
       "method": "HEAD",
       "niktoId": 740001,
       "port": 3000,
+      "references": [
+        {
+          "type": "URL",
+          "value": "https://cwe.mitre.org/data/definitions/530.html",
+        },
+        {
+          "type": "CWE",
+          "value": "CWE-530",
+        },
+      ],
     },
     "category": "Potential Backup File",
     "description": null,
@@ -1930,6 +3109,16 @@ exports[`parses OWASP Juice Shop result file into findings 1`] = `
       "method": "HEAD",
       "niktoId": 740001,
       "port": 3000,
+      "references": [
+        {
+          "type": "URL",
+          "value": "https://cwe.mitre.org/data/definitions/530.html",
+        },
+        {
+          "type": "CWE",
+          "value": "CWE-530",
+        },
+      ],
     },
     "category": "Potential Backup File",
     "description": null,
@@ -1946,6 +3135,16 @@ exports[`parses OWASP Juice Shop result file into findings 1`] = `
       "method": "HEAD",
       "niktoId": 740001,
       "port": 3000,
+      "references": [
+        {
+          "type": "URL",
+          "value": "https://cwe.mitre.org/data/definitions/530.html",
+        },
+        {
+          "type": "CWE",
+          "value": "CWE-530",
+        },
+      ],
     },
     "category": "Potential Backup File",
     "description": null,
@@ -1962,6 +3161,16 @@ exports[`parses OWASP Juice Shop result file into findings 1`] = `
       "method": "HEAD",
       "niktoId": 740001,
       "port": 3000,
+      "references": [
+        {
+          "type": "URL",
+          "value": "https://cwe.mitre.org/data/definitions/530.html",
+        },
+        {
+          "type": "CWE",
+          "value": "CWE-530",
+        },
+      ],
     },
     "category": "Potential Backup File",
     "description": null,
@@ -1978,6 +3187,16 @@ exports[`parses OWASP Juice Shop result file into findings 1`] = `
       "method": "HEAD",
       "niktoId": 740001,
       "port": 3000,
+      "references": [
+        {
+          "type": "URL",
+          "value": "https://cwe.mitre.org/data/definitions/530.html",
+        },
+        {
+          "type": "CWE",
+          "value": "CWE-530",
+        },
+      ],
     },
     "category": "Potential Backup File",
     "description": null,
@@ -1994,6 +3213,16 @@ exports[`parses OWASP Juice Shop result file into findings 1`] = `
       "method": "HEAD",
       "niktoId": 740001,
       "port": 3000,
+      "references": [
+        {
+          "type": "URL",
+          "value": "https://cwe.mitre.org/data/definitions/530.html",
+        },
+        {
+          "type": "CWE",
+          "value": "CWE-530",
+        },
+      ],
     },
     "category": "Potential Backup File",
     "description": null,
@@ -2010,6 +3239,16 @@ exports[`parses OWASP Juice Shop result file into findings 1`] = `
       "method": "HEAD",
       "niktoId": 740001,
       "port": 3000,
+      "references": [
+        {
+          "type": "URL",
+          "value": "https://cwe.mitre.org/data/definitions/530.html",
+        },
+        {
+          "type": "CWE",
+          "value": "CWE-530",
+        },
+      ],
     },
     "category": "Potential Backup File",
     "description": null,
@@ -2026,6 +3265,16 @@ exports[`parses OWASP Juice Shop result file into findings 1`] = `
       "method": "HEAD",
       "niktoId": 740001,
       "port": 3000,
+      "references": [
+        {
+          "type": "URL",
+          "value": "https://cwe.mitre.org/data/definitions/530.html",
+        },
+        {
+          "type": "CWE",
+          "value": "CWE-530",
+        },
+      ],
     },
     "category": "Potential Backup File",
     "description": null,
@@ -2042,6 +3291,16 @@ exports[`parses OWASP Juice Shop result file into findings 1`] = `
       "method": "HEAD",
       "niktoId": 740001,
       "port": 3000,
+      "references": [
+        {
+          "type": "URL",
+          "value": "https://cwe.mitre.org/data/definitions/530.html",
+        },
+        {
+          "type": "CWE",
+          "value": "CWE-530",
+        },
+      ],
     },
     "category": "Potential Backup File",
     "description": null,
@@ -2058,6 +3317,16 @@ exports[`parses OWASP Juice Shop result file into findings 1`] = `
       "method": "HEAD",
       "niktoId": 740001,
       "port": 3000,
+      "references": [
+        {
+          "type": "URL",
+          "value": "https://cwe.mitre.org/data/definitions/530.html",
+        },
+        {
+          "type": "CWE",
+          "value": "CWE-530",
+        },
+      ],
     },
     "category": "Potential Backup File",
     "description": null,
@@ -2074,6 +3343,16 @@ exports[`parses OWASP Juice Shop result file into findings 1`] = `
       "method": "HEAD",
       "niktoId": 740001,
       "port": 3000,
+      "references": [
+        {
+          "type": "URL",
+          "value": "https://cwe.mitre.org/data/definitions/530.html",
+        },
+        {
+          "type": "CWE",
+          "value": "CWE-530",
+        },
+      ],
     },
     "category": "Potential Backup File",
     "description": null,
@@ -2090,6 +3369,16 @@ exports[`parses OWASP Juice Shop result file into findings 1`] = `
       "method": "HEAD",
       "niktoId": 740001,
       "port": 3000,
+      "references": [
+        {
+          "type": "URL",
+          "value": "https://cwe.mitre.org/data/definitions/530.html",
+        },
+        {
+          "type": "CWE",
+          "value": "CWE-530",
+        },
+      ],
     },
     "category": "Potential Backup File",
     "description": null,
@@ -2106,6 +3395,16 @@ exports[`parses OWASP Juice Shop result file into findings 1`] = `
       "method": "HEAD",
       "niktoId": 740001,
       "port": 3000,
+      "references": [
+        {
+          "type": "URL",
+          "value": "https://cwe.mitre.org/data/definitions/530.html",
+        },
+        {
+          "type": "CWE",
+          "value": "CWE-530",
+        },
+      ],
     },
     "category": "Potential Backup File",
     "description": null,
@@ -2122,6 +3421,16 @@ exports[`parses OWASP Juice Shop result file into findings 1`] = `
       "method": "HEAD",
       "niktoId": 740001,
       "port": 3000,
+      "references": [
+        {
+          "type": "URL",
+          "value": "https://cwe.mitre.org/data/definitions/530.html",
+        },
+        {
+          "type": "CWE",
+          "value": "CWE-530",
+        },
+      ],
     },
     "category": "Potential Backup File",
     "description": null,
@@ -2138,6 +3447,16 @@ exports[`parses OWASP Juice Shop result file into findings 1`] = `
       "method": "HEAD",
       "niktoId": 740001,
       "port": 3000,
+      "references": [
+        {
+          "type": "URL",
+          "value": "https://cwe.mitre.org/data/definitions/530.html",
+        },
+        {
+          "type": "CWE",
+          "value": "CWE-530",
+        },
+      ],
     },
     "category": "Potential Backup File",
     "description": null,
@@ -2154,6 +3473,16 @@ exports[`parses OWASP Juice Shop result file into findings 1`] = `
       "method": "HEAD",
       "niktoId": 740001,
       "port": 3000,
+      "references": [
+        {
+          "type": "URL",
+          "value": "https://cwe.mitre.org/data/definitions/530.html",
+        },
+        {
+          "type": "CWE",
+          "value": "CWE-530",
+        },
+      ],
     },
     "category": "Potential Backup File",
     "description": null,
@@ -2170,6 +3499,16 @@ exports[`parses OWASP Juice Shop result file into findings 1`] = `
       "method": "HEAD",
       "niktoId": 740001,
       "port": 3000,
+      "references": [
+        {
+          "type": "URL",
+          "value": "https://cwe.mitre.org/data/definitions/530.html",
+        },
+        {
+          "type": "CWE",
+          "value": "CWE-530",
+        },
+      ],
     },
     "category": "Potential Backup File",
     "description": null,
@@ -2186,6 +3525,16 @@ exports[`parses OWASP Juice Shop result file into findings 1`] = `
       "method": "HEAD",
       "niktoId": 740001,
       "port": 3000,
+      "references": [
+        {
+          "type": "URL",
+          "value": "https://cwe.mitre.org/data/definitions/530.html",
+        },
+        {
+          "type": "CWE",
+          "value": "CWE-530",
+        },
+      ],
     },
     "category": "Potential Backup File",
     "description": null,
@@ -2202,6 +3551,16 @@ exports[`parses OWASP Juice Shop result file into findings 1`] = `
       "method": "HEAD",
       "niktoId": 740001,
       "port": 3000,
+      "references": [
+        {
+          "type": "URL",
+          "value": "https://cwe.mitre.org/data/definitions/530.html",
+        },
+        {
+          "type": "CWE",
+          "value": "CWE-530",
+        },
+      ],
     },
     "category": "Potential Backup File",
     "description": null,
@@ -2218,6 +3577,16 @@ exports[`parses OWASP Juice Shop result file into findings 1`] = `
       "method": "HEAD",
       "niktoId": 740001,
       "port": 3000,
+      "references": [
+        {
+          "type": "URL",
+          "value": "https://cwe.mitre.org/data/definitions/530.html",
+        },
+        {
+          "type": "CWE",
+          "value": "CWE-530",
+        },
+      ],
     },
     "category": "Potential Backup File",
     "description": null,
@@ -2234,6 +3603,16 @@ exports[`parses OWASP Juice Shop result file into findings 1`] = `
       "method": "HEAD",
       "niktoId": 740001,
       "port": 3000,
+      "references": [
+        {
+          "type": "URL",
+          "value": "https://cwe.mitre.org/data/definitions/530.html",
+        },
+        {
+          "type": "CWE",
+          "value": "CWE-530",
+        },
+      ],
     },
     "category": "Potential Backup File",
     "description": null,
@@ -2250,6 +3629,16 @@ exports[`parses OWASP Juice Shop result file into findings 1`] = `
       "method": "HEAD",
       "niktoId": 740001,
       "port": 3000,
+      "references": [
+        {
+          "type": "URL",
+          "value": "https://cwe.mitre.org/data/definitions/530.html",
+        },
+        {
+          "type": "CWE",
+          "value": "CWE-530",
+        },
+      ],
     },
     "category": "Potential Backup File",
     "description": null,
@@ -2266,6 +3655,16 @@ exports[`parses OWASP Juice Shop result file into findings 1`] = `
       "method": "HEAD",
       "niktoId": 740001,
       "port": 3000,
+      "references": [
+        {
+          "type": "URL",
+          "value": "https://cwe.mitre.org/data/definitions/530.html",
+        },
+        {
+          "type": "CWE",
+          "value": "CWE-530",
+        },
+      ],
     },
     "category": "Potential Backup File",
     "description": null,
@@ -2282,6 +3681,16 @@ exports[`parses OWASP Juice Shop result file into findings 1`] = `
       "method": "HEAD",
       "niktoId": 740001,
       "port": 3000,
+      "references": [
+        {
+          "type": "URL",
+          "value": "https://cwe.mitre.org/data/definitions/530.html",
+        },
+        {
+          "type": "CWE",
+          "value": "CWE-530",
+        },
+      ],
     },
     "category": "Potential Backup File",
     "description": null,
@@ -2298,6 +3707,16 @@ exports[`parses OWASP Juice Shop result file into findings 1`] = `
       "method": "HEAD",
       "niktoId": 740001,
       "port": 3000,
+      "references": [
+        {
+          "type": "URL",
+          "value": "https://cwe.mitre.org/data/definitions/530.html",
+        },
+        {
+          "type": "CWE",
+          "value": "CWE-530",
+        },
+      ],
     },
     "category": "Potential Backup File",
     "description": null,
@@ -2314,6 +3733,7 @@ exports[`parses OWASP Juice Shop result file into findings 1`] = `
       "method": "GET",
       "niktoId": 1675,
       "port": 3000,
+      "references": null,
     },
     "category": "Potential Vulnerability",
     "description": null,
@@ -2330,6 +3750,7 @@ exports[`parses OWASP Juice Shop result file into findings 1`] = `
       "method": "GET",
       "niktoId": 1811,
       "port": 3000,
+      "references": null,
     },
     "category": "Potential Vulnerability",
     "description": null,
@@ -2346,6 +3767,12 @@ exports[`parses OWASP Juice Shop result file into findings 1`] = `
       "method": "POST",
       "niktoId": 6737,
       "port": 3000,
+      "references": [
+        {
+          "type": "URL",
+          "value": "https://seclists.org/fulldisclosure/2014/Feb/171",
+        },
+      ],
     },
     "category": "Potential Vulnerability",
     "description": null,
@@ -2362,6 +3789,12 @@ exports[`parses OWASP Juice Shop result file into findings 1`] = `
       "method": "POST",
       "niktoId": 6737,
       "port": 3000,
+      "references": [
+        {
+          "type": "URL",
+          "value": "https://seclists.org/fulldisclosure/2014/Feb/171",
+        },
+      ],
     },
     "category": "Potential Vulnerability",
     "description": null,
@@ -2383,6 +3816,12 @@ exports[`parses www.securecodebox.io result file into findings 1`] = `
       "method": "GET",
       "niktoId": 999957,
       "port": 80,
+      "references": [
+        {
+          "type": "URL",
+          "value": "https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/X-Frame-Options",
+        },
+      ],
     },
     "category": "X-Frame-Options Header",
     "description": null,
@@ -2399,6 +3838,12 @@ exports[`parses www.securecodebox.io result file into findings 1`] = `
       "method": "GET",
       "niktoId": 287,
       "port": 80,
+      "references": [
+        {
+          "type": "URL",
+          "value": "https://www.netlify.com/",
+        },
+      ],
     },
     "category": "Potential Vulnerability",
     "description": null,
@@ -2415,6 +3860,12 @@ exports[`parses www.securecodebox.io result file into findings 1`] = `
       "method": "GET",
       "niktoId": 999103,
       "port": 80,
+      "references": [
+        {
+          "type": "URL",
+          "value": "https://www.netsparker.com/web-vulnerability-scanner/vulnerabilities/missing-content-type-header/",
+        },
+      ],
     },
     "category": "X-Content-Type-Options Header",
     "description": null,

--- a/scanners/nikto/parser/parser.js
+++ b/scanners/nikto/parser/parser.js
@@ -91,7 +91,7 @@ async function parse({ host, ip, port: portString, banner, vulnerabilities }) {
         method,
         port,
         niktoId,
-        references: refs.length > 0 ? refs : null,
+        references: refs
       },
     };
   });

--- a/scanners/nuclei/parser/__snapshots__/parser.test.js.snap
+++ b/scanners/nuclei/parser/__snapshots__/parser.test.js.snap
@@ -98,6 +98,20 @@ exports[`parses log4shell result correctly 1`] = `
     "identified_at": "2021-12-21T15:36:21.962Z",
     "location": "http://10.1.6.107:8080",
     "name": "Remote code injection in Log4j",
+    "references": [
+      {
+        "type": "URL",
+        "value": "https://github.com/advisories/ghsa-jfh8-c2jp-5v3q",
+      },
+      {
+        "type": "URL",
+        "value": "https://www.lunasec.io/docs/blog/log4j-zero-day/",
+      },
+      {
+        "type": "URL",
+        "value": "https://gist.github.com/bugbountynights/dde69038573db1c12705edb39f9a704a",
+      },
+    ],
     "severity": "HIGH",
   },
 ]
@@ -158,6 +172,7 @@ Content-Length: 0
     "identified_at": "2022-09-09T19:56:16.141Z",
     "location": "https://example.com",
     "name": "Allowed Options Method",
+    "references": null,
     "severity": "INFORMATIONAL",
   },
 ]
@@ -201,6 +216,12 @@ exports[`parses secureCodeBox.io result correctly 1`] = `
     "identified_at": "2022-09-09T19:26:27.762Z",
     "location": "https://www.securecodebox.io",
     "name": "DOM EventListener detection",
+    "references": [
+      {
+        "type": "URL",
+        "value": "https://portswigger.net/web-security/dom-based/controlling-the-web-message-source",
+      },
+    ],
     "severity": "INFORMATIONAL",
   },
   {
@@ -238,6 +259,7 @@ exports[`parses secureCodeBox.io result correctly 1`] = `
     "identified_at": "2022-09-09T19:26:27.777Z",
     "location": "https://www.securecodebox.io",
     "name": "Email Extractor",
+    "references": null,
     "severity": "INFORMATIONAL",
   },
   {
@@ -277,6 +299,12 @@ exports[`parses secureCodeBox.io result correctly 1`] = `
     "identified_at": "2022-09-09T19:26:28.511Z",
     "location": "https://www.securecodebox.io",
     "name": "Metatag CMS Detection",
+    "references": [
+      {
+        "type": "URL",
+        "value": "https://www.w3schools.com/tags/att_meta_name.asp",
+      },
+    ],
     "severity": "INFORMATIONAL",
   },
   {
@@ -319,6 +347,7 @@ exports[`parses secureCodeBox.io result correctly 1`] = `
     "identified_at": "2022-09-09T19:27:13.644Z",
     "location": "https://www.securecodebox.io",
     "name": "HTTP Missing Security Headers",
+    "references": null,
     "severity": "INFORMATIONAL",
   },
   {
@@ -361,6 +390,7 @@ exports[`parses secureCodeBox.io result correctly 1`] = `
     "identified_at": "2022-09-09T19:27:13.644Z",
     "location": "https://www.securecodebox.io",
     "name": "HTTP Missing Security Headers",
+    "references": null,
     "severity": "INFORMATIONAL",
   },
   {
@@ -403,6 +433,7 @@ exports[`parses secureCodeBox.io result correctly 1`] = `
     "identified_at": "2022-09-09T19:27:13.644Z",
     "location": "https://www.securecodebox.io",
     "name": "HTTP Missing Security Headers",
+    "references": null,
     "severity": "INFORMATIONAL",
   },
   {
@@ -445,6 +476,7 @@ exports[`parses secureCodeBox.io result correctly 1`] = `
     "identified_at": "2022-09-09T19:27:13.644Z",
     "location": "https://www.securecodebox.io",
     "name": "HTTP Missing Security Headers",
+    "references": null,
     "severity": "INFORMATIONAL",
   },
   {
@@ -487,6 +519,7 @@ exports[`parses secureCodeBox.io result correctly 1`] = `
     "identified_at": "2022-09-09T19:27:13.645Z",
     "location": "https://www.securecodebox.io",
     "name": "HTTP Missing Security Headers",
+    "references": null,
     "severity": "INFORMATIONAL",
   },
   {
@@ -529,6 +562,7 @@ exports[`parses secureCodeBox.io result correctly 1`] = `
     "identified_at": "2022-09-09T19:27:13.645Z",
     "location": "https://www.securecodebox.io",
     "name": "HTTP Missing Security Headers",
+    "references": null,
     "severity": "INFORMATIONAL",
   },
   {
@@ -571,6 +605,7 @@ exports[`parses secureCodeBox.io result correctly 1`] = `
     "identified_at": "2022-09-09T19:27:13.655Z",
     "location": "https://www.securecodebox.io",
     "name": "HTTP Missing Security Headers",
+    "references": null,
     "severity": "INFORMATIONAL",
   },
   {
@@ -613,6 +648,7 @@ exports[`parses secureCodeBox.io result correctly 1`] = `
     "identified_at": "2022-09-09T19:27:13.659Z",
     "location": "https://www.securecodebox.io",
     "name": "HTTP Missing Security Headers",
+    "references": null,
     "severity": "INFORMATIONAL",
   },
   {
@@ -655,6 +691,7 @@ exports[`parses secureCodeBox.io result correctly 1`] = `
     "identified_at": "2022-09-09T19:27:13.659Z",
     "location": "https://www.securecodebox.io",
     "name": "HTTP Missing Security Headers",
+    "references": null,
     "severity": "INFORMATIONAL",
   },
   {
@@ -697,6 +734,7 @@ exports[`parses secureCodeBox.io result correctly 1`] = `
     "identified_at": "2022-09-09T19:27:13.659Z",
     "location": "https://www.securecodebox.io",
     "name": "HTTP Missing Security Headers",
+    "references": null,
     "severity": "INFORMATIONAL",
   },
   {
@@ -739,6 +777,7 @@ exports[`parses secureCodeBox.io result correctly 1`] = `
     "identified_at": "2022-09-09T19:27:13.659Z",
     "location": "https://www.securecodebox.io",
     "name": "HTTP Missing Security Headers",
+    "references": null,
     "severity": "INFORMATIONAL",
   },
   {
@@ -781,6 +820,7 @@ exports[`parses secureCodeBox.io result correctly 1`] = `
     "identified_at": "2022-09-09T19:27:13.660Z",
     "location": "https://www.securecodebox.io",
     "name": "HTTP Missing Security Headers",
+    "references": null,
     "severity": "INFORMATIONAL",
   },
   {
@@ -823,6 +863,7 @@ exports[`parses secureCodeBox.io result correctly 1`] = `
     "identified_at": "2022-09-09T19:27:13.660Z",
     "location": "https://www.securecodebox.io",
     "name": "HTTP Missing Security Headers",
+    "references": null,
     "severity": "INFORMATIONAL",
   },
   {
@@ -865,6 +906,7 @@ exports[`parses secureCodeBox.io result correctly 1`] = `
     "identified_at": "2022-09-09T19:27:13.660Z",
     "location": "https://www.securecodebox.io",
     "name": "HTTP Missing Security Headers",
+    "references": null,
     "severity": "INFORMATIONAL",
   },
   {
@@ -907,6 +949,7 @@ exports[`parses secureCodeBox.io result correctly 1`] = `
     "identified_at": "2022-09-09T19:27:13.660Z",
     "location": "https://www.securecodebox.io",
     "name": "HTTP Missing Security Headers",
+    "references": null,
     "severity": "INFORMATIONAL",
   },
   {
@@ -949,6 +992,7 @@ exports[`parses secureCodeBox.io result correctly 1`] = `
     "identified_at": "2022-09-09T19:27:13.660Z",
     "location": "https://www.securecodebox.io",
     "name": "HTTP Missing Security Headers",
+    "references": null,
     "severity": "INFORMATIONAL",
   },
   {
@@ -989,6 +1033,24 @@ exports[`parses secureCodeBox.io result correctly 1`] = `
     "identified_at": "2022-09-09T19:27:25.325Z",
     "location": "https://www.securecodebox.io",
     "name": "CNAME Fingerprint",
+    "references": [
+      {
+        "type": "URL",
+        "value": "https://www.theregister.com/2021/02/24/dns_cname_tracking/",
+      },
+      {
+        "type": "URL",
+        "value": "https://www.ionos.com/digitalguide/hosting/technical-matters/cname-record/",
+      },
+      {
+        "type": "CWE",
+        "value": "CWE-200",
+      },
+      {
+        "type": "URL",
+        "value": "https://cwe.mitre.org/data/definitions/cwe-200.html",
+      },
+    ],
     "severity": "INFORMATIONAL",
   },
   {
@@ -1025,6 +1087,7 @@ exports[`parses secureCodeBox.io result correctly 1`] = `
     "identified_at": "2022-09-09T19:27:53.046Z",
     "location": "https://www.securecodebox.io",
     "name": "TLS Version",
+    "references": null,
     "severity": "INFORMATIONAL",
   },
   {
@@ -1062,6 +1125,7 @@ exports[`parses secureCodeBox.io result correctly 1`] = `
     "identified_at": "2022-09-09T19:28:02.187Z",
     "location": "https://www.securecodebox.io",
     "name": "SSL DNS Names",
+    "references": null,
     "severity": "INFORMATIONAL",
   },
 ]
@@ -1109,6 +1173,7 @@ exports[`parses the example.com result correctly 1`] = `
     "identified_at": "2022-09-09T19:18:55.271Z",
     "location": "https://example.com",
     "name": "HTTP Missing Security Headers",
+    "references": null,
     "severity": "INFORMATIONAL",
   },
   {
@@ -1151,6 +1216,7 @@ exports[`parses the example.com result correctly 1`] = `
     "identified_at": "2022-09-09T19:18:55.272Z",
     "location": "https://example.com",
     "name": "HTTP Missing Security Headers",
+    "references": null,
     "severity": "INFORMATIONAL",
   },
   {
@@ -1193,6 +1259,7 @@ exports[`parses the example.com result correctly 1`] = `
     "identified_at": "2022-09-09T19:18:55.272Z",
     "location": "https://example.com",
     "name": "HTTP Missing Security Headers",
+    "references": null,
     "severity": "INFORMATIONAL",
   },
   {
@@ -1235,6 +1302,7 @@ exports[`parses the example.com result correctly 1`] = `
     "identified_at": "2022-09-09T19:18:55.272Z",
     "location": "https://example.com",
     "name": "HTTP Missing Security Headers",
+    "references": null,
     "severity": "INFORMATIONAL",
   },
   {
@@ -1277,6 +1345,7 @@ exports[`parses the example.com result correctly 1`] = `
     "identified_at": "2022-09-09T19:18:55.272Z",
     "location": "https://example.com",
     "name": "HTTP Missing Security Headers",
+    "references": null,
     "severity": "INFORMATIONAL",
   },
   {
@@ -1319,6 +1388,7 @@ exports[`parses the example.com result correctly 1`] = `
     "identified_at": "2022-09-09T19:18:55.272Z",
     "location": "https://example.com",
     "name": "HTTP Missing Security Headers",
+    "references": null,
     "severity": "INFORMATIONAL",
   },
   {
@@ -1361,6 +1431,7 @@ exports[`parses the example.com result correctly 1`] = `
     "identified_at": "2022-09-09T19:18:55.292Z",
     "location": "https://example.com",
     "name": "HTTP Missing Security Headers",
+    "references": null,
     "severity": "INFORMATIONAL",
   },
   {
@@ -1403,6 +1474,7 @@ exports[`parses the example.com result correctly 1`] = `
     "identified_at": "2022-09-09T19:18:55.293Z",
     "location": "https://example.com",
     "name": "HTTP Missing Security Headers",
+    "references": null,
     "severity": "INFORMATIONAL",
   },
   {
@@ -1445,6 +1517,7 @@ exports[`parses the example.com result correctly 1`] = `
     "identified_at": "2022-09-09T19:18:55.293Z",
     "location": "https://example.com",
     "name": "HTTP Missing Security Headers",
+    "references": null,
     "severity": "INFORMATIONAL",
   },
   {
@@ -1487,6 +1560,7 @@ exports[`parses the example.com result correctly 1`] = `
     "identified_at": "2022-09-09T19:18:55.293Z",
     "location": "https://example.com",
     "name": "HTTP Missing Security Headers",
+    "references": null,
     "severity": "INFORMATIONAL",
   },
   {
@@ -1529,6 +1603,7 @@ exports[`parses the example.com result correctly 1`] = `
     "identified_at": "2022-09-09T19:18:55.293Z",
     "location": "https://example.com",
     "name": "HTTP Missing Security Headers",
+    "references": null,
     "severity": "INFORMATIONAL",
   },
   {
@@ -1571,6 +1646,7 @@ exports[`parses the example.com result correctly 1`] = `
     "identified_at": "2022-09-09T19:18:55.293Z",
     "location": "https://example.com",
     "name": "HTTP Missing Security Headers",
+    "references": null,
     "severity": "INFORMATIONAL",
   },
   {
@@ -1613,6 +1689,7 @@ exports[`parses the example.com result correctly 1`] = `
     "identified_at": "2022-09-09T19:18:55.293Z",
     "location": "https://example.com",
     "name": "HTTP Missing Security Headers",
+    "references": null,
     "severity": "INFORMATIONAL",
   },
   {
@@ -1655,6 +1732,7 @@ exports[`parses the example.com result correctly 1`] = `
     "identified_at": "2022-09-09T19:18:55.293Z",
     "location": "https://example.com",
     "name": "HTTP Missing Security Headers",
+    "references": null,
     "severity": "INFORMATIONAL",
   },
   {
@@ -1697,6 +1775,7 @@ exports[`parses the example.com result correctly 1`] = `
     "identified_at": "2022-09-09T19:18:55.293Z",
     "location": "https://example.com",
     "name": "HTTP Missing Security Headers",
+    "references": null,
     "severity": "INFORMATIONAL",
   },
   {
@@ -1739,6 +1818,7 @@ exports[`parses the example.com result correctly 1`] = `
     "identified_at": "2022-09-09T19:18:55.293Z",
     "location": "https://example.com",
     "name": "HTTP Missing Security Headers",
+    "references": null,
     "severity": "INFORMATIONAL",
   },
   {
@@ -1781,6 +1861,7 @@ exports[`parses the example.com result correctly 1`] = `
     "identified_at": "2022-09-09T19:18:55.294Z",
     "location": "https://example.com",
     "name": "HTTP Missing Security Headers",
+    "references": null,
     "severity": "INFORMATIONAL",
   },
   {
@@ -1824,6 +1905,7 @@ exports[`parses the example.com result correctly 1`] = `
     "identified_at": "2022-09-09T19:18:55.401Z",
     "location": "https://example.com",
     "name": "SSL DNS Names",
+    "references": null,
     "severity": "INFORMATIONAL",
   },
   {
@@ -1861,6 +1943,7 @@ exports[`parses the example.com result correctly 1`] = `
     "identified_at": "2022-09-09T19:19:38.295Z",
     "location": "https://example.com",
     "name": "Allowed Options Method",
+    "references": null,
     "severity": "INFORMATIONAL",
   },
   {
@@ -1903,6 +1986,12 @@ exports[`parses the example.com result correctly 1`] = `
     "identified_at": "2022-09-09T19:20:23.432Z",
     "location": "https://example.com",
     "name": "Deprecated TLS Detection (TLS 1.1 or SSLv3)",
+    "references": [
+      {
+        "type": "URL",
+        "value": "https://ssl-config.mozilla.org/#config=intermediate",
+      },
+    ],
     "severity": "INFORMATIONAL",
   },
   {
@@ -1945,6 +2034,12 @@ exports[`parses the example.com result correctly 1`] = `
     "identified_at": "2022-09-09T19:20:23.731Z",
     "location": "https://example.com",
     "name": "Deprecated TLS Detection (TLS 1.1 or SSLv3)",
+    "references": [
+      {
+        "type": "URL",
+        "value": "https://ssl-config.mozilla.org/#config=intermediate",
+      },
+    ],
     "severity": "INFORMATIONAL",
   },
   {
@@ -1983,6 +2078,16 @@ exports[`parses the example.com result correctly 1`] = `
     "identified_at": "2022-09-09T19:20:29.548Z",
     "location": "https://example.com",
     "name": "NS Record Detection",
+    "references": [
+      {
+        "type": "CWE",
+        "value": "CWE-200",
+      },
+      {
+        "type": "URL",
+        "value": "https://cwe.mitre.org/data/definitions/cwe-200.html",
+      },
+    ],
     "severity": "INFORMATIONAL",
   },
   {
@@ -2028,6 +2133,24 @@ exports[`parses the example.com result correctly 1`] = `
     "identified_at": "2022-09-09T19:20:38.059Z",
     "location": "https://example.com",
     "name": "DNSSEC Detection",
+    "references": [
+      {
+        "type": "URL",
+        "value": "https://www.icann.org/resources/pages/dnssec-what-is-it-why-important-2019-03-05-en",
+      },
+      {
+        "type": "URL",
+        "value": "https://www.cyberciti.biz/faq/unix-linux-test-and-validate-dnssec-using-dig-command-line/",
+      },
+      {
+        "type": "CWE",
+        "value": "CWE-200",
+      },
+      {
+        "type": "URL",
+        "value": "https://cwe.mitre.org/data/definitions/cwe-200.html",
+      },
+    ],
     "severity": "INFORMATIONAL",
   },
   {
@@ -2068,6 +2191,20 @@ exports[`parses the example.com result correctly 1`] = `
     "identified_at": "2022-09-09T19:20:45.095Z",
     "location": "https://example.com",
     "name": "DNS TXT Record Detected",
+    "references": [
+      {
+        "type": "URL",
+        "value": "https://www.netspi.com/blog/technical/network-penetration-testing/analyzing-dns-txt-records-to-fingerprint-service-providers/",
+      },
+      {
+        "type": "CWE",
+        "value": "CWE-200",
+      },
+      {
+        "type": "URL",
+        "value": "https://cwe.mitre.org/data/definitions/cwe-200.html",
+      },
+    ],
     "severity": "INFORMATIONAL",
   },
   {
@@ -2108,6 +2245,24 @@ exports[`parses the example.com result correctly 1`] = `
     "identified_at": "2022-09-09T19:20:54.419Z",
     "location": "https://example.com",
     "name": "MX Record Detection",
+    "references": [
+      {
+        "type": "URL",
+        "value": "https://www.cloudflare.com/learning/dns/dns-records/dns-mx-record/",
+      },
+      {
+        "type": "URL",
+        "value": "https://mxtoolbox.com/",
+      },
+      {
+        "type": "CWE",
+        "value": "CWE-200",
+      },
+      {
+        "type": "URL",
+        "value": "https://cwe.mitre.org/data/definitions/cwe-200.html",
+      },
+    ],
     "severity": "INFORMATIONAL",
   },
   {
@@ -2144,6 +2299,7 @@ exports[`parses the example.com result correctly 1`] = `
     "identified_at": "2022-09-09T19:21:04.604Z",
     "location": "https://example.com",
     "name": "TLS Version",
+    "references": null,
     "severity": "INFORMATIONAL",
   },
   {
@@ -2182,6 +2338,7 @@ exports[`parses the example.com result correctly 1`] = `
     "identified_at": "2022-09-09T19:21:17.696Z",
     "location": "https://example.com",
     "name": "Microsoft Azure - Domain Tenant ID",
+    "references": null,
     "severity": "INFORMATIONAL",
   },
 ]

--- a/scanners/semgrep/parser/parser.js
+++ b/scanners/semgrep/parser/parser.js
@@ -34,7 +34,7 @@ async function parse(fileContent) {
     });
 
     if(result.extra.metadata.cwe != null) {
-      const cweReference = result.extra.metadata.cwe.substring(4,6); 
+      const cweReference = String(result.extra.metadata.cwe).substring(4,6); 
       references.push(
         {
           "type": "CWE",

--- a/scanners/semgrep/parser/parser.js
+++ b/scanners/semgrep/parser/parser.js
@@ -25,13 +25,33 @@ async function parse(fileContent) {
     // severity of the issue: translate semgrep severity levels (INFO, WARNING, ERROR) to those of SCB (INFORMATIONAL, LOW, MEDIUM, HIGH)
     const severity = severityMap.has(result.extra.severity.toLowerCase()) ? severityMap.get(result.extra.severity.toLowerCase()) : "INFORMATIONAL"
 
+
+    const references = result.extra.metadata?.references?.map((link) => {
+      return {
+        "type": "URL",
+        "value": link,
+      }
+    });
+
+    if(result.extra.metadata.cwe != null) {
+      const cweReference = result.extra.metadata.cwe.substring(4,6); 
+      references.push(
+        {
+          "type": "CWE",
+          "value": `CWE-${cweReference}`
+        },
+        {
+          "type": "URL",
+          "value": `https://cwe.mitre.org/data/definitions/${cweReference}.html`
+        });
+    }
     const attributes = {
       // Common weakness enumeration, if available
       "cwe": result.extra.metadata.cwe || null,
       // OWASP category, if available
       "owasp_category": result.extra.metadata.owasp || null,
       // References given in the rule
-      "references": result.extra.metadata.references || null,
+      "references": references || null,
       // Link to the semgrep rule
       "rule_source": result.extra.metadata.source || null,
       // Which line of code matched?

--- a/scanners/semgrep/parser/parser.test.js
+++ b/scanners/semgrep/parser/parser.test.js
@@ -55,7 +55,18 @@ test("should properly parse file with a single result", async () => {
       "cwe": "CWE-78: Improper Neutralization of Special Elements used in an OS Command ('OS Command Injection')",
       "owasp_category": "A1: Injection",
       "references": [
-        "https://owasp.org/www-community/attacks/Command_Injection",
+        {
+          "type": "URL",
+          "value": "https://owasp.org/www-community/attacks/Command_Injection",
+        },
+        {
+          "type": "CWE",
+          "value": "CWE-78",
+        },
+        {
+          "type": "URL",
+          "value": "https://cwe.mitre.org/data/definitions/78.html",
+        },
       ],
       "rule_source": "https://semgrep.dev/r/python.django.security.injection.command.command-injection-os-system.command-injection-os-system",
     },
@@ -86,7 +97,18 @@ test("should properly parse file with multiple results", async () => {
       "cwe": "CWE-78: Improper Neutralization of Special Elements used in an OS Command ('OS Command Injection')",
       "owasp_category": "A1: Injection",
       "references": [
-        "https://owasp.org/www-community/attacks/Command_Injection",
+        {
+          "type": "URL",
+          "value": "https://owasp.org/www-community/attacks/Command_Injection",
+        },
+        {
+          "type": "CWE",
+          "value": "CWE-78",
+        },
+        {
+          "type": "URL",
+          "value": "https://cwe.mitre.org/data/definitions/78.html",
+        },
       ],
       "rule_source": "https://semgrep.dev/r/python.django.security.injection.command.command-injection-os-system.command-injection-os-system",
     },
@@ -101,7 +123,18 @@ test("should properly parse file with multiple results", async () => {
       "cwe": "CWE-78: Improper Neutralization of Special Elements used in an OS Command ('OS Command Injection')",
       "owasp_category": "A1: Injection",
       "references": [
-        "https://owasp.org/www-community/attacks/Command_Injection",
+        {
+          "type": "URL",
+          "value": "https://owasp.org/www-community/attacks/Command_Injection",
+        },
+        {
+          "type": "CWE",
+          "value": "CWE-78",
+        },
+        {
+          "type": "URL",
+          "value": "https://cwe.mitre.org/data/definitions/78.html",
+        },
       ],
       "rule_source": "https://semgrep.dev/r/python.django.security.injection.command.command-injection-os-system.command-injection-os-system",
     },

--- a/scanners/trivy/parser/__snapshots__/parser.test.js.snap
+++ b/scanners/trivy/parser/__snapshots__/parser.test.js.snap
@@ -30,31 +30,31 @@ exports[`parses bkimminich/juice-shop:v10.2.0 result file into findings 1`] = `
         "value": "CVE-2021-36159",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://nvd.nist.gov/vuln/detail/CVE-2021-36159",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://github.com/freebsd/freebsd-src/commits/main/lib/libfetch",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://gitlab.alpinelinux.org/alpine/apk-tools/-/issues/10749",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://lists.apache.org/thread.html/r61db8e7dcb56dc000a5387a88f7a473bacec5ee01b9ff3f55308aacc@%3Cdev.kafka.apache.org%3E",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://lists.apache.org/thread.html/r61db8e7dcb56dc000a5387a88f7a473bacec5ee01b9ff3f55308aacc@%3Cusers.kafka.apache.org%3E",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://lists.apache.org/thread.html/rbf4ce74b0d1fa9810dec50ba3ace0caeea677af7c27a97111c06ccb7@%3Cdev.kafka.apache.org%3E",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://lists.apache.org/thread.html/rbf4ce74b0d1fa9810dec50ba3ace0caeea677af7c27a97111c06ccb7@%3Cusers.kafka.apache.org%3E",
       },
     ],
@@ -84,15 +84,15 @@ exports[`parses bkimminich/juice-shop:v10.2.0 result file into findings 1`] = `
         "value": "CVE-2021-30139",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://nvd.nist.gov/vuln/detail/CVE-2021-30139",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://gitlab.alpinelinux.org/alpine/apk-tools/-/issues/10741",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://gitlab.alpinelinux.org/alpine/aports/-/issues/12606",
       },
     ],
@@ -127,35 +127,35 @@ exports[`parses bkimminich/juice-shop:v10.2.0 result file into findings 1`] = `
         "value": "CVE-2021-28831",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://nvd.nist.gov/vuln/detail/CVE-2021-28831",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2021-28831",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://git.busybox.net/busybox/commit/?id=f25d254dfd4243698c31a4f3153d4ac72aa9e9bd",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://lists.debian.org/debian-lts-announce/2021/04/msg00001.html",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://lists.fedoraproject.org/archives/list/package-announce@lists.fedoraproject.org/message/3UDQGJRECXFS5EZVDH2OI45FMO436AC4/",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://lists.fedoraproject.org/archives/list/package-announce@lists.fedoraproject.org/message/Z7ZIFKPRR32ZYA3WAA2NXFA3QHHOU6FJ/",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://lists.fedoraproject.org/archives/list/package-announce@lists.fedoraproject.org/message/ZASBW7QRRLY5V2R44MQ4QQM4CZIDHM2U/",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://security.gentoo.org/glsa/202105-09",
       },
     ],
@@ -195,55 +195,55 @@ exports[`parses bkimminich/juice-shop:v10.2.0 result file into findings 1`] = `
         "value": "CVE-2021-3711",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://nvd.nist.gov/vuln/detail/CVE-2021-3711",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "http://www.openwall.com/lists/oss-security/2021/08/26/2",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2021-3711",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://git.openssl.org/gitweb/?p=openssl.git;a=commitdiff;h=59f5e75f3bced8fc0e130d72a3f582cf7b480b46",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://lists.apache.org/thread.html/r18995de860f0e63635f3008fd2a6aca82394249476d21691e7c59c9e@%3Cdev.tomcat.apache.org%3E",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://lists.apache.org/thread.html/rad5d9f83f0d11fb3f8bb148d179b8a9ad7c6a17f18d70e5805a713d1@%3Cdev.tomcat.apache.org%3E",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://security.netapp.com/advisory/ntap-20210827-0010/",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://security.netapp.com/advisory/ntap-20211022-0003/",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://ubuntu.com/security/notices/USN-5051-1",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://www.debian.org/security/2021/dsa-4963",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://www.openssl.org/news/secadv/20210824.txt",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://www.oracle.com/security-alerts/cpuoct2021.html",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://www.tenable.com/security/tns-2021-16",
       },
     ],
@@ -305,143 +305,143 @@ exports[`parses bkimminich/juice-shop:v10.2.0 result file into findings 1`] = `
         "value": "CVE-2020-1967",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://nvd.nist.gov/vuln/detail/CVE-2020-1967",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "http://lists.opensuse.org/opensuse-security-announce/2020-07/msg00004.html",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "http://lists.opensuse.org/opensuse-security-announce/2020-07/msg00011.html",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "http://packetstormsecurity.com/files/157527/OpenSSL-signature_algorithms_cert-Denial-Of-Service.html",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "http://seclists.org/fulldisclosure/2020/May/5",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "http://www.openwall.com/lists/oss-security/2020/04/22/2",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2020-1967",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://git.openssl.org/gitweb/?p=openssl.git;a=commitdiff;h=eb563247aef3e83dda7679c43f9649270462e5b1",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://github.com/irsl/CVE-2020-1967",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://kb.pulsesecure.net/articles/Pulse_Security_Advisories/SA44440",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://lists.apache.org/thread.html/r66ea9c436da150683432db5fbc8beb8ae01886c6459ac30c2cea7345@%3Cdev.tomcat.apache.org%3E",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://lists.apache.org/thread.html/r94d6ac3f010a38fccf4f432b12180a13fa1cf303559bd805648c9064@%3Cdev.tomcat.apache.org%3E",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://lists.apache.org/thread.html/r9a41e304992ce6aec6585a87842b4f2e692604f5c892c37e3b0587ee@%3Cdev.tomcat.apache.org%3E",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://lists.fedoraproject.org/archives/list/package-announce@lists.fedoraproject.org/message/DDHOAATPWJCXRNFMJ2SASDBBNU5RJONY/",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://lists.fedoraproject.org/archives/list/package-announce@lists.fedoraproject.org/message/EXDDAOWSAIEFQNBHWYE6PPYFV4QXGMCD/",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://lists.fedoraproject.org/archives/list/package-announce@lists.fedoraproject.org/message/XVEP3LAK4JSPRXFO4QF4GG2IVXADV3SO/",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://nvd.nist.gov/vuln/detail/CVE-2020-1967",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://security.FreeBSD.org/advisories/FreeBSD-SA-20:11.openssl.asc",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://security.gentoo.org/glsa/202004-10",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://security.netapp.com/advisory/ntap-20200424-0003/",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://security.netapp.com/advisory/ntap-20200717-0004/",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://www.debian.org/security/2020/dsa-4661",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://www.openssl.org/news/secadv/20200421.txt",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://www.oracle.com//security-alerts/cpujul2021.html",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://www.oracle.com/security-alerts/cpuApr2021.html",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://www.oracle.com/security-alerts/cpujan2021.html",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://www.oracle.com/security-alerts/cpujul2020.html",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://www.oracle.com/security-alerts/cpuoct2020.html",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://www.oracle.com/security-alerts/cpuoct2021.html",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://www.synology.com/security/advisory/Synology_SA_20_05",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://www.synology.com/security/advisory/Synology_SA_20_05_OpenSSL",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://www.tenable.com/security/tns-2020-03",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://www.tenable.com/security/tns-2020-04",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://www.tenable.com/security/tns-2020-11",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://www.tenable.com/security/tns-2021-10",
       },
     ],
@@ -490,91 +490,91 @@ exports[`parses bkimminich/juice-shop:v10.2.0 result file into findings 1`] = `
         "value": "CVE-2021-23840",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://nvd.nist.gov/vuln/detail/CVE-2021-23840",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2021-23840",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://git.openssl.org/gitweb/?p=openssl.git;a=commitdiff;h=6a51b9e1d0cf0bf8515f7201b68fb0a3482b3dc1",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://git.openssl.org/gitweb/?p=openssl.git;a=commitdiff;h=9b1129239f3ebb1d1c98ce9ed41d5c9476c47cb2",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://kb.pulsesecure.net/articles/Pulse_Security_Advisories/SA44846",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://kc.mcafee.com/corporate/index?page=content&id=SB10366",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://linux.oracle.com/cve/CVE-2021-23840.html",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://linux.oracle.com/errata/ELSA-2021-9528.html",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://lists.apache.org/thread.html/r58af02e294bd07f487e2c64ffc0a29b837db5600e33b6e698b9d696b@%3Cissues.bookkeeper.apache.org%3E",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://lists.apache.org/thread.html/rf4c02775860db415b4955778a131c2795223f61cb8c6a450893651e4@%3Cissues.bookkeeper.apache.org%3E",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://security.gentoo.org/glsa/202103-03",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://security.netapp.com/advisory/ntap-20210219-0009/",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://ubuntu.com/security/notices/USN-4738-1",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://ubuntu.com/security/notices/USN-5088-1",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://www.debian.org/security/2021/dsa-4855",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://www.openssl.org/news/secadv/20210216.txt",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://www.oracle.com//security-alerts/cpujul2021.html",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://www.oracle.com/security-alerts/cpuApr2021.html",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://www.oracle.com/security-alerts/cpuoct2021.html",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://www.tenable.com/security/tns-2021-03",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://www.tenable.com/security/tns-2021-09",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://www.tenable.com/security/tns-2021-10",
       },
     ],
@@ -625,99 +625,99 @@ exports[`parses bkimminich/juice-shop:v10.2.0 result file into findings 1`] = `
         "value": "CVE-2021-3450",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://nvd.nist.gov/vuln/detail/CVE-2021-3450",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "http://www.openwall.com/lists/oss-security/2021/03/27/1",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "http://www.openwall.com/lists/oss-security/2021/03/27/2",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "http://www.openwall.com/lists/oss-security/2021/03/28/3",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "http://www.openwall.com/lists/oss-security/2021/03/28/4",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://git.openssl.org/gitweb/?p=openssl.git;a=commitdiff;h=2a40b7bc7b94dd7de897a74571e7024f0cf0d63b",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://kb.pulsesecure.net/articles/Pulse_Security_Advisories/SA44845",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://kc.mcafee.com/corporate/index?page=content&id=SB10356",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://linux.oracle.com/cve/CVE-2021-3450.html",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://linux.oracle.com/errata/ELSA-2021-9151.html",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://lists.fedoraproject.org/archives/list/package-announce@lists.fedoraproject.org/message/CCBFLLVQVILIVGZMBJL3IXZGKWQISYNP/",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://mta.openssl.org/pipermail/openssl-announce/2021-March/000198.html",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://psirt.global.sonicwall.com/vuln-detail/SNWLID-2021-0013",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://security.FreeBSD.org/advisories/FreeBSD-SA-21:07.openssl.asc",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://security.gentoo.org/glsa/202103-03",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://security.netapp.com/advisory/ntap-20210326-0006/",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://tools.cisco.com/security/center/content/CiscoSecurityAdvisory/cisco-sa-openssl-2021-GHY28dJd",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://www.openssl.org/news/secadv/20210325.txt",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://www.oracle.com//security-alerts/cpujul2021.html",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://www.oracle.com/security-alerts/cpuApr2021.html",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://www.oracle.com/security-alerts/cpuoct2021.html",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://www.tenable.com/security/tns-2021-05",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://www.tenable.com/security/tns-2021-08",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://www.tenable.com/security/tns-2021-09",
       },
     ],
@@ -764,83 +764,83 @@ exports[`parses bkimminich/juice-shop:v10.2.0 result file into findings 1`] = `
         "value": "CVE-2021-3712",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://nvd.nist.gov/vuln/detail/CVE-2021-3712",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "http://www.openwall.com/lists/oss-security/2021/08/26/2",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2021-3712",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://git.openssl.org/gitweb/?p=openssl.git;a=commitdiff;h=94d23fcff9b2a7a8368dfe52214d5c2569882c11",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://git.openssl.org/gitweb/?p=openssl.git;a=commitdiff;h=ccb0a11145ee72b042d10593a64eaf9e8a55ec12",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://kc.mcafee.com/corporate/index?page=content&id=SB10366",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://lists.apache.org/thread.html/r18995de860f0e63635f3008fd2a6aca82394249476d21691e7c59c9e@%3Cdev.tomcat.apache.org%3E",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://lists.apache.org/thread.html/rad5d9f83f0d11fb3f8bb148d179b8a9ad7c6a17f18d70e5805a713d1@%3Cdev.tomcat.apache.org%3E",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://lists.debian.org/debian-lts-announce/2021/09/msg00014.html",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://lists.debian.org/debian-lts-announce/2021/09/msg00021.html",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://security.netapp.com/advisory/ntap-20210827-0010/",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://ubuntu.com/security/notices/USN-5051-1",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://ubuntu.com/security/notices/USN-5051-2",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://ubuntu.com/security/notices/USN-5051-3",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://ubuntu.com/security/notices/USN-5051-4 (regression only in trusty/esm)",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://ubuntu.com/security/notices/USN-5088-1",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://www.debian.org/security/2021/dsa-4963",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://www.openssl.org/news/secadv/20210824.txt",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://www.oracle.com/security-alerts/cpuoct2021.html",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://www.tenable.com/security/tns-2021-16",
       },
     ],
@@ -896,119 +896,119 @@ exports[`parses bkimminich/juice-shop:v10.2.0 result file into findings 1`] = `
         "value": "CVE-2020-1971",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://nvd.nist.gov/vuln/detail/CVE-2020-1971",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "http://www.openwall.com/lists/oss-security/2021/09/14/2",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2020-1971",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://git.openssl.org/gitweb/?p=openssl.git;a=commitdiff;h=2154ab83e14ede338d2ede9bbe5cdfce5d5a6c9e",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://git.openssl.org/gitweb/?p=openssl.git;a=commitdiff;h=f960d81215ebf3f65e03d4d5d857fb9b666d6920",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://kb.pulsesecure.net/articles/Pulse_Security_Advisories/SA44676",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://linux.oracle.com/cve/CVE-2020-1971.html",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://linux.oracle.com/errata/ELSA-2021-9150.html",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://lists.apache.org/thread.html/r63c6f2dd363d9b514d0a4bcf624580616a679898cc14c109a49b750c@%3Cdev.tomcat.apache.org%3E",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://lists.apache.org/thread.html/rbb769f771711fb274e0a4acb1b5911c8aab544a6ac5e8c12d40c5143@%3Ccommits.pulsar.apache.org%3E",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://lists.debian.org/debian-lts-announce/2020/12/msg00020.html",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://lists.debian.org/debian-lts-announce/2020/12/msg00021.html",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://lists.fedoraproject.org/archives/list/package-announce@lists.fedoraproject.org/message/DGSI34Y5LQ5RYXN4M2I5ZQT65LFVDOUU/",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://lists.fedoraproject.org/archives/list/package-announce@lists.fedoraproject.org/message/PWPSSZNZOBJU2YR6Z4TGHXKYW3YP5QG7/",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://security.FreeBSD.org/advisories/FreeBSD-SA-20:33.openssl.asc",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://security.gentoo.org/glsa/202012-13",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://security.netapp.com/advisory/ntap-20201218-0005/",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://security.netapp.com/advisory/ntap-20210513-0002/",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://ubuntu.com/security/notices/USN-4662-1",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://ubuntu.com/security/notices/USN-4745-1",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://www.debian.org/security/2020/dsa-4807",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://www.openssl.org/news/secadv/20201208.txt",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://www.oracle.com//security-alerts/cpujul2021.html",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://www.oracle.com/security-alerts/cpuApr2021.html",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://www.oracle.com/security-alerts/cpujan2021.html",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://www.oracle.com/security-alerts/cpuoct2021.html",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://www.tenable.com/security/tns-2020-11",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://www.tenable.com/security/tns-2021-09",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://www.tenable.com/security/tns-2021-10",
       },
     ],
@@ -1060,103 +1060,103 @@ exports[`parses bkimminich/juice-shop:v10.2.0 result file into findings 1`] = `
         "value": "CVE-2021-23841",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://nvd.nist.gov/vuln/detail/CVE-2021-23841",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "http://seclists.org/fulldisclosure/2021/May/67",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "http://seclists.org/fulldisclosure/2021/May/68",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "http://seclists.org/fulldisclosure/2021/May/70",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2021-23841",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://git.openssl.org/gitweb/?p=openssl.git;a=commitdiff;h=122a19ab48091c657f7cb1fb3af9fc07bd557bbf",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://git.openssl.org/gitweb/?p=openssl.git;a=commitdiff;h=8252ee4d90f3f2004d3d0aeeed003ad49c9a7807",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://kb.pulsesecure.net/articles/Pulse_Security_Advisories/SA44846",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://linux.oracle.com/cve/CVE-2021-23841.html",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://linux.oracle.com/errata/ELSA-2021-9528.html",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://security.gentoo.org/glsa/202103-03",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://security.netapp.com/advisory/ntap-20210219-0009/",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://security.netapp.com/advisory/ntap-20210513-0002/",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://support.apple.com/kb/HT212528",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://support.apple.com/kb/HT212529",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://support.apple.com/kb/HT212534",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://ubuntu.com/security/notices/USN-4738-1",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://ubuntu.com/security/notices/USN-4745-1",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://www.debian.org/security/2021/dsa-4855",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://www.openssl.org/news/secadv/20210216.txt",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://www.oracle.com//security-alerts/cpujul2021.html",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://www.oracle.com/security-alerts/cpuApr2021.html",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://www.oracle.com/security-alerts/cpuoct2021.html",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://www.tenable.com/security/tns-2021-03",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://www.tenable.com/security/tns-2021-09",
       },
     ],
@@ -1214,127 +1214,127 @@ exports[`parses bkimminich/juice-shop:v10.2.0 result file into findings 1`] = `
         "value": "CVE-2021-3449",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://nvd.nist.gov/vuln/detail/CVE-2021-3449",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "http://www.openwall.com/lists/oss-security/2021/03/27/1",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "http://www.openwall.com/lists/oss-security/2021/03/27/2",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "http://www.openwall.com/lists/oss-security/2021/03/28/3",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "http://www.openwall.com/lists/oss-security/2021/03/28/4",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://cert-portal.siemens.com/productcert/pdf/ssa-772220.pdf",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2021-3449",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://git.openssl.org/gitweb/?p=openssl.git;a=commitdiff;h=fb9fa6b51defd48157eeb207f52181f735d96148",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://kb.pulsesecure.net/articles/Pulse_Security_Advisories/SA44845",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://kc.mcafee.com/corporate/index?page=content&id=SB10356",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://linux.oracle.com/cve/CVE-2021-3449.html",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://linux.oracle.com/errata/ELSA-2021-9151.html",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://lists.debian.org/debian-lts-announce/2021/08/msg00029.html",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://lists.fedoraproject.org/archives/list/package-announce@lists.fedoraproject.org/message/CCBFLLVQVILIVGZMBJL3IXZGKWQISYNP/",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://psirt.global.sonicwall.com/vuln-detail/SNWLID-2021-0013",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://security.FreeBSD.org/advisories/FreeBSD-SA-21:07.openssl.asc",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://security.gentoo.org/glsa/202103-03",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://security.netapp.com/advisory/ntap-20210326-0006/",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://security.netapp.com/advisory/ntap-20210513-0002/",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://tools.cisco.com/security/center/content/CiscoSecurityAdvisory/cisco-sa-openssl-2021-GHY28dJd",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://ubuntu.com/security/notices/USN-4891-1",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://ubuntu.com/security/notices/USN-5038-1",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://www.debian.org/security/2021/dsa-4875",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://www.openssl.org/news/secadv/20210325.txt",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://www.oracle.com//security-alerts/cpujul2021.html",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://www.oracle.com/security-alerts/cpuApr2021.html",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://www.oracle.com/security-alerts/cpuoct2021.html",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://www.tenable.com/security/tns-2021-05",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://www.tenable.com/security/tns-2021-06",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://www.tenable.com/security/tns-2021-09",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://www.tenable.com/security/tns-2021-10",
       },
     ],
@@ -1369,35 +1369,35 @@ exports[`parses bkimminich/juice-shop:v10.2.0 result file into findings 1`] = `
         "value": "CVE-2021-23839",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://nvd.nist.gov/vuln/detail/CVE-2021-23839",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://git.openssl.org/gitweb/?p=openssl.git;a=commitdiff;h=30919ab80a478f2d81f2e9acdcca3fa4740cd547",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://kb.pulsesecure.net/articles/Pulse_Security_Advisories/SA44846",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://security.netapp.com/advisory/ntap-20210219-0009/",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://www.openssl.org/news/secadv/20210216.txt",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://www.oracle.com//security-alerts/cpujul2021.html",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://www.oracle.com/security-alerts/cpuApr2021.html",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://www.oracle.com/security-alerts/cpuoct2021.html",
       },
     ],
@@ -1431,31 +1431,31 @@ exports[`parses bkimminich/juice-shop:v10.2.0 result file into findings 1`] = `
         "value": "CVE-2019-15847",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://nvd.nist.gov/vuln/detail/CVE-2019-15847",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "http://lists.opensuse.org/opensuse-security-announce/2019-10/msg00056.html",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "http://lists.opensuse.org/opensuse-security-announce/2019-10/msg00057.html",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "http://lists.opensuse.org/opensuse-security-announce/2020-05/msg00058.html",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://gcc.gnu.org/bugzilla/show_bug.cgi?id=91481",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://linux.oracle.com/cve/CVE-2019-15847.html",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://linux.oracle.com/errata/ELSA-2020-1864.html",
       },
     ],
@@ -1495,55 +1495,55 @@ exports[`parses bkimminich/juice-shop:v10.2.0 result file into findings 1`] = `
         "value": "CVE-2021-3711",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://nvd.nist.gov/vuln/detail/CVE-2021-3711",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "http://www.openwall.com/lists/oss-security/2021/08/26/2",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2021-3711",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://git.openssl.org/gitweb/?p=openssl.git;a=commitdiff;h=59f5e75f3bced8fc0e130d72a3f582cf7b480b46",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://lists.apache.org/thread.html/r18995de860f0e63635f3008fd2a6aca82394249476d21691e7c59c9e@%3Cdev.tomcat.apache.org%3E",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://lists.apache.org/thread.html/rad5d9f83f0d11fb3f8bb148d179b8a9ad7c6a17f18d70e5805a713d1@%3Cdev.tomcat.apache.org%3E",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://security.netapp.com/advisory/ntap-20210827-0010/",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://security.netapp.com/advisory/ntap-20211022-0003/",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://ubuntu.com/security/notices/USN-5051-1",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://www.debian.org/security/2021/dsa-4963",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://www.openssl.org/news/secadv/20210824.txt",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://www.oracle.com/security-alerts/cpuoct2021.html",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://www.tenable.com/security/tns-2021-16",
       },
     ],
@@ -1605,143 +1605,143 @@ exports[`parses bkimminich/juice-shop:v10.2.0 result file into findings 1`] = `
         "value": "CVE-2020-1967",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://nvd.nist.gov/vuln/detail/CVE-2020-1967",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "http://lists.opensuse.org/opensuse-security-announce/2020-07/msg00004.html",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "http://lists.opensuse.org/opensuse-security-announce/2020-07/msg00011.html",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "http://packetstormsecurity.com/files/157527/OpenSSL-signature_algorithms_cert-Denial-Of-Service.html",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "http://seclists.org/fulldisclosure/2020/May/5",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "http://www.openwall.com/lists/oss-security/2020/04/22/2",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2020-1967",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://git.openssl.org/gitweb/?p=openssl.git;a=commitdiff;h=eb563247aef3e83dda7679c43f9649270462e5b1",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://github.com/irsl/CVE-2020-1967",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://kb.pulsesecure.net/articles/Pulse_Security_Advisories/SA44440",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://lists.apache.org/thread.html/r66ea9c436da150683432db5fbc8beb8ae01886c6459ac30c2cea7345@%3Cdev.tomcat.apache.org%3E",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://lists.apache.org/thread.html/r94d6ac3f010a38fccf4f432b12180a13fa1cf303559bd805648c9064@%3Cdev.tomcat.apache.org%3E",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://lists.apache.org/thread.html/r9a41e304992ce6aec6585a87842b4f2e692604f5c892c37e3b0587ee@%3Cdev.tomcat.apache.org%3E",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://lists.fedoraproject.org/archives/list/package-announce@lists.fedoraproject.org/message/DDHOAATPWJCXRNFMJ2SASDBBNU5RJONY/",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://lists.fedoraproject.org/archives/list/package-announce@lists.fedoraproject.org/message/EXDDAOWSAIEFQNBHWYE6PPYFV4QXGMCD/",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://lists.fedoraproject.org/archives/list/package-announce@lists.fedoraproject.org/message/XVEP3LAK4JSPRXFO4QF4GG2IVXADV3SO/",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://nvd.nist.gov/vuln/detail/CVE-2020-1967",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://security.FreeBSD.org/advisories/FreeBSD-SA-20:11.openssl.asc",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://security.gentoo.org/glsa/202004-10",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://security.netapp.com/advisory/ntap-20200424-0003/",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://security.netapp.com/advisory/ntap-20200717-0004/",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://www.debian.org/security/2020/dsa-4661",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://www.openssl.org/news/secadv/20200421.txt",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://www.oracle.com//security-alerts/cpujul2021.html",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://www.oracle.com/security-alerts/cpuApr2021.html",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://www.oracle.com/security-alerts/cpujan2021.html",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://www.oracle.com/security-alerts/cpujul2020.html",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://www.oracle.com/security-alerts/cpuoct2020.html",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://www.oracle.com/security-alerts/cpuoct2021.html",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://www.synology.com/security/advisory/Synology_SA_20_05",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://www.synology.com/security/advisory/Synology_SA_20_05_OpenSSL",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://www.tenable.com/security/tns-2020-03",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://www.tenable.com/security/tns-2020-04",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://www.tenable.com/security/tns-2020-11",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://www.tenable.com/security/tns-2021-10",
       },
     ],
@@ -1790,91 +1790,91 @@ exports[`parses bkimminich/juice-shop:v10.2.0 result file into findings 1`] = `
         "value": "CVE-2021-23840",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://nvd.nist.gov/vuln/detail/CVE-2021-23840",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2021-23840",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://git.openssl.org/gitweb/?p=openssl.git;a=commitdiff;h=6a51b9e1d0cf0bf8515f7201b68fb0a3482b3dc1",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://git.openssl.org/gitweb/?p=openssl.git;a=commitdiff;h=9b1129239f3ebb1d1c98ce9ed41d5c9476c47cb2",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://kb.pulsesecure.net/articles/Pulse_Security_Advisories/SA44846",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://kc.mcafee.com/corporate/index?page=content&id=SB10366",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://linux.oracle.com/cve/CVE-2021-23840.html",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://linux.oracle.com/errata/ELSA-2021-9528.html",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://lists.apache.org/thread.html/r58af02e294bd07f487e2c64ffc0a29b837db5600e33b6e698b9d696b@%3Cissues.bookkeeper.apache.org%3E",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://lists.apache.org/thread.html/rf4c02775860db415b4955778a131c2795223f61cb8c6a450893651e4@%3Cissues.bookkeeper.apache.org%3E",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://security.gentoo.org/glsa/202103-03",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://security.netapp.com/advisory/ntap-20210219-0009/",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://ubuntu.com/security/notices/USN-4738-1",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://ubuntu.com/security/notices/USN-5088-1",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://www.debian.org/security/2021/dsa-4855",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://www.openssl.org/news/secadv/20210216.txt",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://www.oracle.com//security-alerts/cpujul2021.html",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://www.oracle.com/security-alerts/cpuApr2021.html",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://www.oracle.com/security-alerts/cpuoct2021.html",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://www.tenable.com/security/tns-2021-03",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://www.tenable.com/security/tns-2021-09",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://www.tenable.com/security/tns-2021-10",
       },
     ],
@@ -1925,99 +1925,99 @@ exports[`parses bkimminich/juice-shop:v10.2.0 result file into findings 1`] = `
         "value": "CVE-2021-3450",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://nvd.nist.gov/vuln/detail/CVE-2021-3450",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "http://www.openwall.com/lists/oss-security/2021/03/27/1",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "http://www.openwall.com/lists/oss-security/2021/03/27/2",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "http://www.openwall.com/lists/oss-security/2021/03/28/3",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "http://www.openwall.com/lists/oss-security/2021/03/28/4",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://git.openssl.org/gitweb/?p=openssl.git;a=commitdiff;h=2a40b7bc7b94dd7de897a74571e7024f0cf0d63b",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://kb.pulsesecure.net/articles/Pulse_Security_Advisories/SA44845",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://kc.mcafee.com/corporate/index?page=content&id=SB10356",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://linux.oracle.com/cve/CVE-2021-3450.html",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://linux.oracle.com/errata/ELSA-2021-9151.html",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://lists.fedoraproject.org/archives/list/package-announce@lists.fedoraproject.org/message/CCBFLLVQVILIVGZMBJL3IXZGKWQISYNP/",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://mta.openssl.org/pipermail/openssl-announce/2021-March/000198.html",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://psirt.global.sonicwall.com/vuln-detail/SNWLID-2021-0013",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://security.FreeBSD.org/advisories/FreeBSD-SA-21:07.openssl.asc",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://security.gentoo.org/glsa/202103-03",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://security.netapp.com/advisory/ntap-20210326-0006/",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://tools.cisco.com/security/center/content/CiscoSecurityAdvisory/cisco-sa-openssl-2021-GHY28dJd",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://www.openssl.org/news/secadv/20210325.txt",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://www.oracle.com//security-alerts/cpujul2021.html",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://www.oracle.com/security-alerts/cpuApr2021.html",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://www.oracle.com/security-alerts/cpuoct2021.html",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://www.tenable.com/security/tns-2021-05",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://www.tenable.com/security/tns-2021-08",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://www.tenable.com/security/tns-2021-09",
       },
     ],
@@ -2064,83 +2064,83 @@ exports[`parses bkimminich/juice-shop:v10.2.0 result file into findings 1`] = `
         "value": "CVE-2021-3712",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://nvd.nist.gov/vuln/detail/CVE-2021-3712",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "http://www.openwall.com/lists/oss-security/2021/08/26/2",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2021-3712",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://git.openssl.org/gitweb/?p=openssl.git;a=commitdiff;h=94d23fcff9b2a7a8368dfe52214d5c2569882c11",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://git.openssl.org/gitweb/?p=openssl.git;a=commitdiff;h=ccb0a11145ee72b042d10593a64eaf9e8a55ec12",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://kc.mcafee.com/corporate/index?page=content&id=SB10366",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://lists.apache.org/thread.html/r18995de860f0e63635f3008fd2a6aca82394249476d21691e7c59c9e@%3Cdev.tomcat.apache.org%3E",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://lists.apache.org/thread.html/rad5d9f83f0d11fb3f8bb148d179b8a9ad7c6a17f18d70e5805a713d1@%3Cdev.tomcat.apache.org%3E",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://lists.debian.org/debian-lts-announce/2021/09/msg00014.html",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://lists.debian.org/debian-lts-announce/2021/09/msg00021.html",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://security.netapp.com/advisory/ntap-20210827-0010/",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://ubuntu.com/security/notices/USN-5051-1",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://ubuntu.com/security/notices/USN-5051-2",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://ubuntu.com/security/notices/USN-5051-3",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://ubuntu.com/security/notices/USN-5051-4 (regression only in trusty/esm)",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://ubuntu.com/security/notices/USN-5088-1",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://www.debian.org/security/2021/dsa-4963",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://www.openssl.org/news/secadv/20210824.txt",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://www.oracle.com/security-alerts/cpuoct2021.html",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://www.tenable.com/security/tns-2021-16",
       },
     ],
@@ -2196,119 +2196,119 @@ exports[`parses bkimminich/juice-shop:v10.2.0 result file into findings 1`] = `
         "value": "CVE-2020-1971",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://nvd.nist.gov/vuln/detail/CVE-2020-1971",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "http://www.openwall.com/lists/oss-security/2021/09/14/2",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2020-1971",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://git.openssl.org/gitweb/?p=openssl.git;a=commitdiff;h=2154ab83e14ede338d2ede9bbe5cdfce5d5a6c9e",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://git.openssl.org/gitweb/?p=openssl.git;a=commitdiff;h=f960d81215ebf3f65e03d4d5d857fb9b666d6920",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://kb.pulsesecure.net/articles/Pulse_Security_Advisories/SA44676",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://linux.oracle.com/cve/CVE-2020-1971.html",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://linux.oracle.com/errata/ELSA-2021-9150.html",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://lists.apache.org/thread.html/r63c6f2dd363d9b514d0a4bcf624580616a679898cc14c109a49b750c@%3Cdev.tomcat.apache.org%3E",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://lists.apache.org/thread.html/rbb769f771711fb274e0a4acb1b5911c8aab544a6ac5e8c12d40c5143@%3Ccommits.pulsar.apache.org%3E",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://lists.debian.org/debian-lts-announce/2020/12/msg00020.html",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://lists.debian.org/debian-lts-announce/2020/12/msg00021.html",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://lists.fedoraproject.org/archives/list/package-announce@lists.fedoraproject.org/message/DGSI34Y5LQ5RYXN4M2I5ZQT65LFVDOUU/",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://lists.fedoraproject.org/archives/list/package-announce@lists.fedoraproject.org/message/PWPSSZNZOBJU2YR6Z4TGHXKYW3YP5QG7/",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://security.FreeBSD.org/advisories/FreeBSD-SA-20:33.openssl.asc",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://security.gentoo.org/glsa/202012-13",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://security.netapp.com/advisory/ntap-20201218-0005/",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://security.netapp.com/advisory/ntap-20210513-0002/",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://ubuntu.com/security/notices/USN-4662-1",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://ubuntu.com/security/notices/USN-4745-1",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://www.debian.org/security/2020/dsa-4807",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://www.openssl.org/news/secadv/20201208.txt",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://www.oracle.com//security-alerts/cpujul2021.html",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://www.oracle.com/security-alerts/cpuApr2021.html",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://www.oracle.com/security-alerts/cpujan2021.html",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://www.oracle.com/security-alerts/cpuoct2021.html",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://www.tenable.com/security/tns-2020-11",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://www.tenable.com/security/tns-2021-09",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://www.tenable.com/security/tns-2021-10",
       },
     ],
@@ -2360,103 +2360,103 @@ exports[`parses bkimminich/juice-shop:v10.2.0 result file into findings 1`] = `
         "value": "CVE-2021-23841",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://nvd.nist.gov/vuln/detail/CVE-2021-23841",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "http://seclists.org/fulldisclosure/2021/May/67",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "http://seclists.org/fulldisclosure/2021/May/68",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "http://seclists.org/fulldisclosure/2021/May/70",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2021-23841",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://git.openssl.org/gitweb/?p=openssl.git;a=commitdiff;h=122a19ab48091c657f7cb1fb3af9fc07bd557bbf",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://git.openssl.org/gitweb/?p=openssl.git;a=commitdiff;h=8252ee4d90f3f2004d3d0aeeed003ad49c9a7807",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://kb.pulsesecure.net/articles/Pulse_Security_Advisories/SA44846",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://linux.oracle.com/cve/CVE-2021-23841.html",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://linux.oracle.com/errata/ELSA-2021-9528.html",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://security.gentoo.org/glsa/202103-03",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://security.netapp.com/advisory/ntap-20210219-0009/",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://security.netapp.com/advisory/ntap-20210513-0002/",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://support.apple.com/kb/HT212528",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://support.apple.com/kb/HT212529",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://support.apple.com/kb/HT212534",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://ubuntu.com/security/notices/USN-4738-1",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://ubuntu.com/security/notices/USN-4745-1",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://www.debian.org/security/2021/dsa-4855",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://www.openssl.org/news/secadv/20210216.txt",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://www.oracle.com//security-alerts/cpujul2021.html",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://www.oracle.com/security-alerts/cpuApr2021.html",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://www.oracle.com/security-alerts/cpuoct2021.html",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://www.tenable.com/security/tns-2021-03",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://www.tenable.com/security/tns-2021-09",
       },
     ],
@@ -2514,127 +2514,127 @@ exports[`parses bkimminich/juice-shop:v10.2.0 result file into findings 1`] = `
         "value": "CVE-2021-3449",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://nvd.nist.gov/vuln/detail/CVE-2021-3449",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "http://www.openwall.com/lists/oss-security/2021/03/27/1",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "http://www.openwall.com/lists/oss-security/2021/03/27/2",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "http://www.openwall.com/lists/oss-security/2021/03/28/3",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "http://www.openwall.com/lists/oss-security/2021/03/28/4",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://cert-portal.siemens.com/productcert/pdf/ssa-772220.pdf",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2021-3449",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://git.openssl.org/gitweb/?p=openssl.git;a=commitdiff;h=fb9fa6b51defd48157eeb207f52181f735d96148",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://kb.pulsesecure.net/articles/Pulse_Security_Advisories/SA44845",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://kc.mcafee.com/corporate/index?page=content&id=SB10356",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://linux.oracle.com/cve/CVE-2021-3449.html",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://linux.oracle.com/errata/ELSA-2021-9151.html",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://lists.debian.org/debian-lts-announce/2021/08/msg00029.html",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://lists.fedoraproject.org/archives/list/package-announce@lists.fedoraproject.org/message/CCBFLLVQVILIVGZMBJL3IXZGKWQISYNP/",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://psirt.global.sonicwall.com/vuln-detail/SNWLID-2021-0013",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://security.FreeBSD.org/advisories/FreeBSD-SA-21:07.openssl.asc",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://security.gentoo.org/glsa/202103-03",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://security.netapp.com/advisory/ntap-20210326-0006/",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://security.netapp.com/advisory/ntap-20210513-0002/",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://tools.cisco.com/security/center/content/CiscoSecurityAdvisory/cisco-sa-openssl-2021-GHY28dJd",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://ubuntu.com/security/notices/USN-4891-1",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://ubuntu.com/security/notices/USN-5038-1",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://www.debian.org/security/2021/dsa-4875",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://www.openssl.org/news/secadv/20210325.txt",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://www.oracle.com//security-alerts/cpujul2021.html",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://www.oracle.com/security-alerts/cpuApr2021.html",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://www.oracle.com/security-alerts/cpuoct2021.html",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://www.tenable.com/security/tns-2021-05",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://www.tenable.com/security/tns-2021-06",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://www.tenable.com/security/tns-2021-09",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://www.tenable.com/security/tns-2021-10",
       },
     ],
@@ -2669,35 +2669,35 @@ exports[`parses bkimminich/juice-shop:v10.2.0 result file into findings 1`] = `
         "value": "CVE-2021-23839",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://nvd.nist.gov/vuln/detail/CVE-2021-23839",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://git.openssl.org/gitweb/?p=openssl.git;a=commitdiff;h=30919ab80a478f2d81f2e9acdcca3fa4740cd547",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://kb.pulsesecure.net/articles/Pulse_Security_Advisories/SA44846",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://security.netapp.com/advisory/ntap-20210219-0009/",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://www.openssl.org/news/secadv/20210216.txt",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://www.oracle.com//security-alerts/cpujul2021.html",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://www.oracle.com/security-alerts/cpuApr2021.html",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://www.oracle.com/security-alerts/cpuoct2021.html",
       },
     ],
@@ -2731,31 +2731,31 @@ exports[`parses bkimminich/juice-shop:v10.2.0 result file into findings 1`] = `
         "value": "CVE-2019-15847",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://nvd.nist.gov/vuln/detail/CVE-2019-15847",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "http://lists.opensuse.org/opensuse-security-announce/2019-10/msg00056.html",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "http://lists.opensuse.org/opensuse-security-announce/2019-10/msg00057.html",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "http://lists.opensuse.org/opensuse-security-announce/2020-05/msg00058.html",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://gcc.gnu.org/bugzilla/show_bug.cgi?id=91481",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://linux.oracle.com/cve/CVE-2019-15847.html",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://linux.oracle.com/errata/ELSA-2020-1864.html",
       },
     ],
@@ -2793,47 +2793,47 @@ exports[`parses bkimminich/juice-shop:v10.2.0 result file into findings 1`] = `
         "value": "CVE-2020-28928",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://nvd.nist.gov/vuln/detail/CVE-2020-28928",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "http://www.openwall.com/lists/oss-security/2020/11/20/4",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://lists.apache.org/thread.html/r2134abfe847bea7795f0e53756d10a47e6643f35ab8169df8b8a9eb1@%3Cnotifications.apisix.apache.org%3E",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://lists.apache.org/thread.html/r90b60cf49348e515257b4950900c1bd3ab95a960cf2469d919c7264e@%3Cnotifications.apisix.apache.org%3E",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://lists.apache.org/thread.html/ra63e8dc5137d952afc55dbbfa63be83304ecf842d1eab1ff3ebb29e2@%3Cnotifications.apisix.apache.org%3E",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://lists.debian.org/debian-lts-announce/2020/11/msg00050.html",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://lists.fedoraproject.org/archives/list/package-announce@lists.fedoraproject.org/message/LKQ3RVSMVZNZNO4D65W2CZZ4DMYFZN2Q/",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://lists.fedoraproject.org/archives/list/package-announce@lists.fedoraproject.org/message/UW27QVY7ERPTSGKS4KAWE5TU7EJWHKVQ/",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://musl.libc.org/releases.html",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://www.oracle.com//security-alerts/cpujul2021.html",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://www.oracle.com/security-alerts/cpuoct2021.html",
       },
     ],
@@ -2871,47 +2871,47 @@ exports[`parses bkimminich/juice-shop:v10.2.0 result file into findings 1`] = `
         "value": "CVE-2020-28928",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://nvd.nist.gov/vuln/detail/CVE-2020-28928",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "http://www.openwall.com/lists/oss-security/2020/11/20/4",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://lists.apache.org/thread.html/r2134abfe847bea7795f0e53756d10a47e6643f35ab8169df8b8a9eb1@%3Cnotifications.apisix.apache.org%3E",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://lists.apache.org/thread.html/r90b60cf49348e515257b4950900c1bd3ab95a960cf2469d919c7264e@%3Cnotifications.apisix.apache.org%3E",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://lists.apache.org/thread.html/ra63e8dc5137d952afc55dbbfa63be83304ecf842d1eab1ff3ebb29e2@%3Cnotifications.apisix.apache.org%3E",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://lists.debian.org/debian-lts-announce/2020/11/msg00050.html",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://lists.fedoraproject.org/archives/list/package-announce@lists.fedoraproject.org/message/LKQ3RVSMVZNZNO4D65W2CZZ4DMYFZN2Q/",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://lists.fedoraproject.org/archives/list/package-announce@lists.fedoraproject.org/message/UW27QVY7ERPTSGKS4KAWE5TU7EJWHKVQ/",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://musl.libc.org/releases.html",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://www.oracle.com//security-alerts/cpujul2021.html",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://www.oracle.com/security-alerts/cpuoct2021.html",
       },
     ],
@@ -2946,35 +2946,35 @@ exports[`parses bkimminich/juice-shop:v10.2.0 result file into findings 1`] = `
         "value": "CVE-2021-28831",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://nvd.nist.gov/vuln/detail/CVE-2021-28831",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2021-28831",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://git.busybox.net/busybox/commit/?id=f25d254dfd4243698c31a4f3153d4ac72aa9e9bd",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://lists.debian.org/debian-lts-announce/2021/04/msg00001.html",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://lists.fedoraproject.org/archives/list/package-announce@lists.fedoraproject.org/message/3UDQGJRECXFS5EZVDH2OI45FMO436AC4/",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://lists.fedoraproject.org/archives/list/package-announce@lists.fedoraproject.org/message/Z7ZIFKPRR32ZYA3WAA2NXFA3QHHOU6FJ/",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://lists.fedoraproject.org/archives/list/package-announce@lists.fedoraproject.org/message/ZASBW7QRRLY5V2R44MQ4QQM4CZIDHM2U/",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://security.gentoo.org/glsa/202105-09",
       },
     ],
@@ -3006,23 +3006,23 @@ exports[`parses bkimminich/juice-shop:v10.2.0 result file into findings 1`] = `
         "value": "CVE-2021-3807",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://nvd.nist.gov/vuln/detail/CVE-2021-3807",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://github.com/advisories/GHSA-93q8-gq69-wqmw",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://github.com/chalk/ansi-regex/commit/8d1d7cdb586269882c4bdc1b7325d0c58c8f76f9",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://huntr.dev/bounties/5b3cf33b-ede0-4398-9974-800876dfd994",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://nvd.nist.gov/vuln/detail/CVE-2021-3807",
       },
     ],
@@ -3054,23 +3054,23 @@ exports[`parses bkimminich/juice-shop:v10.2.0 result file into findings 1`] = `
         "value": "CVE-2021-3807",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://nvd.nist.gov/vuln/detail/CVE-2021-3807",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://github.com/advisories/GHSA-93q8-gq69-wqmw",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://github.com/chalk/ansi-regex/commit/8d1d7cdb586269882c4bdc1b7325d0c58c8f76f9",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://huntr.dev/bounties/5b3cf33b-ede0-4398-9974-800876dfd994",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://nvd.nist.gov/vuln/detail/CVE-2021-3807",
       },
     ],
@@ -3100,15 +3100,15 @@ exports[`parses bkimminich/juice-shop:v10.2.0 result file into findings 1`] = `
         "value": "NSWG-ECO-428",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://github.com/nodejs/security-wg/tree/master/vuln",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://github.com/brianloveswords/base64url/pull/25",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://hackerone.com/reports/321687",
       },
     ],
@@ -3139,11 +3139,11 @@ Update to version 3.0.0 or later.",
     "osi_layer": "NOT_APPLICABLE",
     "references": [
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://github.com/advisories/GHSA-rvg8-pwq2-xj7q",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://github.com/brianloveswords/base64url/pull/25",
       },
     ],
@@ -3177,31 +3177,31 @@ Update to version 3.0.0 or later.",
         "value": "CVE-2020-8244",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://nvd.nist.gov/vuln/detail/CVE-2020-8244",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2020-8244",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://github.com/advisories/GHSA-pp7h-53gx-mx7r",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://github.com/rvagg/bl/commit/d3e240e3b8ba4048d3c76ef5fb9dd1f8872d3190",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://hackerone.com/reports/966347",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://nvd.nist.gov/vuln/detail/CVE-2020-8244",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://ubuntu.com/security/notices/USN-5098-1",
       },
     ],
@@ -3235,31 +3235,31 @@ Update to version 3.0.0 or later.",
         "value": "CVE-2020-8244",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://nvd.nist.gov/vuln/detail/CVE-2020-8244",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2020-8244",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://github.com/advisories/GHSA-pp7h-53gx-mx7r",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://github.com/rvagg/bl/commit/d3e240e3b8ba4048d3c76ef5fb9dd1f8872d3190",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://hackerone.com/reports/966347",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://nvd.nist.gov/vuln/detail/CVE-2020-8244",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://ubuntu.com/security/notices/USN-5098-1",
       },
     ],
@@ -3294,35 +3294,35 @@ Update to version 3.0.0 or later.",
         "value": "CVE-2021-29060",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://nvd.nist.gov/vuln/detail/CVE-2021-29060",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://github.com/Qix-/color-string/commit/0789e21284c33d89ebc4ab4ca6f759b9375ac9d3",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://github.com/advisories/GHSA-257v-vj4p-3w2h",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://github.com/yetingli/PoCs/blob/main/CVE-2021-29060/Color-String.md",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://github.com/yetingli/SaveResults/blob/main/js/color-string.js",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://nvd.nist.gov/vuln/detail/CVE-2021-29060",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://snyk.io/vuln/SNYK-JS-COLORSTRING-1082939",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://www.npmjs.com/package/color-string",
       },
     ],
@@ -3348,11 +3348,11 @@ Update to version 3.0.0 or later.",
     "osi_layer": "NOT_APPLICABLE",
     "references": [
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://github.com/advisories/GHSA-h6ch-v84p-w6p9",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://github.com/kpdecker/jsdiff/commit/2aec4298639bf30fb88a00b356bf404d3551b8c0",
       },
     ],
@@ -3387,35 +3387,35 @@ Update to version 3.0.0 or later.",
         "value": "CVE-2020-8116",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://nvd.nist.gov/vuln/detail/CVE-2020-8116",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://github.com/advisories/GHSA-ff7x-qrg7-qggm",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://github.com/sindresorhus/dot-prop/issues/63",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://github.com/sindresorhus/dot-prop/tree/v4",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://hackerone.com/reports/719856",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://linux.oracle.com/cve/CVE-2020-8116.html",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://linux.oracle.com/errata/ELSA-2021-0548.html",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://nvd.nist.gov/vuln/detail/CVE-2020-8116",
       },
     ],
@@ -3447,23 +3447,23 @@ Update to version 3.0.0 or later.",
         "value": "CVE-2020-15084",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://nvd.nist.gov/vuln/detail/CVE-2020-15084",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://github.com/advisories/GHSA-6g6m-m6h5-w9gf",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://github.com/auth0/express-jwt/commit/7ecab5f8f0cab5297c2b863596566eb0c019cdef",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://github.com/auth0/express-jwt/security/advisories/GHSA-6g6m-m6h5-w9gf",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://nvd.nist.gov/vuln/detail/CVE-2020-15084",
       },
     ],
@@ -3495,23 +3495,23 @@ Update to version 3.0.0 or later.",
         "value": "CVE-2020-28282",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://nvd.nist.gov/vuln/detail/CVE-2020-28282",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://github.com/advisories/GHSA-957j-59c2-j692",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://github.com/cowboy/node-getobject/blob/aba04a8e1d6180eb39eff09990c3a43886ba8937/lib/getobject.js#L48",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://nvd.nist.gov/vuln/detail/CVE-2020-28282",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://www.whitesourcesoftware.com/vulnerability-database/CVE-2020-28282",
       },
     ],
@@ -3545,31 +3545,31 @@ Update to version 3.0.0 or later.",
         "value": "CVE-2017-16042",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://nvd.nist.gov/vuln/detail/CVE-2017-16042",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2017-16042",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://github.com/advisories/GHSA-qh2h-chj9-jffq",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://github.com/tj/node-growl/issues/60",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://github.com/tj/node-growl/pull/61",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://nodesecurity.io/advisories/146",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://nvd.nist.gov/vuln/detail/CVE-2017-16042",
       },
     ],
@@ -3607,47 +3607,47 @@ Update to version 3.0.0 or later.",
         "value": "CVE-2020-7729",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://nvd.nist.gov/vuln/detail/CVE-2020-7729",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2020-7729",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://github.com/advisories/GHSA-m5pj-vjjf-4m3h",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://github.com/gruntjs/grunt/blob/master/lib/grunt/file.js%23L249",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://github.com/gruntjs/grunt/commit/e350cea1724eb3476464561a380fb6a64e61e4e7",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://lists.debian.org/debian-lts-announce/2020/09/msg00008.html",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://nvd.nist.gov/vuln/detail/CVE-2020-7729",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://snyk.io/vuln/SNYK-JAVA-ORGWEBJARSNPM-607922",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://snyk.io/vuln/SNYK-JS-GRUNT-597546",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://ubuntu.com/security/notices/USN-4595-1",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://usn.ubuntu.com/4595-1/",
       },
     ],
@@ -3685,47 +3685,47 @@ Update to version 3.0.0 or later.",
         "value": "CVE-2021-23362",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://nvd.nist.gov/vuln/detail/CVE-2021-23362",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://github.com/advisories/GHSA-43f8-2h32-f4cj",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://github.com/npm/hosted-git-info/commit/29adfe5ef789784c861b2cdeb15051ec2ba651a7",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://github.com/npm/hosted-git-info/commit/8d4b3697d79bcd89cdb36d1db165e3696c783a01",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://github.com/npm/hosted-git-info/commit/bede0dc38e1785e732bf0a48ba6f81a4a908eba3",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://github.com/npm/hosted-git-info/commits/v2",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://linux.oracle.com/cve/CVE-2021-23362.html",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://linux.oracle.com/errata/ELSA-2021-3074.html",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://nvd.nist.gov/vuln/detail/CVE-2021-23362",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://snyk.io/vuln/SNYK-JAVA-ORGWEBJARSNPM-1088356",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://snyk.io/vuln/SNYK-JS-HOSTEDGITINFO-1088355",
       },
     ],
@@ -3762,43 +3762,43 @@ Update to version 3.0.0 or later.",
         "value": "CVE-2020-7788",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://nvd.nist.gov/vuln/detail/CVE-2020-7788",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2020-7788",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://github.com/advisories/GHSA-qqgx-2p2h-9c37",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://github.com/npm/ini/commit/56d2805e07ccd94e2ba0984ac9240ff02d44b6f1",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://github.com/npm/ini/commit/56d2805e07ccd94e2ba0984ac9240ff02d44b6f1 (v1.3.6)",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://linux.oracle.com/cve/CVE-2020-7788.html",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://linux.oracle.com/errata/ELSA-2021-0551.html",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://lists.debian.org/debian-lts-announce/2020/12/msg00032.html",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://nvd.nist.gov/vuln/detail/CVE-2020-7788",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://snyk.io/vuln/SNYK-JS-INI-1048974",
       },
     ],
@@ -3832,31 +3832,31 @@ Update to version 3.0.0 or later.",
         "value": "CVE-2015-9235",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://nvd.nist.gov/vuln/detail/CVE-2015-9235",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://auth0.com/blog/2015/03/31/critical-vulnerabilities-in-json-web-token-libraries/",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://github.com/advisories/GHSA-c7hr-j4mj-j2w6",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://github.com/auth0/node-jsonwebtoken/commit/1bb584bc382295eeb7ee8c4452a673a77a68b687",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://nodesecurity.io/advisories/17",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://nvd.nist.gov/vuln/detail/CVE-2015-9235",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://www.timmclean.net/2015/02/25/jwt-alg-none.html",
       },
     ],
@@ -3887,19 +3887,19 @@ Update to version 3.0.0 or later.",
         "value": "NSWG-ECO-17",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://github.com/nodejs/security-wg/tree/master/vuln",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://auth0.com/blog/2015/03/31/critical-vulnerabilities-in-json-web-token-libraries/",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://github.com/auth0/node-jsonwebtoken/commit/1bb584bc382295eeb7ee8c4452a673a77a68b687",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://www.timmclean.net/2015/02/25/jwt-alg-none.html",
       },
     ],
@@ -3933,31 +3933,31 @@ Update to version 3.0.0 or later.",
         "value": "CVE-2015-9235",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://nvd.nist.gov/vuln/detail/CVE-2015-9235",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://auth0.com/blog/2015/03/31/critical-vulnerabilities-in-json-web-token-libraries/",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://github.com/advisories/GHSA-c7hr-j4mj-j2w6",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://github.com/auth0/node-jsonwebtoken/commit/1bb584bc382295eeb7ee8c4452a673a77a68b687",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://nodesecurity.io/advisories/17",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://nvd.nist.gov/vuln/detail/CVE-2015-9235",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://www.timmclean.net/2015/02/25/jwt-alg-none.html",
       },
     ],
@@ -3988,19 +3988,19 @@ Update to version 3.0.0 or later.",
         "value": "NSWG-ECO-17",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://github.com/nodejs/security-wg/tree/master/vuln",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://auth0.com/blog/2015/03/31/critical-vulnerabilities-in-json-web-token-libraries/",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://github.com/auth0/node-jsonwebtoken/commit/1bb584bc382295eeb7ee8c4452a673a77a68b687",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://www.timmclean.net/2015/02/25/jwt-alg-none.html",
       },
     ],
@@ -4036,23 +4036,23 @@ In addition, there is the \`none\` algorithm to be concerned about.  In versions
         "value": "CVE-2016-1000223",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://nvd.nist.gov/vuln/detail/CVE-2016-1000223",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://auth0.com/blog/2015/03/31/critical-vulnerabilities-in-json-web-token-libraries/",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://github.com/advisories/GHSA-gjcw-v447-2w7q",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://github.com/brianloveswords/node-jws/commit/585d0e1e97b6747c10cf5b7689ccc5618a89b299#diff-4ac32a78649ca5bdd8e0ba38b7006a1e",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://nvd.nist.gov/vuln/detail/CVE-2016-1000223",
       },
     ],
@@ -4088,39 +4088,39 @@ In addition, there is the \`none\` algorithm to be concerned about.  In versions
         "value": "CVE-2019-10744",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://nvd.nist.gov/vuln/detail/CVE-2019-10744",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://access.redhat.com/errata/RHSA-2019:3024",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://github.com/advisories/GHSA-jf85-cpcp-j695",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://nvd.nist.gov/vuln/detail/CVE-2019-10744",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://security.netapp.com/advisory/ntap-20191004-0005/",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://snyk.io/vuln/SNYK-JS-LODASH-450202",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://support.f5.com/csp/article/K47105354?utm_source=f5support&amp;utm_medium=RSS",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://www.oracle.com/security-alerts/cpujan2021.html",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://www.oracle.com/security-alerts/cpuoct2020.html",
       },
     ],
@@ -4157,43 +4157,43 @@ In addition, there is the \`none\` algorithm to be concerned about.  In versions
         "value": "CVE-2020-8203",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://nvd.nist.gov/vuln/detail/CVE-2020-8203",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://github.com/advisories/GHSA-p6mc-m468-83gw",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://github.com/lodash/lodash/issues/4874",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://hackerone.com/reports/712065",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://nvd.nist.gov/vuln/detail/CVE-2020-8203",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://security.netapp.com/advisory/ntap-20200724-0006/",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://www.npmjs.com/advisories/1523",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://www.oracle.com//security-alerts/cpujul2021.html",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://www.oracle.com/security-alerts/cpuApr2021.html",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://www.oracle.com/security-alerts/cpuoct2021.html",
       },
     ],
@@ -4234,59 +4234,59 @@ In addition, there is the \`none\` algorithm to be concerned about.  In versions
         "value": "CVE-2021-23337",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://nvd.nist.gov/vuln/detail/CVE-2021-23337",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2021-23337",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://github.com/advisories/GHSA-35jh-r3h4-6jhm",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://github.com/lodash/lodash/blob/ddfd9b11a0126db2302cb70ec9973b66baec0975/lodash.js%23L14851",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://nvd.nist.gov/vuln/detail/CVE-2021-23337",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://security.netapp.com/advisory/ntap-20210312-0006/",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://snyk.io/vuln/SNYK-JAVA-ORGFUJIONWEBJARS-1074932",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://snyk.io/vuln/SNYK-JAVA-ORGWEBJARS-1074930",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://snyk.io/vuln/SNYK-JAVA-ORGWEBJARSBOWER-1074928",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://snyk.io/vuln/SNYK-JAVA-ORGWEBJARSBOWERGITHUBLODASH-1074931",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://snyk.io/vuln/SNYK-JAVA-ORGWEBJARSNPM-1074929",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://snyk.io/vuln/SNYK-JS-LODASH-1040724",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://www.oracle.com//security-alerts/cpujul2021.html",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://www.oracle.com/security-alerts/cpuoct2021.html",
       },
     ],
@@ -4319,27 +4319,27 @@ In addition, there is the \`none\` algorithm to be concerned about.  In versions
         "value": "CVE-2018-16487",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://nvd.nist.gov/vuln/detail/CVE-2018-16487",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2018-16487",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://github.com/advisories/GHSA-4xc9-xhrj-v574",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://hackerone.com/reports/380873",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://nvd.nist.gov/vuln/detail/CVE-2018-16487",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://security.netapp.com/advisory/ntap-20190919-0004/",
       },
     ],
@@ -4375,39 +4375,39 @@ In addition, there is the \`none\` algorithm to be concerned about.  In versions
         "value": "CVE-2018-3721",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://nvd.nist.gov/vuln/detail/CVE-2018-3721",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2018-3721",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://github.com/advisories/GHSA-fvqr-27wr-82fm",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://github.com/lodash/lodash/commit/d8e069cc3410082e44eb18fcf8e7f3d08ebe1d4a",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://hackerone.com/reports/310443",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://nvd.nist.gov/vuln/detail/CVE-2018-3721",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://security.netapp.com/advisory/ntap-20190919-0004/",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://snyk.io/vuln/npm:lodash:20180130",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://www.npmjs.com/advisories/577",
       },
     ],
@@ -4442,35 +4442,35 @@ In addition, there is the \`none\` algorithm to be concerned about.  In versions
         "value": "CVE-2019-1010266",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://nvd.nist.gov/vuln/detail/CVE-2019-1010266",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2019-1010266",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://github.com/advisories/GHSA-x5rq-j2xg-h7qm",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://github.com/lodash/lodash/issues/3359",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://github.com/lodash/lodash/wiki/Changelog",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://nvd.nist.gov/vuln/detail/CVE-2019-1010266",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://security.netapp.com/advisory/ntap-20190919-0004/",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://snyk.io/vuln/SNYK-JS-LODASH-73639",
       },
     ],
@@ -4506,39 +4506,39 @@ In addition, there is the \`none\` algorithm to be concerned about.  In versions
         "value": "CVE-2019-10744",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://nvd.nist.gov/vuln/detail/CVE-2019-10744",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://access.redhat.com/errata/RHSA-2019:3024",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://github.com/advisories/GHSA-jf85-cpcp-j695",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://nvd.nist.gov/vuln/detail/CVE-2019-10744",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://security.netapp.com/advisory/ntap-20191004-0005/",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://snyk.io/vuln/SNYK-JS-LODASH-450202",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://support.f5.com/csp/article/K47105354?utm_source=f5support&amp;utm_medium=RSS",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://www.oracle.com/security-alerts/cpujan2021.html",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://www.oracle.com/security-alerts/cpuoct2020.html",
       },
     ],
@@ -4575,43 +4575,43 @@ In addition, there is the \`none\` algorithm to be concerned about.  In versions
         "value": "CVE-2020-8203",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://nvd.nist.gov/vuln/detail/CVE-2020-8203",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://github.com/advisories/GHSA-p6mc-m468-83gw",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://github.com/lodash/lodash/issues/4874",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://hackerone.com/reports/712065",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://nvd.nist.gov/vuln/detail/CVE-2020-8203",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://security.netapp.com/advisory/ntap-20200724-0006/",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://www.npmjs.com/advisories/1523",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://www.oracle.com//security-alerts/cpujul2021.html",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://www.oracle.com/security-alerts/cpuApr2021.html",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://www.oracle.com/security-alerts/cpuoct2021.html",
       },
     ],
@@ -4652,59 +4652,59 @@ In addition, there is the \`none\` algorithm to be concerned about.  In versions
         "value": "CVE-2021-23337",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://nvd.nist.gov/vuln/detail/CVE-2021-23337",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2021-23337",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://github.com/advisories/GHSA-35jh-r3h4-6jhm",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://github.com/lodash/lodash/blob/ddfd9b11a0126db2302cb70ec9973b66baec0975/lodash.js%23L14851",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://nvd.nist.gov/vuln/detail/CVE-2021-23337",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://security.netapp.com/advisory/ntap-20210312-0006/",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://snyk.io/vuln/SNYK-JAVA-ORGFUJIONWEBJARS-1074932",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://snyk.io/vuln/SNYK-JAVA-ORGWEBJARS-1074930",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://snyk.io/vuln/SNYK-JAVA-ORGWEBJARSBOWER-1074928",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://snyk.io/vuln/SNYK-JAVA-ORGWEBJARSBOWERGITHUBLODASH-1074931",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://snyk.io/vuln/SNYK-JAVA-ORGWEBJARSNPM-1074929",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://snyk.io/vuln/SNYK-JS-LODASH-1040724",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://www.oracle.com//security-alerts/cpujul2021.html",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://www.oracle.com/security-alerts/cpuoct2021.html",
       },
     ],
@@ -4741,43 +4741,43 @@ In addition, there is the \`none\` algorithm to be concerned about.  In versions
         "value": "CVE-2020-8203",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://nvd.nist.gov/vuln/detail/CVE-2020-8203",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://github.com/advisories/GHSA-p6mc-m468-83gw",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://github.com/lodash/lodash/issues/4874",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://hackerone.com/reports/712065",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://nvd.nist.gov/vuln/detail/CVE-2020-8203",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://security.netapp.com/advisory/ntap-20200724-0006/",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://www.npmjs.com/advisories/1523",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://www.oracle.com//security-alerts/cpujul2021.html",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://www.oracle.com/security-alerts/cpuApr2021.html",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://www.oracle.com/security-alerts/cpuoct2021.html",
       },
     ],
@@ -4818,59 +4818,59 @@ In addition, there is the \`none\` algorithm to be concerned about.  In versions
         "value": "CVE-2021-23337",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://nvd.nist.gov/vuln/detail/CVE-2021-23337",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2021-23337",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://github.com/advisories/GHSA-35jh-r3h4-6jhm",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://github.com/lodash/lodash/blob/ddfd9b11a0126db2302cb70ec9973b66baec0975/lodash.js%23L14851",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://nvd.nist.gov/vuln/detail/CVE-2021-23337",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://security.netapp.com/advisory/ntap-20210312-0006/",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://snyk.io/vuln/SNYK-JAVA-ORGFUJIONWEBJARS-1074932",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://snyk.io/vuln/SNYK-JAVA-ORGWEBJARS-1074930",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://snyk.io/vuln/SNYK-JAVA-ORGWEBJARSBOWER-1074928",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://snyk.io/vuln/SNYK-JAVA-ORGWEBJARSBOWERGITHUBLODASH-1074931",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://snyk.io/vuln/SNYK-JAVA-ORGWEBJARSNPM-1074929",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://snyk.io/vuln/SNYK-JS-LODASH-1040724",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://www.oracle.com//security-alerts/cpujul2021.html",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://www.oracle.com/security-alerts/cpuoct2021.html",
       },
     ],
@@ -4901,19 +4901,19 @@ In addition, there is the \`none\` algorithm to be concerned about.  In versions
         "value": "NSWG-ECO-516",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://github.com/nodejs/security-wg/tree/master/vuln",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://github.com/lodash/lodash/pull/4759",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://hackerone.com/reports/712065",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://www.npmjs.com/advisories/1523",
       },
     ],
@@ -4944,11 +4944,11 @@ No fix is currently available. Consider using an alternative package until a fix
     "osi_layer": "NOT_APPLICABLE",
     "references": [
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://github.com/advisories/GHSA-5mrr-rgp6-x4gr",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://github.com/bkimminich/juice-shop/issues/1173",
       },
     ],
@@ -4982,31 +4982,31 @@ No fix is currently available. Consider using an alternative package until a fix
         "value": "CVE-2020-7598",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://nvd.nist.gov/vuln/detail/CVE-2020-7598",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "http://lists.opensuse.org/opensuse-security-announce/2020-06/msg00024.html",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://github.com/advisories/GHSA-vh95-rmgr-6w4m",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://linux.oracle.com/cve/CVE-2020-7598.html",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://linux.oracle.com/errata/ELSA-2020-2852.html",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://nvd.nist.gov/vuln/detail/CVE-2020-7598",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://snyk.io/vuln/SNYK-JS-MINIMIST-559764",
       },
     ],
@@ -5039,27 +5039,27 @@ No fix is currently available. Consider using an alternative package until a fix
         "value": "CVE-2017-18214",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://nvd.nist.gov/vuln/detail/CVE-2017-18214",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://github.com/advisories/GHSA-446m-mv8f-q348",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://github.com/moment/moment/issues/4163",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://nodesecurity.io/advisories/532",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://nvd.nist.gov/vuln/detail/CVE-2017-18214",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://www.tenable.com/security/tns-2019-02",
       },
     ],
@@ -5099,55 +5099,55 @@ No fix is currently available. Consider using an alternative package until a fix
         "value": "CVE-2016-4055",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://nvd.nist.gov/vuln/detail/CVE-2016-4055",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "http://www.openwall.com/lists/oss-security/2016/04/20/11",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "http://www.oracle.com/technetwork/security-advisory/cpujul2018-4258247.html",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "http://www.securityfocus.com/bid/95849",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://github.com/advisories/GHSA-87vv-r9j6-g5qv",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://lists.apache.org/thread.html/10f0f3aefd51444d1198c65f44ffdf2d78ca3359423dbc1c168c9731@%3Cdev.flink.apache.org%3E",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://lists.apache.org/thread.html/17ff53f7999e74fbe3cc0ceb4e1c3b00b180b7c5afec8e978837bc49@%3Cuser.flink.apache.org%3E",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://lists.apache.org/thread.html/52bafac05ad174000ea465fe275fd3cc7bd5c25535a7631c0bc9bfb2@%3Cuser.flink.apache.org%3E",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://lists.apache.org/thread.html/54df3aeb4239b64b50b356f0ca6f986e3c4ca5b84c515dce077c7854@%3Cuser.flink.apache.org%3E",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://nodesecurity.io/advisories/55",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://nvd.nist.gov/vuln/detail/CVE-2016-4055",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://www.owasp.org/index.php/Regular_expression_Denial_of_Service_-_ReDoS",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://www.tenable.com/security/tns-2019-02",
       },
     ],
@@ -5187,55 +5187,55 @@ No fix is currently available. Consider using an alternative package until a fix
         "value": "CVE-2020-15095",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://nvd.nist.gov/vuln/detail/CVE-2020-15095",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "http://lists.opensuse.org/opensuse-security-announce/2020-10/msg00011.html",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "http://lists.opensuse.org/opensuse-security-announce/2020-10/msg00015.html",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "http://lists.opensuse.org/opensuse-security-announce/2020-10/msg00023.html",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://github.com/advisories/GHSA-93f3-23rq-pjfp",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://github.com/npm/cli/blob/66aab417f836a901f8afb265251f761bb0422463/CHANGELOG.md#6146-2020-07-07",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://github.com/npm/cli/commit/a9857b8f6869451ff058789c4631fadfde5bbcbc",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://github.com/npm/cli/security/advisories/GHSA-93f3-23rq-pjfp",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://linux.oracle.com/cve/CVE-2020-15095.html",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://linux.oracle.com/errata/ELSA-2021-0548.html",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://lists.fedoraproject.org/archives/list/package-announce@lists.fedoraproject.org/message/4OOYAMJVLLCLXDTHW3V5UXNULZBBK4O6/",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://nvd.nist.gov/vuln/detail/CVE-2020-15095",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://security.gentoo.org/glsa/202101-07",
       },
     ],
@@ -5261,11 +5261,11 @@ No fix is currently available. Consider using an alternative package until a fix
     "osi_layer": "NOT_APPLICABLE",
     "references": [
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://github.com/advisories/GHSA-jmqm-f2gx-4fjv",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://github.com/npm/npm-registry-fetch/security/advisories/GHSA-jmqm-f2gx-4fjv",
       },
     ],
@@ -5301,39 +5301,39 @@ No fix is currently available. Consider using an alternative package until a fix
         "value": "CVE-2020-7754",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://nvd.nist.gov/vuln/detail/CVE-2020-7754",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://github.com/advisories/GHSA-pw54-mh39-w3hc",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://github.com/npm/npm-user-validate/commit/c8a87dac1a4cc6988b5418f30411a8669bef204e",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://github.com/npm/npm-user-validate/security/advisories/GHSA-xgh6-85xh-479p",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://linux.oracle.com/cve/CVE-2020-7754.html",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://linux.oracle.com/errata/ELSA-2021-0551.html",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://nvd.nist.gov/vuln/detail/CVE-2020-7754",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://snyk.io/vuln/SNYK-JAVA-ORGWEBJARSNPM-1019353",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://snyk.io/vuln/SNYK-JS-NPMUSERVALIDATE-1019352",
       },
     ],
@@ -5368,11 +5368,11 @@ Restrict the character length to a reasonable degree before passing a value to \
     "osi_layer": "NOT_APPLICABLE",
     "references": [
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://github.com/advisories/GHSA-xgh6-85xh-479p",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://github.com/npm/npm-user-validate/security/advisories/GHSA-xgh6-85xh-479p",
       },
     ],
@@ -5408,39 +5408,39 @@ Restrict the character length to a reasonable degree before passing a value to \
         "value": "CVE-2021-23343",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://nvd.nist.gov/vuln/detail/CVE-2021-23343",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://github.com/advisories/GHSA-hj48-42vr-x3v9",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://github.com/jbgutierrez/path-parse/issues/8",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://linux.oracle.com/cve/CVE-2021-23343.html",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://linux.oracle.com/errata/ELSA-2021-3666.html",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://lists.apache.org/thread.html/r6a32cb3eda3b19096ad48ef1e7aa8f26e005f2f63765abb69ce08b85@%3Cdev.myfaces.apache.org%3E",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://nvd.nist.gov/vuln/detail/CVE-2021-23343",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://snyk.io/vuln/SNYK-JAVA-ORGWEBJARSNPM-1279028",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://snyk.io/vuln/SNYK-JS-PATHPARSE-1077067",
       },
     ],
@@ -5477,43 +5477,43 @@ Restrict the character length to a reasonable degree before passing a value to \
         "value": "CVE-2021-21353",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://nvd.nist.gov/vuln/detail/CVE-2021-21353",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://github.com/advisories/GHSA-p493-635q-r6gr",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://github.com/pugjs/pug/commit/991e78f7c4220b2f8da042877c6f0ef5a4683be0",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://github.com/pugjs/pug/issues/3312",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://github.com/pugjs/pug/pull/3314",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://github.com/pugjs/pug/releases/tag/pug%403.0.1",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://github.com/pugjs/pug/security/advisories/GHSA-p493-635q-r6gr",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://nvd.nist.gov/vuln/detail/CVE-2021-21353",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://www.npmjs.com/package/pug",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://www.npmjs.com/package/pug-code-gen",
       },
     ],
@@ -5550,43 +5550,43 @@ Restrict the character length to a reasonable degree before passing a value to \
         "value": "CVE-2021-21353",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://nvd.nist.gov/vuln/detail/CVE-2021-21353",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://github.com/advisories/GHSA-p493-635q-r6gr",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://github.com/pugjs/pug/commit/991e78f7c4220b2f8da042877c6f0ef5a4683be0",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://github.com/pugjs/pug/issues/3312",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://github.com/pugjs/pug/pull/3314",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://github.com/pugjs/pug/releases/tag/pug%403.0.1",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://github.com/pugjs/pug/security/advisories/GHSA-p493-635q-r6gr",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://nvd.nist.gov/vuln/detail/CVE-2021-21353",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://www.npmjs.com/package/pug",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://www.npmjs.com/package/pug-code-gen",
       },
     ],
@@ -5619,27 +5619,27 @@ Restrict the character length to a reasonable degree before passing a value to \
         "value": "CVE-2016-1000237",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://nvd.nist.gov/vuln/detail/CVE-2016-1000237",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://github.com/advisories/GHSA-3j7m-hmh3-9jmp",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://github.com/punkave/sanitize-html/issues/29",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://nodesecurity.io/advisories/135",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://nvd.nist.gov/vuln/detail/CVE-2016-1000237",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://raw.githubusercontent.com/distributedweaknessfiling/cvelist/master/2016/1000xxx/CVE-2016-1000237.json",
       },
     ],
@@ -5672,27 +5672,27 @@ Restrict the character length to a reasonable degree before passing a value to \
         "value": "CVE-2017-16016",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://nvd.nist.gov/vuln/detail/CVE-2017-16016",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://github.com/advisories/GHSA-xc6g-ggrc-qq4r",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://github.com/punkave/sanitize-html/commit/5d205a1005ba0df80e21d8c64a15bb3accdb2403",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://github.com/punkave/sanitize-html/issues/100",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://nodesecurity.io/advisories/154",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://nvd.nist.gov/vuln/detail/CVE-2017-16016",
       },
     ],
@@ -5725,27 +5725,27 @@ Restrict the character length to a reasonable degree before passing a value to \
         "value": "CVE-2021-26539",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://nvd.nist.gov/vuln/detail/CVE-2021-26539",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://advisory.checkmarx.net/advisory/CX-2021-4308",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://github.com/advisories/GHSA-rjqq-98f6-6j3r",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://github.com/apostrophecms/sanitize-html/blob/main/CHANGELOG.md#231-2021-01-22",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://github.com/apostrophecms/sanitize-html/pull/458",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://nvd.nist.gov/vuln/detail/CVE-2021-26539",
       },
     ],
@@ -5778,27 +5778,27 @@ Restrict the character length to a reasonable degree before passing a value to \
         "value": "CVE-2021-26540",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://nvd.nist.gov/vuln/detail/CVE-2021-26540",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://advisory.checkmarx.net/advisory/CX-2021-4309",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://github.com/advisories/GHSA-mjxr-4v3x-q3m4",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://github.com/apostrophecms/sanitize-html/blob/main/CHANGELOG.md#232-2021-01-26",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://github.com/apostrophecms/sanitize-html/pull/460",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://nvd.nist.gov/vuln/detail/CVE-2021-26540",
       },
     ],
@@ -5846,15 +5846,15 @@ console.log(clean);
         "value": "NSWG-ECO-154",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://github.com/nodejs/security-wg/tree/master/vuln",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://github.com/punkave/sanitize-html/commit/5d205a1005ba0df80e21d8c64a15bb3accdb2403",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://github.com/punkave/sanitize-html/issues/100",
       },
     ],
@@ -5889,35 +5889,35 @@ console.log(clean);
         "value": "CVE-2021-23440",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://nvd.nist.gov/vuln/detail/CVE-2021-23440",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://github.com/advisories/GHSA-4jqc-8m5r-9rpr",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://github.com/jonschlinkert/set-value/commit/7cf8073bb06bf0c15e08475f9f952823b4576452",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://github.com/jonschlinkert/set-value/pull/33",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://nvd.nist.gov/vuln/detail/CVE-2021-23440",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://snyk.io/vuln/SNYK-JAVA-ORGWEBJARSNPM-1584212",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://snyk.io/vuln/SNYK-JS-SETVALUE-1540541",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://www.huntr.dev/bounties/2eae1159-01de-4f82-a177-7478a408c4a2/",
       },
     ],
@@ -5951,31 +5951,31 @@ console.log(clean);
         "value": "CVE-2020-28481",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://nvd.nist.gov/vuln/detail/CVE-2020-28481",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://github.com/advisories/GHSA-fxwf-4rqh-v8g3",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://github.com/socketio/socket.io/issues/3671",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://nvd.nist.gov/vuln/detail/CVE-2020-28481",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://snyk.io/vuln/SNYK-JAVA-ORGWEBJARSBOWER-1056358",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://snyk.io/vuln/SNYK-JAVA-ORGWEBJARSNPM-1056357",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://snyk.io/vuln/SNYK-JS-SOCKETIO-1024859",
       },
     ],
@@ -6009,31 +6009,31 @@ console.log(clean);
         "value": "CVE-2020-36049",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://nvd.nist.gov/vuln/detail/CVE-2020-36049",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://blog.caller.xyz/socketio-engineio-dos/",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://github.com/advisories/GHSA-xfhh-g9f5-x4m4",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://github.com/bcaller/kill-engine-io",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://github.com/socketio/socket.io-parser/commit/dcb942d24db97162ad16a67c2a0cf30875342d55",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://nvd.nist.gov/vuln/detail/CVE-2020-36049",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://snyk.io/vuln/SNYK-JAVA-ORGWEBJARSNPM-1056753",
       },
     ],
@@ -6067,31 +6067,31 @@ console.log(clean);
         "value": "CVE-2020-36049",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://nvd.nist.gov/vuln/detail/CVE-2020-36049",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://blog.caller.xyz/socketio-engineio-dos/",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://github.com/advisories/GHSA-xfhh-g9f5-x4m4",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://github.com/bcaller/kill-engine-io",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://github.com/socketio/socket.io-parser/commit/dcb942d24db97162ad16a67c2a0cf30875342d55",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://nvd.nist.gov/vuln/detail/CVE-2020-36049",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://snyk.io/vuln/SNYK-JAVA-ORGWEBJARSNPM-1056753",
       },
     ],
@@ -6128,43 +6128,43 @@ console.log(clean);
         "value": "CVE-2021-27290",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://nvd.nist.gov/vuln/detail/CVE-2021-27290",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2021-27290",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://doyensec.com/resources/Doyensec_Advisory_ssri_redos.pdf",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://github.com/advisories/GHSA-vx3p-948g-6vhq",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://github.com/yetingli/SaveResults/blob/main/pdf/ssri-redos.pdf",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://linux.oracle.com/cve/CVE-2021-27290.html",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://linux.oracle.com/errata/ELSA-2021-3074.html",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://npmjs.com",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://nvd.nist.gov/vuln/detail/CVE-2021-27290",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://www.oracle.com/security-alerts/cpuoct2021.html",
       },
     ],
@@ -6201,43 +6201,43 @@ console.log(clean);
         "value": "CVE-2021-32803",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://nvd.nist.gov/vuln/detail/CVE-2021-32803",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://github.com/advisories/GHSA-r628-mhmh-qjhw",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://github.com/npm/node-tar/commit/9dbdeb6df8e9dbd96fa9e84341b9d74734be6c20",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://github.com/npm/node-tar/security/advisories/GHSA-r628-mhmh-qjhw",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://linux.oracle.com/cve/CVE-2021-32803.html",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://linux.oracle.com/errata/ELSA-2021-3666.html",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://nvd.nist.gov/vuln/detail/CVE-2021-32803",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://www.npmjs.com/advisories/1771",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://www.npmjs.com/package/tar",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://www.oracle.com/security-alerts/cpuoct2021.html",
       },
     ],
@@ -6274,43 +6274,43 @@ console.log(clean);
         "value": "CVE-2021-32804",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://nvd.nist.gov/vuln/detail/CVE-2021-32804",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://github.com/advisories/GHSA-3jfq-g458-7qm9",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://github.com/npm/node-tar/commit/1f036ca23f64a547bdd6c79c1a44bc62e8115da4",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://github.com/npm/node-tar/security/advisories/GHSA-3jfq-g458-7qm9",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://linux.oracle.com/cve/CVE-2021-32804.html",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://linux.oracle.com/errata/ELSA-2021-3666.html",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://nvd.nist.gov/vuln/detail/CVE-2021-32804",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://www.npmjs.com/advisories/1770",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://www.npmjs.com/package/tar",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://www.oracle.com/security-alerts/cpuoct2021.html",
       },
     ],
@@ -6344,31 +6344,31 @@ console.log(clean);
         "value": "CVE-2021-37701",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://nvd.nist.gov/vuln/detail/CVE-2021-37701",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://github.com/advisories/GHSA-9r2w-394v-53qc",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://github.com/npm/node-tar/security/advisories/GHSA-9r2w-394v-53qc",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://nvd.nist.gov/vuln/detail/CVE-2021-37701",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://www.npmjs.com/advisories/1779",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://www.npmjs.com/package/tar",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://www.oracle.com/security-alerts/cpuoct2021.html",
       },
     ],
@@ -6402,31 +6402,31 @@ console.log(clean);
         "value": "CVE-2021-37712",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://nvd.nist.gov/vuln/detail/CVE-2021-37712",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://github.com/advisories/GHSA-qq89-hq3f-393p",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://github.com/npm/node-tar/security/advisories/GHSA-qq89-hq3f-393p",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://nvd.nist.gov/vuln/detail/CVE-2021-37712",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://www.npmjs.com/advisories/1780",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://www.npmjs.com/package/tar",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://www.oracle.com/security-alerts/cpuoct2021.html",
       },
     ],
@@ -6459,27 +6459,27 @@ console.log(clean);
         "value": "CVE-2021-37713",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://nvd.nist.gov/vuln/detail/CVE-2021-37713",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://github.com/advisories/GHSA-5955-9wpr-37jh",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://github.com/npm/node-tar/security/advisories/GHSA-5955-9wpr-37jh",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://nvd.nist.gov/vuln/detail/CVE-2021-37713",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://www.npmjs.com/package/tar",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://www.oracle.com/security-alerts/cpuoct2021.html",
       },
     ],
@@ -6511,23 +6511,23 @@ console.log(clean);
         "value": "CVE-2021-33623",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://nvd.nist.gov/vuln/detail/CVE-2021-33623",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://github.com/advisories/GHSA-7p7h-4mm5-852v",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://github.com/sindresorhus/trim-newlines/releases/tag/v4.0.1",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://nvd.nist.gov/vuln/detail/CVE-2021-33623",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://www.npmjs.com/package/trim-newlines",
       },
     ],
@@ -6559,23 +6559,23 @@ console.log(clean);
         "value": "CVE-2021-3765",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://nvd.nist.gov/vuln/detail/CVE-2021-3765",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://github.com/advisories/GHSA-qgmg-gppg-76g5",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://github.com/validatorjs/validator.js/commit/496fc8b2a7f5997acaaec33cc44d0b8dba5fb5e1",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://huntr.dev/bounties/c37e975c-21a3-4c5f-9b57-04d63b28cfc9",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://nvd.nist.gov/vuln/detail/CVE-2021-3765",
       },
     ],
@@ -6608,27 +6608,27 @@ console.log(clean);
         "value": "CVE-2021-32640",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://nvd.nist.gov/vuln/detail/CVE-2021-32640",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://github.com/advisories/GHSA-6fc8-4gx4-v693",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://github.com/websockets/ws/commit/00c425ec77993773d823f018f64a5c44e17023ff",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://github.com/websockets/ws/security/advisories/GHSA-6fc8-4gx4-v693",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://lists.apache.org/thread.html/rdfa7b6253c4d6271e31566ecd5f30b7ce1b8fb2c89d52b8c4e0f4e30@%3Ccommits.tinkerpop.apache.org%3E",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://nvd.nist.gov/vuln/detail/CVE-2021-32640",
       },
     ],
@@ -6661,27 +6661,27 @@ console.log(clean);
         "value": "CVE-2021-32640",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://nvd.nist.gov/vuln/detail/CVE-2021-32640",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://github.com/advisories/GHSA-6fc8-4gx4-v693",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://github.com/websockets/ws/commit/00c425ec77993773d823f018f64a5c44e17023ff",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://github.com/websockets/ws/security/advisories/GHSA-6fc8-4gx4-v693",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://lists.apache.org/thread.html/rdfa7b6253c4d6271e31566ecd5f30b7ce1b8fb2c89d52b8c4e0f4e30@%3Ccommits.tinkerpop.apache.org%3E",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://nvd.nist.gov/vuln/detail/CVE-2021-32640",
       },
     ],
@@ -6715,31 +6715,31 @@ console.log(clean);
         "value": "CVE-2021-31597",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://nvd.nist.gov/vuln/detail/CVE-2021-31597",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://github.com/advisories/GHSA-72mh-269x-7mh5",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://github.com/mjwwit/node-XMLHttpRequest/commit/bf53329b61ca6afc5d28f6b8d2dc2e3ca740a9b2",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://github.com/mjwwit/node-XMLHttpRequest/compare/v1.6.0...1.6.1",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://nvd.nist.gov/vuln/detail/CVE-2021-31597",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://people.kingsds.network/wesgarland/xmlhttprequest-ssl-vuln.txt",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://security.netapp.com/advisory/ntap-20210618-0004/",
       },
     ],
@@ -6774,35 +6774,35 @@ console.log(clean);
         "value": "CVE-2020-28502",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://nvd.nist.gov/vuln/detail/CVE-2020-28502",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://github.com/advisories/GHSA-h4j5-c7cj-74xg",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://github.com/driverdan/node-XMLHttpRequest/blob/1.6.0/lib/XMLHttpRequest.js%23L480",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://nvd.nist.gov/vuln/detail/CVE-2020-28502",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://snyk.io/vuln/SNYK-JAVA-ORGWEBJARSNPM-1082937",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://snyk.io/vuln/SNYK-JAVA-ORGWEBJARSNPM-1082938",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://snyk.io/vuln/SNYK-JS-XMLHTTPREQUEST-1082935",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://snyk.io/vuln/SNYK-JS-XMLHTTPREQUESTSSL-1082936",
       },
     ],
@@ -6839,43 +6839,43 @@ console.log(clean);
         "value": "CVE-2020-7774",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://nvd.nist.gov/vuln/detail/CVE-2020-7774",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://github.com/advisories/GHSA-c4w7-xm78-47vh",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://github.com/yargs/y18n/issues/96",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://github.com/yargs/y18n/pull/108",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://linux.oracle.com/cve/CVE-2020-7774.html",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://linux.oracle.com/errata/ELSA-2021-0551.html",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://nvd.nist.gov/vuln/detail/CVE-2020-7774",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://snyk.io/vuln/SNYK-JAVA-ORGWEBJARSNPM-1038306",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://snyk.io/vuln/SNYK-JS-Y18N-1021887",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://www.oracle.com/security-alerts/cpuApr2021.html",
       },
     ],
@@ -6912,43 +6912,43 @@ console.log(clean);
         "value": "CVE-2020-7774",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://nvd.nist.gov/vuln/detail/CVE-2020-7774",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://github.com/advisories/GHSA-c4w7-xm78-47vh",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://github.com/yargs/y18n/issues/96",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://github.com/yargs/y18n/pull/108",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://linux.oracle.com/cve/CVE-2020-7774.html",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://linux.oracle.com/errata/ELSA-2021-0551.html",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://nvd.nist.gov/vuln/detail/CVE-2020-7774",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://snyk.io/vuln/SNYK-JAVA-ORGWEBJARSNPM-1038306",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://snyk.io/vuln/SNYK-JS-Y18N-1021887",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://www.oracle.com/security-alerts/cpuApr2021.html",
       },
     ],
@@ -6981,27 +6981,27 @@ console.log(clean);
         "value": "CVE-2020-7608",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://nvd.nist.gov/vuln/detail/CVE-2020-7608",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://github.com/advisories/GHSA-p9pc-299p-vxgp",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://linux.oracle.com/cve/CVE-2020-7608.html",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://linux.oracle.com/errata/ELSA-2021-0548.html",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://nvd.nist.gov/vuln/detail/CVE-2020-7608",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://snyk.io/vuln/SNYK-JS-YARGSPARSER-560381",
       },
     ],
@@ -7034,27 +7034,27 @@ console.log(clean);
         "value": "CVE-2020-7608",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://nvd.nist.gov/vuln/detail/CVE-2020-7608",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://github.com/advisories/GHSA-p9pc-299p-vxgp",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://linux.oracle.com/cve/CVE-2020-7608.html",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://linux.oracle.com/errata/ELSA-2021-0548.html",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://nvd.nist.gov/vuln/detail/CVE-2020-7608",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://snyk.io/vuln/SNYK-JS-YARGSPARSER-560381",
       },
     ],
@@ -7091,23 +7091,23 @@ exports[`parses bkimminich/juice-shop:v12.10.2 result file into findings 1`] = `
         "value": "CVE-2021-3807",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://nvd.nist.gov/vuln/detail/CVE-2021-3807",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://github.com/advisories/GHSA-93q8-gq69-wqmw",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://github.com/chalk/ansi-regex/commit/8d1d7cdb586269882c4bdc1b7325d0c58c8f76f9",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://huntr.dev/bounties/5b3cf33b-ede0-4398-9974-800876dfd994",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://nvd.nist.gov/vuln/detail/CVE-2021-3807",
       },
     ],
@@ -7139,23 +7139,23 @@ exports[`parses bkimminich/juice-shop:v12.10.2 result file into findings 1`] = `
         "value": "CVE-2021-3807",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://nvd.nist.gov/vuln/detail/CVE-2021-3807",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://github.com/advisories/GHSA-93q8-gq69-wqmw",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://github.com/chalk/ansi-regex/commit/8d1d7cdb586269882c4bdc1b7325d0c58c8f76f9",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://huntr.dev/bounties/5b3cf33b-ede0-4398-9974-800876dfd994",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://nvd.nist.gov/vuln/detail/CVE-2021-3807",
       },
     ],
@@ -7185,15 +7185,15 @@ exports[`parses bkimminich/juice-shop:v12.10.2 result file into findings 1`] = `
         "value": "NSWG-ECO-428",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://github.com/nodejs/security-wg/tree/master/vuln",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://github.com/brianloveswords/base64url/pull/25",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://hackerone.com/reports/321687",
       },
     ],
@@ -7224,11 +7224,11 @@ Update to version 3.0.0 or later.",
     "osi_layer": "NOT_APPLICABLE",
     "references": [
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://github.com/advisories/GHSA-rvg8-pwq2-xj7q",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://github.com/brianloveswords/base64url/pull/25",
       },
     ],
@@ -7254,11 +7254,11 @@ Update to version 3.0.0 or later.",
     "osi_layer": "NOT_APPLICABLE",
     "references": [
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://github.com/advisories/GHSA-h6ch-v84p-w6p9",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://github.com/kpdecker/jsdiff/commit/2aec4298639bf30fb88a00b356bf404d3551b8c0",
       },
     ],
@@ -7290,23 +7290,23 @@ Update to version 3.0.0 or later.",
         "value": "CVE-2020-15084",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://nvd.nist.gov/vuln/detail/CVE-2020-15084",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://github.com/advisories/GHSA-6g6m-m6h5-w9gf",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://github.com/auth0/express-jwt/commit/7ecab5f8f0cab5297c2b863596566eb0c019cdef",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://github.com/auth0/express-jwt/security/advisories/GHSA-6g6m-m6h5-w9gf",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://nvd.nist.gov/vuln/detail/CVE-2020-15084",
       },
     ],
@@ -7340,31 +7340,31 @@ Update to version 3.0.0 or later.",
         "value": "CVE-2017-16042",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://nvd.nist.gov/vuln/detail/CVE-2017-16042",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2017-16042",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://github.com/advisories/GHSA-qh2h-chj9-jffq",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://github.com/tj/node-growl/issues/60",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://github.com/tj/node-growl/pull/61",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://nodesecurity.io/advisories/146",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://nvd.nist.gov/vuln/detail/CVE-2017-16042",
       },
     ],
@@ -7395,19 +7395,19 @@ Update to version 3.0.0 or later.",
         "value": "CVE-2021-32822",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://nvd.nist.gov/vuln/detail/CVE-2021-32822",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://github.com/advisories/GHSA-7f5c-rpf4-86p8",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://nvd.nist.gov/vuln/detail/CVE-2021-32822",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://securitylab.github.com/advisories/GHSL-2021-020-pillarjs-hbs/",
       },
     ],
@@ -7441,31 +7441,31 @@ Update to version 3.0.0 or later.",
         "value": "CVE-2015-9235",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://nvd.nist.gov/vuln/detail/CVE-2015-9235",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://auth0.com/blog/2015/03/31/critical-vulnerabilities-in-json-web-token-libraries/",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://github.com/advisories/GHSA-c7hr-j4mj-j2w6",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://github.com/auth0/node-jsonwebtoken/commit/1bb584bc382295eeb7ee8c4452a673a77a68b687",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://nodesecurity.io/advisories/17",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://nvd.nist.gov/vuln/detail/CVE-2015-9235",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://www.timmclean.net/2015/02/25/jwt-alg-none.html",
       },
     ],
@@ -7496,19 +7496,19 @@ Update to version 3.0.0 or later.",
         "value": "NSWG-ECO-17",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://github.com/nodejs/security-wg/tree/master/vuln",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://auth0.com/blog/2015/03/31/critical-vulnerabilities-in-json-web-token-libraries/",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://github.com/auth0/node-jsonwebtoken/commit/1bb584bc382295eeb7ee8c4452a673a77a68b687",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://www.timmclean.net/2015/02/25/jwt-alg-none.html",
       },
     ],
@@ -7542,31 +7542,31 @@ Update to version 3.0.0 or later.",
         "value": "CVE-2015-9235",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://nvd.nist.gov/vuln/detail/CVE-2015-9235",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://auth0.com/blog/2015/03/31/critical-vulnerabilities-in-json-web-token-libraries/",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://github.com/advisories/GHSA-c7hr-j4mj-j2w6",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://github.com/auth0/node-jsonwebtoken/commit/1bb584bc382295eeb7ee8c4452a673a77a68b687",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://nodesecurity.io/advisories/17",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://nvd.nist.gov/vuln/detail/CVE-2015-9235",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://www.timmclean.net/2015/02/25/jwt-alg-none.html",
       },
     ],
@@ -7597,19 +7597,19 @@ Update to version 3.0.0 or later.",
         "value": "NSWG-ECO-17",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://github.com/nodejs/security-wg/tree/master/vuln",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://auth0.com/blog/2015/03/31/critical-vulnerabilities-in-json-web-token-libraries/",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://github.com/auth0/node-jsonwebtoken/commit/1bb584bc382295eeb7ee8c4452a673a77a68b687",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://www.timmclean.net/2015/02/25/jwt-alg-none.html",
       },
     ],
@@ -7645,23 +7645,23 @@ In addition, there is the \`none\` algorithm to be concerned about.  In versions
         "value": "CVE-2016-1000223",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://nvd.nist.gov/vuln/detail/CVE-2016-1000223",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://auth0.com/blog/2015/03/31/critical-vulnerabilities-in-json-web-token-libraries/",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://github.com/advisories/GHSA-gjcw-v447-2w7q",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://github.com/brianloveswords/node-jws/commit/585d0e1e97b6747c10cf5b7689ccc5618a89b299#diff-4ac32a78649ca5bdd8e0ba38b7006a1e",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://nvd.nist.gov/vuln/detail/CVE-2016-1000223",
       },
     ],
@@ -7697,39 +7697,39 @@ In addition, there is the \`none\` algorithm to be concerned about.  In versions
         "value": "CVE-2019-10744",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://nvd.nist.gov/vuln/detail/CVE-2019-10744",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://access.redhat.com/errata/RHSA-2019:3024",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://github.com/advisories/GHSA-jf85-cpcp-j695",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://nvd.nist.gov/vuln/detail/CVE-2019-10744",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://security.netapp.com/advisory/ntap-20191004-0005/",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://snyk.io/vuln/SNYK-JS-LODASH-450202",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://support.f5.com/csp/article/K47105354?utm_source=f5support&amp;utm_medium=RSS",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://www.oracle.com/security-alerts/cpujan2021.html",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://www.oracle.com/security-alerts/cpuoct2020.html",
       },
     ],
@@ -7766,43 +7766,43 @@ In addition, there is the \`none\` algorithm to be concerned about.  In versions
         "value": "CVE-2020-8203",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://nvd.nist.gov/vuln/detail/CVE-2020-8203",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://github.com/advisories/GHSA-p6mc-m468-83gw",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://github.com/lodash/lodash/issues/4874",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://hackerone.com/reports/712065",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://nvd.nist.gov/vuln/detail/CVE-2020-8203",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://security.netapp.com/advisory/ntap-20200724-0006/",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://www.npmjs.com/advisories/1523",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://www.oracle.com//security-alerts/cpujul2021.html",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://www.oracle.com/security-alerts/cpuApr2021.html",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://www.oracle.com/security-alerts/cpuoct2021.html",
       },
     ],
@@ -7843,59 +7843,59 @@ In addition, there is the \`none\` algorithm to be concerned about.  In versions
         "value": "CVE-2021-23337",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://nvd.nist.gov/vuln/detail/CVE-2021-23337",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2021-23337",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://github.com/advisories/GHSA-35jh-r3h4-6jhm",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://github.com/lodash/lodash/blob/ddfd9b11a0126db2302cb70ec9973b66baec0975/lodash.js%23L14851",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://nvd.nist.gov/vuln/detail/CVE-2021-23337",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://security.netapp.com/advisory/ntap-20210312-0006/",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://snyk.io/vuln/SNYK-JAVA-ORGFUJIONWEBJARS-1074932",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://snyk.io/vuln/SNYK-JAVA-ORGWEBJARS-1074930",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://snyk.io/vuln/SNYK-JAVA-ORGWEBJARSBOWER-1074928",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://snyk.io/vuln/SNYK-JAVA-ORGWEBJARSBOWERGITHUBLODASH-1074931",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://snyk.io/vuln/SNYK-JAVA-ORGWEBJARSNPM-1074929",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://snyk.io/vuln/SNYK-JS-LODASH-1040724",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://www.oracle.com//security-alerts/cpujul2021.html",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://www.oracle.com/security-alerts/cpuoct2021.html",
       },
     ],
@@ -7928,27 +7928,27 @@ In addition, there is the \`none\` algorithm to be concerned about.  In versions
         "value": "CVE-2018-16487",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://nvd.nist.gov/vuln/detail/CVE-2018-16487",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2018-16487",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://github.com/advisories/GHSA-4xc9-xhrj-v574",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://hackerone.com/reports/380873",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://nvd.nist.gov/vuln/detail/CVE-2018-16487",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://security.netapp.com/advisory/ntap-20190919-0004/",
       },
     ],
@@ -7984,39 +7984,39 @@ In addition, there is the \`none\` algorithm to be concerned about.  In versions
         "value": "CVE-2018-3721",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://nvd.nist.gov/vuln/detail/CVE-2018-3721",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2018-3721",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://github.com/advisories/GHSA-fvqr-27wr-82fm",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://github.com/lodash/lodash/commit/d8e069cc3410082e44eb18fcf8e7f3d08ebe1d4a",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://hackerone.com/reports/310443",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://nvd.nist.gov/vuln/detail/CVE-2018-3721",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://security.netapp.com/advisory/ntap-20190919-0004/",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://snyk.io/vuln/npm:lodash:20180130",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://www.npmjs.com/advisories/577",
       },
     ],
@@ -8051,35 +8051,35 @@ In addition, there is the \`none\` algorithm to be concerned about.  In versions
         "value": "CVE-2019-1010266",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://nvd.nist.gov/vuln/detail/CVE-2019-1010266",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2019-1010266",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://github.com/advisories/GHSA-x5rq-j2xg-h7qm",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://github.com/lodash/lodash/issues/3359",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://github.com/lodash/lodash/wiki/Changelog",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://nvd.nist.gov/vuln/detail/CVE-2019-1010266",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://security.netapp.com/advisory/ntap-20190919-0004/",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://snyk.io/vuln/SNYK-JS-LODASH-73639",
       },
     ],
@@ -8115,39 +8115,39 @@ In addition, there is the \`none\` algorithm to be concerned about.  In versions
         "value": "CVE-2019-10744",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://nvd.nist.gov/vuln/detail/CVE-2019-10744",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://access.redhat.com/errata/RHSA-2019:3024",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://github.com/advisories/GHSA-jf85-cpcp-j695",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://nvd.nist.gov/vuln/detail/CVE-2019-10744",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://security.netapp.com/advisory/ntap-20191004-0005/",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://snyk.io/vuln/SNYK-JS-LODASH-450202",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://support.f5.com/csp/article/K47105354?utm_source=f5support&amp;utm_medium=RSS",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://www.oracle.com/security-alerts/cpujan2021.html",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://www.oracle.com/security-alerts/cpuoct2020.html",
       },
     ],
@@ -8184,43 +8184,43 @@ In addition, there is the \`none\` algorithm to be concerned about.  In versions
         "value": "CVE-2020-8203",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://nvd.nist.gov/vuln/detail/CVE-2020-8203",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://github.com/advisories/GHSA-p6mc-m468-83gw",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://github.com/lodash/lodash/issues/4874",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://hackerone.com/reports/712065",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://nvd.nist.gov/vuln/detail/CVE-2020-8203",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://security.netapp.com/advisory/ntap-20200724-0006/",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://www.npmjs.com/advisories/1523",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://www.oracle.com//security-alerts/cpujul2021.html",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://www.oracle.com/security-alerts/cpuApr2021.html",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://www.oracle.com/security-alerts/cpuoct2021.html",
       },
     ],
@@ -8261,59 +8261,59 @@ In addition, there is the \`none\` algorithm to be concerned about.  In versions
         "value": "CVE-2021-23337",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://nvd.nist.gov/vuln/detail/CVE-2021-23337",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2021-23337",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://github.com/advisories/GHSA-35jh-r3h4-6jhm",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://github.com/lodash/lodash/blob/ddfd9b11a0126db2302cb70ec9973b66baec0975/lodash.js%23L14851",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://nvd.nist.gov/vuln/detail/CVE-2021-23337",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://security.netapp.com/advisory/ntap-20210312-0006/",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://snyk.io/vuln/SNYK-JAVA-ORGFUJIONWEBJARS-1074932",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://snyk.io/vuln/SNYK-JAVA-ORGWEBJARS-1074930",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://snyk.io/vuln/SNYK-JAVA-ORGWEBJARSBOWER-1074928",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://snyk.io/vuln/SNYK-JAVA-ORGWEBJARSBOWERGITHUBLODASH-1074931",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://snyk.io/vuln/SNYK-JAVA-ORGWEBJARSNPM-1074929",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://snyk.io/vuln/SNYK-JS-LODASH-1040724",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://www.oracle.com//security-alerts/cpujul2021.html",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://www.oracle.com/security-alerts/cpuoct2021.html",
       },
     ],
@@ -8344,11 +8344,11 @@ No fix is currently available. Consider using an alternative package until a fix
     "osi_layer": "NOT_APPLICABLE",
     "references": [
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://github.com/advisories/GHSA-5mrr-rgp6-x4gr",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://github.com/bkimminich/juice-shop/issues/1173",
       },
     ],
@@ -8381,27 +8381,27 @@ No fix is currently available. Consider using an alternative package until a fix
         "value": "CVE-2017-18214",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://nvd.nist.gov/vuln/detail/CVE-2017-18214",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://github.com/advisories/GHSA-446m-mv8f-q348",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://github.com/moment/moment/issues/4163",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://nodesecurity.io/advisories/532",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://nvd.nist.gov/vuln/detail/CVE-2017-18214",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://www.tenable.com/security/tns-2019-02",
       },
     ],
@@ -8441,55 +8441,55 @@ No fix is currently available. Consider using an alternative package until a fix
         "value": "CVE-2016-4055",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://nvd.nist.gov/vuln/detail/CVE-2016-4055",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "http://www.openwall.com/lists/oss-security/2016/04/20/11",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "http://www.oracle.com/technetwork/security-advisory/cpujul2018-4258247.html",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "http://www.securityfocus.com/bid/95849",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://github.com/advisories/GHSA-87vv-r9j6-g5qv",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://lists.apache.org/thread.html/10f0f3aefd51444d1198c65f44ffdf2d78ca3359423dbc1c168c9731@%3Cdev.flink.apache.org%3E",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://lists.apache.org/thread.html/17ff53f7999e74fbe3cc0ceb4e1c3b00b180b7c5afec8e978837bc49@%3Cuser.flink.apache.org%3E",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://lists.apache.org/thread.html/52bafac05ad174000ea465fe275fd3cc7bd5c25535a7631c0bc9bfb2@%3Cuser.flink.apache.org%3E",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://lists.apache.org/thread.html/54df3aeb4239b64b50b356f0ca6f986e3c4ca5b84c515dce077c7854@%3Cuser.flink.apache.org%3E",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://nodesecurity.io/advisories/55",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://nvd.nist.gov/vuln/detail/CVE-2016-4055",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://www.owasp.org/index.php/Regular_expression_Denial_of_Service_-_ReDoS",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://www.tenable.com/security/tns-2019-02",
       },
     ],
@@ -8522,27 +8522,27 @@ No fix is currently available. Consider using an alternative package until a fix
         "value": "CVE-2016-1000237",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://nvd.nist.gov/vuln/detail/CVE-2016-1000237",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://github.com/advisories/GHSA-3j7m-hmh3-9jmp",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://github.com/punkave/sanitize-html/issues/29",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://nodesecurity.io/advisories/135",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://nvd.nist.gov/vuln/detail/CVE-2016-1000237",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://raw.githubusercontent.com/distributedweaknessfiling/cvelist/master/2016/1000xxx/CVE-2016-1000237.json",
       },
     ],
@@ -8575,27 +8575,27 @@ No fix is currently available. Consider using an alternative package until a fix
         "value": "CVE-2017-16016",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://nvd.nist.gov/vuln/detail/CVE-2017-16016",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://github.com/advisories/GHSA-xc6g-ggrc-qq4r",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://github.com/punkave/sanitize-html/commit/5d205a1005ba0df80e21d8c64a15bb3accdb2403",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://github.com/punkave/sanitize-html/issues/100",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://nodesecurity.io/advisories/154",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://nvd.nist.gov/vuln/detail/CVE-2017-16016",
       },
     ],
@@ -8628,27 +8628,27 @@ No fix is currently available. Consider using an alternative package until a fix
         "value": "CVE-2021-26539",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://nvd.nist.gov/vuln/detail/CVE-2021-26539",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://advisory.checkmarx.net/advisory/CX-2021-4308",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://github.com/advisories/GHSA-rjqq-98f6-6j3r",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://github.com/apostrophecms/sanitize-html/blob/main/CHANGELOG.md#231-2021-01-22",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://github.com/apostrophecms/sanitize-html/pull/458",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://nvd.nist.gov/vuln/detail/CVE-2021-26539",
       },
     ],
@@ -8681,27 +8681,27 @@ No fix is currently available. Consider using an alternative package until a fix
         "value": "CVE-2021-26540",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://nvd.nist.gov/vuln/detail/CVE-2021-26540",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://advisory.checkmarx.net/advisory/CX-2021-4309",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://github.com/advisories/GHSA-mjxr-4v3x-q3m4",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://github.com/apostrophecms/sanitize-html/blob/main/CHANGELOG.md#232-2021-01-26",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://github.com/apostrophecms/sanitize-html/pull/460",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://nvd.nist.gov/vuln/detail/CVE-2021-26540",
       },
     ],
@@ -8749,15 +8749,15 @@ console.log(clean);
         "value": "NSWG-ECO-154",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://github.com/nodejs/security-wg/tree/master/vuln",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://github.com/punkave/sanitize-html/commit/5d205a1005ba0df80e21d8c64a15bb3accdb2403",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://github.com/punkave/sanitize-html/issues/100",
       },
     ],
@@ -8792,35 +8792,35 @@ console.log(clean);
         "value": "CVE-2021-23440",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://nvd.nist.gov/vuln/detail/CVE-2021-23440",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://github.com/advisories/GHSA-4jqc-8m5r-9rpr",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://github.com/jonschlinkert/set-value/commit/7cf8073bb06bf0c15e08475f9f952823b4576452",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://github.com/jonschlinkert/set-value/pull/33",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://nvd.nist.gov/vuln/detail/CVE-2021-23440",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://snyk.io/vuln/SNYK-JAVA-ORGWEBJARSNPM-1584212",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://snyk.io/vuln/SNYK-JS-SETVALUE-1540541",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://www.huntr.dev/bounties/2eae1159-01de-4f82-a177-7478a408c4a2/",
       },
     ],
@@ -8857,43 +8857,43 @@ console.log(clean);
         "value": "CVE-2021-32803",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://nvd.nist.gov/vuln/detail/CVE-2021-32803",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://github.com/advisories/GHSA-r628-mhmh-qjhw",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://github.com/npm/node-tar/commit/9dbdeb6df8e9dbd96fa9e84341b9d74734be6c20",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://github.com/npm/node-tar/security/advisories/GHSA-r628-mhmh-qjhw",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://linux.oracle.com/cve/CVE-2021-32803.html",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://linux.oracle.com/errata/ELSA-2021-3666.html",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://nvd.nist.gov/vuln/detail/CVE-2021-32803",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://www.npmjs.com/advisories/1771",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://www.npmjs.com/package/tar",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://www.oracle.com/security-alerts/cpuoct2021.html",
       },
     ],
@@ -8930,43 +8930,43 @@ console.log(clean);
         "value": "CVE-2021-32804",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://nvd.nist.gov/vuln/detail/CVE-2021-32804",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://github.com/advisories/GHSA-3jfq-g458-7qm9",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://github.com/npm/node-tar/commit/1f036ca23f64a547bdd6c79c1a44bc62e8115da4",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://github.com/npm/node-tar/security/advisories/GHSA-3jfq-g458-7qm9",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://linux.oracle.com/cve/CVE-2021-32804.html",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://linux.oracle.com/errata/ELSA-2021-3666.html",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://nvd.nist.gov/vuln/detail/CVE-2021-32804",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://www.npmjs.com/advisories/1770",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://www.npmjs.com/package/tar",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://www.oracle.com/security-alerts/cpuoct2021.html",
       },
     ],
@@ -9000,31 +9000,31 @@ console.log(clean);
         "value": "CVE-2021-37701",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://nvd.nist.gov/vuln/detail/CVE-2021-37701",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://github.com/advisories/GHSA-9r2w-394v-53qc",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://github.com/npm/node-tar/security/advisories/GHSA-9r2w-394v-53qc",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://nvd.nist.gov/vuln/detail/CVE-2021-37701",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://www.npmjs.com/advisories/1779",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://www.npmjs.com/package/tar",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://www.oracle.com/security-alerts/cpuoct2021.html",
       },
     ],
@@ -9058,31 +9058,31 @@ console.log(clean);
         "value": "CVE-2021-37712",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://nvd.nist.gov/vuln/detail/CVE-2021-37712",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://github.com/advisories/GHSA-qq89-hq3f-393p",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://github.com/npm/node-tar/security/advisories/GHSA-qq89-hq3f-393p",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://nvd.nist.gov/vuln/detail/CVE-2021-37712",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://www.npmjs.com/advisories/1780",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://www.npmjs.com/package/tar",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://www.oracle.com/security-alerts/cpuoct2021.html",
       },
     ],
@@ -9115,27 +9115,27 @@ console.log(clean);
         "value": "CVE-2021-37713",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://nvd.nist.gov/vuln/detail/CVE-2021-37713",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://github.com/advisories/GHSA-5955-9wpr-37jh",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://github.com/npm/node-tar/security/advisories/GHSA-5955-9wpr-37jh",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://nvd.nist.gov/vuln/detail/CVE-2021-37713",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://www.npmjs.com/package/tar",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://www.oracle.com/security-alerts/cpuoct2021.html",
       },
     ],
@@ -9167,23 +9167,23 @@ console.log(clean);
         "value": "CVE-2021-3765",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://nvd.nist.gov/vuln/detail/CVE-2021-3765",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://github.com/advisories/GHSA-qgmg-gppg-76g5",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://github.com/validatorjs/validator.js/commit/496fc8b2a7f5997acaaec33cc44d0b8dba5fb5e1",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://huntr.dev/bounties/c37e975c-21a3-4c5f-9b57-04d63b28cfc9",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://nvd.nist.gov/vuln/detail/CVE-2021-3765",
       },
     ],
@@ -9218,35 +9218,35 @@ console.log(clean);
         "value": "CVE-2021-23449",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://nvd.nist.gov/vuln/detail/CVE-2021-23449",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://github.com/advisories/GHSA-rjf2-j2r6-q8gr",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://github.com/patriksimek/vm2/commit/b4f6e2bd2c4a1ef52fc4483d8e35f28bc4481886",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://github.com/patriksimek/vm2/issues/363",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://github.com/patriksimek/vm2/releases/tag/3.9.4",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://nvd.nist.gov/vuln/detail/CVE-2021-23449",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://security.netapp.com/advisory/ntap-20211029-0010/",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://snyk.io/vuln/SNYK-JS-VM2-1585918",
       },
     ],
@@ -9282,19 +9282,19 @@ exports[`parses securecodebox:master result file into findings 1`] = `
         "value": "CVE-2020-26160",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://nvd.nist.gov/vuln/detail/CVE-2020-26160",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://github.com/dgrijalva/jwt-go/pull/426",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://nvd.nist.gov/vuln/detail/CVE-2020-26160",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://snyk.io/vuln/SNYK-GOLANG-GITHUBCOMDGRIJALVAJWTGO-596515",
       },
     ],
@@ -9331,43 +9331,43 @@ exports[`parses securecodebox:master result file into findings 1`] = `
         "value": "CVE-2021-3121",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://nvd.nist.gov/vuln/detail/CVE-2021-3121",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2021-3121",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://discuss.hashicorp.com/t/hcsec-2021-23-consul-exposed-to-denial-of-service-in-gogo-protobuf-dependency/29025",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://github.com/gogo/protobuf/commit/b03c65ea87cdc3521ede29f62fe3ce239267c1bc",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://github.com/gogo/protobuf/compare/v1.3.1...v1.3.2",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://lists.apache.org/thread.html/r68032132c0399c29d6cdc7bd44918535da54060a10a12b1591328bff@%3Cnotifications.skywalking.apache.org%3E",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://lists.apache.org/thread.html/r88d69555cb74a129a7bf84838073b61259b4a3830190e05a3b87994e@%3Ccommits.pulsar.apache.org%3E",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://lists.apache.org/thread.html/rc1e9ff22c5641d73701ba56362fb867d40ed287cca000b131dcf4a44@%3Ccommits.pulsar.apache.org%3E",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://nvd.nist.gov/vuln/detail/CVE-2021-3121",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://security.netapp.com/advisory/ntap-20210219-0006/",
       },
     ],
@@ -9400,27 +9400,27 @@ exports[`parses securecodebox:master result file into findings 1`] = `
         "value": "CVE-2019-19794",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://nvd.nist.gov/vuln/detail/CVE-2019-19794",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://github.com/coredns/coredns/issues/3519",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://github.com/coredns/coredns/issues/3547",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://github.com/miekg/dns/compare/v1.1.24...v1.1.25",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://github.com/miekg/dns/issues/1043",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://github.com/miekg/dns/pull/1044",
       },
     ],
@@ -9453,27 +9453,27 @@ exports[`parses securecodebox:master result file into findings 1`] = `
         "value": "CVE-2020-29652",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://nvd.nist.gov/vuln/detail/CVE-2020-29652",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2020-29652",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://go-review.googlesource.com/c/crypto/+/278852",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://groups.google.com/g/golang-announce/c/ouZIlBimOsE?pli=1",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://lists.apache.org/thread.html/r68032132c0399c29d6cdc7bd44918535da54060a10a12b1591328bff@%3Cnotifications.skywalking.apache.org%3E",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://nvd.nist.gov/vuln/detail/CVE-2020-29652",
       },
     ],
@@ -9504,19 +9504,19 @@ exports[`parses securecodebox:master result file into findings 1`] = `
         "value": "CVE-2020-26160",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://nvd.nist.gov/vuln/detail/CVE-2020-26160",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://github.com/dgrijalva/jwt-go/pull/426",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://nvd.nist.gov/vuln/detail/CVE-2020-26160",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://snyk.io/vuln/SNYK-GOLANG-GITHUBCOMDGRIJALVAJWTGO-596515",
       },
     ],
@@ -9553,43 +9553,43 @@ exports[`parses securecodebox:master result file into findings 1`] = `
         "value": "CVE-2021-3121",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://nvd.nist.gov/vuln/detail/CVE-2021-3121",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2021-3121",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://discuss.hashicorp.com/t/hcsec-2021-23-consul-exposed-to-denial-of-service-in-gogo-protobuf-dependency/29025",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://github.com/gogo/protobuf/commit/b03c65ea87cdc3521ede29f62fe3ce239267c1bc",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://github.com/gogo/protobuf/compare/v1.3.1...v1.3.2",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://lists.apache.org/thread.html/r68032132c0399c29d6cdc7bd44918535da54060a10a12b1591328bff@%3Cnotifications.skywalking.apache.org%3E",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://lists.apache.org/thread.html/r88d69555cb74a129a7bf84838073b61259b4a3830190e05a3b87994e@%3Ccommits.pulsar.apache.org%3E",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://lists.apache.org/thread.html/rc1e9ff22c5641d73701ba56362fb867d40ed287cca000b131dcf4a44@%3Ccommits.pulsar.apache.org%3E",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://nvd.nist.gov/vuln/detail/CVE-2021-3121",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://security.netapp.com/advisory/ntap-20210219-0006/",
       },
     ],
@@ -9622,27 +9622,27 @@ exports[`parses securecodebox:master result file into findings 1`] = `
         "value": "CVE-2020-29652",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://nvd.nist.gov/vuln/detail/CVE-2020-29652",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2020-29652",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://go-review.googlesource.com/c/crypto/+/278852",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://groups.google.com/g/golang-announce/c/ouZIlBimOsE?pli=1",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://lists.apache.org/thread.html/r68032132c0399c29d6cdc7bd44918535da54060a10a12b1591328bff@%3Cnotifications.skywalking.apache.org%3E",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://nvd.nist.gov/vuln/detail/CVE-2020-29652",
       },
     ],
@@ -9677,35 +9677,35 @@ exports[`parses securecodebox:master result file into findings 1`] = `
         "value": "CVE-2020-9283",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://nvd.nist.gov/vuln/detail/CVE-2020-9283",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "http://packetstormsecurity.com/files/156480/Go-SSH-0.0.2-Denial-Of-Service.html",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2020-9283",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://groups.google.com/forum/#!topic/golang-announce/3L45YRc91SY",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://lists.debian.org/debian-lts-announce/2020/10/msg00014.html",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://lists.debian.org/debian-lts-announce/2020/11/msg00027.html",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://lists.debian.org/debian-lts-announce/2020/11/msg00031.html",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://nvd.nist.gov/vuln/detail/CVE-2020-9283",
       },
     ],
@@ -9739,31 +9739,31 @@ exports[`parses securecodebox:master result file into findings 1`] = `
         "value": "CVE-2019-11254",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://nvd.nist.gov/vuln/detail/CVE-2019-11254",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://github.com/kubernetes/kubernetes/issues/89535",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://groups.google.com/d/msg/kubernetes-announce/ALL9s73E5ck/4yHe8J-PBAAJ",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://groups.google.com/forum/#!topic/kubernetes-security-announce/wuwEwZigXBc",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://linux.oracle.com/cve/CVE-2019-11254.html",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://linux.oracle.com/errata/ELSA-2020-5653.html",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://security.netapp.com/advisory/ntap-20200413-0003/",
       },
     ],
@@ -9797,31 +9797,31 @@ exports[`parses securecodebox:master result file into findings 1`] = `
         "value": "CVE-2019-11250",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://nvd.nist.gov/vuln/detail/CVE-2019-11250",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "http://www.openwall.com/lists/oss-security/2020/10/16/2",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://access.redhat.com/errata/RHSA-2019:4052",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://access.redhat.com/errata/RHSA-2019:4087",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://github.com/kubernetes/kubernetes/issues/81114",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://nvd.nist.gov/vuln/detail/CVE-2019-11250",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://security.netapp.com/advisory/ntap-20190919-0003/",
       },
     ],
@@ -9853,23 +9853,23 @@ exports[`parses securecodebox:master result file into findings 1`] = `
         "value": "CVE-2020-8565",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://nvd.nist.gov/vuln/detail/CVE-2020-8565",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://github.com/kubernetes/kubernetes/issues/95623",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://groups.google.com/g/kubernetes-announce/c/ScdmyORnPDk",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://groups.google.com/g/kubernetes-security-discuss/c/vm-HcrFUOCs/m/36utxAM5CwAJ",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://nvd.nist.gov/vuln/detail/CVE-2020-8565",
       },
     ],
@@ -9900,19 +9900,19 @@ exports[`parses securecodebox:master result file into findings 1`] = `
         "value": "CVE-2020-26160",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://nvd.nist.gov/vuln/detail/CVE-2020-26160",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://github.com/dgrijalva/jwt-go/pull/426",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://nvd.nist.gov/vuln/detail/CVE-2020-26160",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://snyk.io/vuln/SNYK-GOLANG-GITHUBCOMDGRIJALVAJWTGO-596515",
       },
     ],
@@ -9949,43 +9949,43 @@ exports[`parses securecodebox:master result file into findings 1`] = `
         "value": "CVE-2021-3121",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://nvd.nist.gov/vuln/detail/CVE-2021-3121",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2021-3121",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://discuss.hashicorp.com/t/hcsec-2021-23-consul-exposed-to-denial-of-service-in-gogo-protobuf-dependency/29025",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://github.com/gogo/protobuf/commit/b03c65ea87cdc3521ede29f62fe3ce239267c1bc",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://github.com/gogo/protobuf/compare/v1.3.1...v1.3.2",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://lists.apache.org/thread.html/r68032132c0399c29d6cdc7bd44918535da54060a10a12b1591328bff@%3Cnotifications.skywalking.apache.org%3E",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://lists.apache.org/thread.html/r88d69555cb74a129a7bf84838073b61259b4a3830190e05a3b87994e@%3Ccommits.pulsar.apache.org%3E",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://lists.apache.org/thread.html/rc1e9ff22c5641d73701ba56362fb867d40ed287cca000b131dcf4a44@%3Ccommits.pulsar.apache.org%3E",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://nvd.nist.gov/vuln/detail/CVE-2021-3121",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://security.netapp.com/advisory/ntap-20210219-0006/",
       },
     ],
@@ -10018,27 +10018,27 @@ exports[`parses securecodebox:master result file into findings 1`] = `
         "value": "CVE-2019-19794",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://nvd.nist.gov/vuln/detail/CVE-2019-19794",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://github.com/coredns/coredns/issues/3519",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://github.com/coredns/coredns/issues/3547",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://github.com/miekg/dns/compare/v1.1.24...v1.1.25",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://github.com/miekg/dns/issues/1043",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://github.com/miekg/dns/pull/1044",
       },
     ],
@@ -10071,27 +10071,27 @@ exports[`parses securecodebox:master result file into findings 1`] = `
         "value": "CVE-2020-29652",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://nvd.nist.gov/vuln/detail/CVE-2020-29652",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2020-29652",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://go-review.googlesource.com/c/crypto/+/278852",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://groups.google.com/g/golang-announce/c/ouZIlBimOsE?pli=1",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://lists.apache.org/thread.html/r68032132c0399c29d6cdc7bd44918535da54060a10a12b1591328bff@%3Cnotifications.skywalking.apache.org%3E",
       },
       {
-        "type": "url",
+        "type": "URL",
         "value": "https://nvd.nist.gov/vuln/detail/CVE-2020-29652",
       },
     ],

--- a/scanners/trivy/parser/__snapshots__/parser.test.js.snap
+++ b/scanners/trivy/parser/__snapshots__/parser.test.js.snap
@@ -24,10 +24,40 @@ exports[`parses bkimminich/juice-shop:v10.2.0 result file into findings 1`] = `
     "mitigation": "Update the affected package apk-tools to the fixed version: 2.10.7-r0 or remove the package from the image.",
     "name": "Vulnerability in Dependency apk-tools (2.10.4-r3)",
     "osi_layer": "NOT_APPLICABLE",
-    "reference": {
-      "id": "CVE-2021-36159",
-      "source": "https://nvd.nist.gov/vuln/detail/CVE-2021-36159",
-    },
+    "references": [
+      {
+        "type": "CVE",
+        "value": "CVE-2021-36159",
+      },
+      {
+        "type": "url",
+        "value": "https://nvd.nist.gov/vuln/detail/CVE-2021-36159",
+      },
+      {
+        "type": "url",
+        "value": "https://github.com/freebsd/freebsd-src/commits/main/lib/libfetch",
+      },
+      {
+        "type": "url",
+        "value": "https://gitlab.alpinelinux.org/alpine/apk-tools/-/issues/10749",
+      },
+      {
+        "type": "url",
+        "value": "https://lists.apache.org/thread.html/r61db8e7dcb56dc000a5387a88f7a473bacec5ee01b9ff3f55308aacc@%3Cdev.kafka.apache.org%3E",
+      },
+      {
+        "type": "url",
+        "value": "https://lists.apache.org/thread.html/r61db8e7dcb56dc000a5387a88f7a473bacec5ee01b9ff3f55308aacc@%3Cusers.kafka.apache.org%3E",
+      },
+      {
+        "type": "url",
+        "value": "https://lists.apache.org/thread.html/rbf4ce74b0d1fa9810dec50ba3ace0caeea677af7c27a97111c06ccb7@%3Cdev.kafka.apache.org%3E",
+      },
+      {
+        "type": "url",
+        "value": "https://lists.apache.org/thread.html/rbf4ce74b0d1fa9810dec50ba3ace0caeea677af7c27a97111c06ccb7@%3Cusers.kafka.apache.org%3E",
+      },
+    ],
     "severity": "HIGH",
   },
   {
@@ -48,10 +78,24 @@ exports[`parses bkimminich/juice-shop:v10.2.0 result file into findings 1`] = `
     "mitigation": "Update the affected package apk-tools to the fixed version: 2.10.6-r0 or remove the package from the image.",
     "name": "Vulnerability in Dependency apk-tools (2.10.4-r3)",
     "osi_layer": "NOT_APPLICABLE",
-    "reference": {
-      "id": "CVE-2021-30139",
-      "source": "https://nvd.nist.gov/vuln/detail/CVE-2021-30139",
-    },
+    "references": [
+      {
+        "type": "CVE",
+        "value": "CVE-2021-30139",
+      },
+      {
+        "type": "url",
+        "value": "https://nvd.nist.gov/vuln/detail/CVE-2021-30139",
+      },
+      {
+        "type": "url",
+        "value": "https://gitlab.alpinelinux.org/alpine/apk-tools/-/issues/10741",
+      },
+      {
+        "type": "url",
+        "value": "https://gitlab.alpinelinux.org/alpine/aports/-/issues/12606",
+      },
+    ],
     "severity": "HIGH",
   },
   {
@@ -77,10 +121,44 @@ exports[`parses bkimminich/juice-shop:v10.2.0 result file into findings 1`] = `
     "mitigation": "Update the affected package busybox to the fixed version: 1.31.1-r10 or remove the package from the image.",
     "name": "busybox: invalid free or segmentation fault via malformed gzip data",
     "osi_layer": "NOT_APPLICABLE",
-    "reference": {
-      "id": "CVE-2021-28831",
-      "source": "https://nvd.nist.gov/vuln/detail/CVE-2021-28831",
-    },
+    "references": [
+      {
+        "type": "CVE",
+        "value": "CVE-2021-28831",
+      },
+      {
+        "type": "url",
+        "value": "https://nvd.nist.gov/vuln/detail/CVE-2021-28831",
+      },
+      {
+        "type": "url",
+        "value": "https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2021-28831",
+      },
+      {
+        "type": "url",
+        "value": "https://git.busybox.net/busybox/commit/?id=f25d254dfd4243698c31a4f3153d4ac72aa9e9bd",
+      },
+      {
+        "type": "url",
+        "value": "https://lists.debian.org/debian-lts-announce/2021/04/msg00001.html",
+      },
+      {
+        "type": "url",
+        "value": "https://lists.fedoraproject.org/archives/list/package-announce@lists.fedoraproject.org/message/3UDQGJRECXFS5EZVDH2OI45FMO436AC4/",
+      },
+      {
+        "type": "url",
+        "value": "https://lists.fedoraproject.org/archives/list/package-announce@lists.fedoraproject.org/message/Z7ZIFKPRR32ZYA3WAA2NXFA3QHHOU6FJ/",
+      },
+      {
+        "type": "url",
+        "value": "https://lists.fedoraproject.org/archives/list/package-announce@lists.fedoraproject.org/message/ZASBW7QRRLY5V2R44MQ4QQM4CZIDHM2U/",
+      },
+      {
+        "type": "url",
+        "value": "https://security.gentoo.org/glsa/202105-09",
+      },
+    ],
     "severity": "HIGH",
   },
   {
@@ -111,10 +189,64 @@ exports[`parses bkimminich/juice-shop:v10.2.0 result file into findings 1`] = `
     "mitigation": "Update the affected package libcrypto1.1 to the fixed version: 1.1.1l-r0 or remove the package from the image.",
     "name": "openssl: SM2 Decryption Buffer Overflow",
     "osi_layer": "NOT_APPLICABLE",
-    "reference": {
-      "id": "CVE-2021-3711",
-      "source": "https://nvd.nist.gov/vuln/detail/CVE-2021-3711",
-    },
+    "references": [
+      {
+        "type": "CVE",
+        "value": "CVE-2021-3711",
+      },
+      {
+        "type": "url",
+        "value": "https://nvd.nist.gov/vuln/detail/CVE-2021-3711",
+      },
+      {
+        "type": "url",
+        "value": "http://www.openwall.com/lists/oss-security/2021/08/26/2",
+      },
+      {
+        "type": "url",
+        "value": "https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2021-3711",
+      },
+      {
+        "type": "url",
+        "value": "https://git.openssl.org/gitweb/?p=openssl.git;a=commitdiff;h=59f5e75f3bced8fc0e130d72a3f582cf7b480b46",
+      },
+      {
+        "type": "url",
+        "value": "https://lists.apache.org/thread.html/r18995de860f0e63635f3008fd2a6aca82394249476d21691e7c59c9e@%3Cdev.tomcat.apache.org%3E",
+      },
+      {
+        "type": "url",
+        "value": "https://lists.apache.org/thread.html/rad5d9f83f0d11fb3f8bb148d179b8a9ad7c6a17f18d70e5805a713d1@%3Cdev.tomcat.apache.org%3E",
+      },
+      {
+        "type": "url",
+        "value": "https://security.netapp.com/advisory/ntap-20210827-0010/",
+      },
+      {
+        "type": "url",
+        "value": "https://security.netapp.com/advisory/ntap-20211022-0003/",
+      },
+      {
+        "type": "url",
+        "value": "https://ubuntu.com/security/notices/USN-5051-1",
+      },
+      {
+        "type": "url",
+        "value": "https://www.debian.org/security/2021/dsa-4963",
+      },
+      {
+        "type": "url",
+        "value": "https://www.openssl.org/news/secadv/20210824.txt",
+      },
+      {
+        "type": "url",
+        "value": "https://www.oracle.com/security-alerts/cpuoct2021.html",
+      },
+      {
+        "type": "url",
+        "value": "https://www.tenable.com/security/tns-2021-16",
+      },
+    ],
     "severity": "HIGH",
   },
   {
@@ -167,10 +299,152 @@ exports[`parses bkimminich/juice-shop:v10.2.0 result file into findings 1`] = `
     "mitigation": "Update the affected package libcrypto1.1 to the fixed version: 1.1.1g-r0 or remove the package from the image.",
     "name": "openssl: Segmentation fault in SSL_check_chain causes denial of service",
     "osi_layer": "NOT_APPLICABLE",
-    "reference": {
-      "id": "CVE-2020-1967",
-      "source": "https://nvd.nist.gov/vuln/detail/CVE-2020-1967",
-    },
+    "references": [
+      {
+        "type": "CVE",
+        "value": "CVE-2020-1967",
+      },
+      {
+        "type": "url",
+        "value": "https://nvd.nist.gov/vuln/detail/CVE-2020-1967",
+      },
+      {
+        "type": "url",
+        "value": "http://lists.opensuse.org/opensuse-security-announce/2020-07/msg00004.html",
+      },
+      {
+        "type": "url",
+        "value": "http://lists.opensuse.org/opensuse-security-announce/2020-07/msg00011.html",
+      },
+      {
+        "type": "url",
+        "value": "http://packetstormsecurity.com/files/157527/OpenSSL-signature_algorithms_cert-Denial-Of-Service.html",
+      },
+      {
+        "type": "url",
+        "value": "http://seclists.org/fulldisclosure/2020/May/5",
+      },
+      {
+        "type": "url",
+        "value": "http://www.openwall.com/lists/oss-security/2020/04/22/2",
+      },
+      {
+        "type": "url",
+        "value": "https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2020-1967",
+      },
+      {
+        "type": "url",
+        "value": "https://git.openssl.org/gitweb/?p=openssl.git;a=commitdiff;h=eb563247aef3e83dda7679c43f9649270462e5b1",
+      },
+      {
+        "type": "url",
+        "value": "https://github.com/irsl/CVE-2020-1967",
+      },
+      {
+        "type": "url",
+        "value": "https://kb.pulsesecure.net/articles/Pulse_Security_Advisories/SA44440",
+      },
+      {
+        "type": "url",
+        "value": "https://lists.apache.org/thread.html/r66ea9c436da150683432db5fbc8beb8ae01886c6459ac30c2cea7345@%3Cdev.tomcat.apache.org%3E",
+      },
+      {
+        "type": "url",
+        "value": "https://lists.apache.org/thread.html/r94d6ac3f010a38fccf4f432b12180a13fa1cf303559bd805648c9064@%3Cdev.tomcat.apache.org%3E",
+      },
+      {
+        "type": "url",
+        "value": "https://lists.apache.org/thread.html/r9a41e304992ce6aec6585a87842b4f2e692604f5c892c37e3b0587ee@%3Cdev.tomcat.apache.org%3E",
+      },
+      {
+        "type": "url",
+        "value": "https://lists.fedoraproject.org/archives/list/package-announce@lists.fedoraproject.org/message/DDHOAATPWJCXRNFMJ2SASDBBNU5RJONY/",
+      },
+      {
+        "type": "url",
+        "value": "https://lists.fedoraproject.org/archives/list/package-announce@lists.fedoraproject.org/message/EXDDAOWSAIEFQNBHWYE6PPYFV4QXGMCD/",
+      },
+      {
+        "type": "url",
+        "value": "https://lists.fedoraproject.org/archives/list/package-announce@lists.fedoraproject.org/message/XVEP3LAK4JSPRXFO4QF4GG2IVXADV3SO/",
+      },
+      {
+        "type": "url",
+        "value": "https://nvd.nist.gov/vuln/detail/CVE-2020-1967",
+      },
+      {
+        "type": "url",
+        "value": "https://security.FreeBSD.org/advisories/FreeBSD-SA-20:11.openssl.asc",
+      },
+      {
+        "type": "url",
+        "value": "https://security.gentoo.org/glsa/202004-10",
+      },
+      {
+        "type": "url",
+        "value": "https://security.netapp.com/advisory/ntap-20200424-0003/",
+      },
+      {
+        "type": "url",
+        "value": "https://security.netapp.com/advisory/ntap-20200717-0004/",
+      },
+      {
+        "type": "url",
+        "value": "https://www.debian.org/security/2020/dsa-4661",
+      },
+      {
+        "type": "url",
+        "value": "https://www.openssl.org/news/secadv/20200421.txt",
+      },
+      {
+        "type": "url",
+        "value": "https://www.oracle.com//security-alerts/cpujul2021.html",
+      },
+      {
+        "type": "url",
+        "value": "https://www.oracle.com/security-alerts/cpuApr2021.html",
+      },
+      {
+        "type": "url",
+        "value": "https://www.oracle.com/security-alerts/cpujan2021.html",
+      },
+      {
+        "type": "url",
+        "value": "https://www.oracle.com/security-alerts/cpujul2020.html",
+      },
+      {
+        "type": "url",
+        "value": "https://www.oracle.com/security-alerts/cpuoct2020.html",
+      },
+      {
+        "type": "url",
+        "value": "https://www.oracle.com/security-alerts/cpuoct2021.html",
+      },
+      {
+        "type": "url",
+        "value": "https://www.synology.com/security/advisory/Synology_SA_20_05",
+      },
+      {
+        "type": "url",
+        "value": "https://www.synology.com/security/advisory/Synology_SA_20_05_OpenSSL",
+      },
+      {
+        "type": "url",
+        "value": "https://www.tenable.com/security/tns-2020-03",
+      },
+      {
+        "type": "url",
+        "value": "https://www.tenable.com/security/tns-2020-04",
+      },
+      {
+        "type": "url",
+        "value": "https://www.tenable.com/security/tns-2020-11",
+      },
+      {
+        "type": "url",
+        "value": "https://www.tenable.com/security/tns-2021-10",
+      },
+    ],
     "severity": "HIGH",
   },
   {
@@ -210,10 +484,100 @@ exports[`parses bkimminich/juice-shop:v10.2.0 result file into findings 1`] = `
     "mitigation": "Update the affected package libcrypto1.1 to the fixed version: 1.1.1j-r0 or remove the package from the image.",
     "name": "openssl: integer overflow in CipherUpdate",
     "osi_layer": "NOT_APPLICABLE",
-    "reference": {
-      "id": "CVE-2021-23840",
-      "source": "https://nvd.nist.gov/vuln/detail/CVE-2021-23840",
-    },
+    "references": [
+      {
+        "type": "CVE",
+        "value": "CVE-2021-23840",
+      },
+      {
+        "type": "url",
+        "value": "https://nvd.nist.gov/vuln/detail/CVE-2021-23840",
+      },
+      {
+        "type": "url",
+        "value": "https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2021-23840",
+      },
+      {
+        "type": "url",
+        "value": "https://git.openssl.org/gitweb/?p=openssl.git;a=commitdiff;h=6a51b9e1d0cf0bf8515f7201b68fb0a3482b3dc1",
+      },
+      {
+        "type": "url",
+        "value": "https://git.openssl.org/gitweb/?p=openssl.git;a=commitdiff;h=9b1129239f3ebb1d1c98ce9ed41d5c9476c47cb2",
+      },
+      {
+        "type": "url",
+        "value": "https://kb.pulsesecure.net/articles/Pulse_Security_Advisories/SA44846",
+      },
+      {
+        "type": "url",
+        "value": "https://kc.mcafee.com/corporate/index?page=content&id=SB10366",
+      },
+      {
+        "type": "url",
+        "value": "https://linux.oracle.com/cve/CVE-2021-23840.html",
+      },
+      {
+        "type": "url",
+        "value": "https://linux.oracle.com/errata/ELSA-2021-9528.html",
+      },
+      {
+        "type": "url",
+        "value": "https://lists.apache.org/thread.html/r58af02e294bd07f487e2c64ffc0a29b837db5600e33b6e698b9d696b@%3Cissues.bookkeeper.apache.org%3E",
+      },
+      {
+        "type": "url",
+        "value": "https://lists.apache.org/thread.html/rf4c02775860db415b4955778a131c2795223f61cb8c6a450893651e4@%3Cissues.bookkeeper.apache.org%3E",
+      },
+      {
+        "type": "url",
+        "value": "https://security.gentoo.org/glsa/202103-03",
+      },
+      {
+        "type": "url",
+        "value": "https://security.netapp.com/advisory/ntap-20210219-0009/",
+      },
+      {
+        "type": "url",
+        "value": "https://ubuntu.com/security/notices/USN-4738-1",
+      },
+      {
+        "type": "url",
+        "value": "https://ubuntu.com/security/notices/USN-5088-1",
+      },
+      {
+        "type": "url",
+        "value": "https://www.debian.org/security/2021/dsa-4855",
+      },
+      {
+        "type": "url",
+        "value": "https://www.openssl.org/news/secadv/20210216.txt",
+      },
+      {
+        "type": "url",
+        "value": "https://www.oracle.com//security-alerts/cpujul2021.html",
+      },
+      {
+        "type": "url",
+        "value": "https://www.oracle.com/security-alerts/cpuApr2021.html",
+      },
+      {
+        "type": "url",
+        "value": "https://www.oracle.com/security-alerts/cpuoct2021.html",
+      },
+      {
+        "type": "url",
+        "value": "https://www.tenable.com/security/tns-2021-03",
+      },
+      {
+        "type": "url",
+        "value": "https://www.tenable.com/security/tns-2021-09",
+      },
+      {
+        "type": "url",
+        "value": "https://www.tenable.com/security/tns-2021-10",
+      },
+    ],
     "severity": "HIGH",
   },
   {
@@ -255,10 +619,108 @@ exports[`parses bkimminich/juice-shop:v10.2.0 result file into findings 1`] = `
     "mitigation": "Update the affected package libcrypto1.1 to the fixed version: 1.1.1k-r0 or remove the package from the image.",
     "name": "openssl: CA certificate check bypass with X509_V_FLAG_X509_STRICT",
     "osi_layer": "NOT_APPLICABLE",
-    "reference": {
-      "id": "CVE-2021-3450",
-      "source": "https://nvd.nist.gov/vuln/detail/CVE-2021-3450",
-    },
+    "references": [
+      {
+        "type": "CVE",
+        "value": "CVE-2021-3450",
+      },
+      {
+        "type": "url",
+        "value": "https://nvd.nist.gov/vuln/detail/CVE-2021-3450",
+      },
+      {
+        "type": "url",
+        "value": "http://www.openwall.com/lists/oss-security/2021/03/27/1",
+      },
+      {
+        "type": "url",
+        "value": "http://www.openwall.com/lists/oss-security/2021/03/27/2",
+      },
+      {
+        "type": "url",
+        "value": "http://www.openwall.com/lists/oss-security/2021/03/28/3",
+      },
+      {
+        "type": "url",
+        "value": "http://www.openwall.com/lists/oss-security/2021/03/28/4",
+      },
+      {
+        "type": "url",
+        "value": "https://git.openssl.org/gitweb/?p=openssl.git;a=commitdiff;h=2a40b7bc7b94dd7de897a74571e7024f0cf0d63b",
+      },
+      {
+        "type": "url",
+        "value": "https://kb.pulsesecure.net/articles/Pulse_Security_Advisories/SA44845",
+      },
+      {
+        "type": "url",
+        "value": "https://kc.mcafee.com/corporate/index?page=content&id=SB10356",
+      },
+      {
+        "type": "url",
+        "value": "https://linux.oracle.com/cve/CVE-2021-3450.html",
+      },
+      {
+        "type": "url",
+        "value": "https://linux.oracle.com/errata/ELSA-2021-9151.html",
+      },
+      {
+        "type": "url",
+        "value": "https://lists.fedoraproject.org/archives/list/package-announce@lists.fedoraproject.org/message/CCBFLLVQVILIVGZMBJL3IXZGKWQISYNP/",
+      },
+      {
+        "type": "url",
+        "value": "https://mta.openssl.org/pipermail/openssl-announce/2021-March/000198.html",
+      },
+      {
+        "type": "url",
+        "value": "https://psirt.global.sonicwall.com/vuln-detail/SNWLID-2021-0013",
+      },
+      {
+        "type": "url",
+        "value": "https://security.FreeBSD.org/advisories/FreeBSD-SA-21:07.openssl.asc",
+      },
+      {
+        "type": "url",
+        "value": "https://security.gentoo.org/glsa/202103-03",
+      },
+      {
+        "type": "url",
+        "value": "https://security.netapp.com/advisory/ntap-20210326-0006/",
+      },
+      {
+        "type": "url",
+        "value": "https://tools.cisco.com/security/center/content/CiscoSecurityAdvisory/cisco-sa-openssl-2021-GHY28dJd",
+      },
+      {
+        "type": "url",
+        "value": "https://www.openssl.org/news/secadv/20210325.txt",
+      },
+      {
+        "type": "url",
+        "value": "https://www.oracle.com//security-alerts/cpujul2021.html",
+      },
+      {
+        "type": "url",
+        "value": "https://www.oracle.com/security-alerts/cpuApr2021.html",
+      },
+      {
+        "type": "url",
+        "value": "https://www.oracle.com/security-alerts/cpuoct2021.html",
+      },
+      {
+        "type": "url",
+        "value": "https://www.tenable.com/security/tns-2021-05",
+      },
+      {
+        "type": "url",
+        "value": "https://www.tenable.com/security/tns-2021-08",
+      },
+      {
+        "type": "url",
+        "value": "https://www.tenable.com/security/tns-2021-09",
+      },
+    ],
     "severity": "HIGH",
   },
   {
@@ -296,10 +758,92 @@ exports[`parses bkimminich/juice-shop:v10.2.0 result file into findings 1`] = `
     "mitigation": "Update the affected package libcrypto1.1 to the fixed version: 1.1.1l-r0 or remove the package from the image.",
     "name": "openssl: Read buffer overruns processing ASN.1 strings",
     "osi_layer": "NOT_APPLICABLE",
-    "reference": {
-      "id": "CVE-2021-3712",
-      "source": "https://nvd.nist.gov/vuln/detail/CVE-2021-3712",
-    },
+    "references": [
+      {
+        "type": "CVE",
+        "value": "CVE-2021-3712",
+      },
+      {
+        "type": "url",
+        "value": "https://nvd.nist.gov/vuln/detail/CVE-2021-3712",
+      },
+      {
+        "type": "url",
+        "value": "http://www.openwall.com/lists/oss-security/2021/08/26/2",
+      },
+      {
+        "type": "url",
+        "value": "https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2021-3712",
+      },
+      {
+        "type": "url",
+        "value": "https://git.openssl.org/gitweb/?p=openssl.git;a=commitdiff;h=94d23fcff9b2a7a8368dfe52214d5c2569882c11",
+      },
+      {
+        "type": "url",
+        "value": "https://git.openssl.org/gitweb/?p=openssl.git;a=commitdiff;h=ccb0a11145ee72b042d10593a64eaf9e8a55ec12",
+      },
+      {
+        "type": "url",
+        "value": "https://kc.mcafee.com/corporate/index?page=content&id=SB10366",
+      },
+      {
+        "type": "url",
+        "value": "https://lists.apache.org/thread.html/r18995de860f0e63635f3008fd2a6aca82394249476d21691e7c59c9e@%3Cdev.tomcat.apache.org%3E",
+      },
+      {
+        "type": "url",
+        "value": "https://lists.apache.org/thread.html/rad5d9f83f0d11fb3f8bb148d179b8a9ad7c6a17f18d70e5805a713d1@%3Cdev.tomcat.apache.org%3E",
+      },
+      {
+        "type": "url",
+        "value": "https://lists.debian.org/debian-lts-announce/2021/09/msg00014.html",
+      },
+      {
+        "type": "url",
+        "value": "https://lists.debian.org/debian-lts-announce/2021/09/msg00021.html",
+      },
+      {
+        "type": "url",
+        "value": "https://security.netapp.com/advisory/ntap-20210827-0010/",
+      },
+      {
+        "type": "url",
+        "value": "https://ubuntu.com/security/notices/USN-5051-1",
+      },
+      {
+        "type": "url",
+        "value": "https://ubuntu.com/security/notices/USN-5051-2",
+      },
+      {
+        "type": "url",
+        "value": "https://ubuntu.com/security/notices/USN-5051-3",
+      },
+      {
+        "type": "url",
+        "value": "https://ubuntu.com/security/notices/USN-5051-4 (regression only in trusty/esm)",
+      },
+      {
+        "type": "url",
+        "value": "https://ubuntu.com/security/notices/USN-5088-1",
+      },
+      {
+        "type": "url",
+        "value": "https://www.debian.org/security/2021/dsa-4963",
+      },
+      {
+        "type": "url",
+        "value": "https://www.openssl.org/news/secadv/20210824.txt",
+      },
+      {
+        "type": "url",
+        "value": "https://www.oracle.com/security-alerts/cpuoct2021.html",
+      },
+      {
+        "type": "url",
+        "value": "https://www.tenable.com/security/tns-2021-16",
+      },
+    ],
     "severity": "HIGH",
   },
   {
@@ -346,10 +890,128 @@ exports[`parses bkimminich/juice-shop:v10.2.0 result file into findings 1`] = `
     "mitigation": "Update the affected package libcrypto1.1 to the fixed version: 1.1.1i-r0 or remove the package from the image.",
     "name": "openssl: EDIPARTYNAME NULL pointer de-reference",
     "osi_layer": "NOT_APPLICABLE",
-    "reference": {
-      "id": "CVE-2020-1971",
-      "source": "https://nvd.nist.gov/vuln/detail/CVE-2020-1971",
-    },
+    "references": [
+      {
+        "type": "CVE",
+        "value": "CVE-2020-1971",
+      },
+      {
+        "type": "url",
+        "value": "https://nvd.nist.gov/vuln/detail/CVE-2020-1971",
+      },
+      {
+        "type": "url",
+        "value": "http://www.openwall.com/lists/oss-security/2021/09/14/2",
+      },
+      {
+        "type": "url",
+        "value": "https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2020-1971",
+      },
+      {
+        "type": "url",
+        "value": "https://git.openssl.org/gitweb/?p=openssl.git;a=commitdiff;h=2154ab83e14ede338d2ede9bbe5cdfce5d5a6c9e",
+      },
+      {
+        "type": "url",
+        "value": "https://git.openssl.org/gitweb/?p=openssl.git;a=commitdiff;h=f960d81215ebf3f65e03d4d5d857fb9b666d6920",
+      },
+      {
+        "type": "url",
+        "value": "https://kb.pulsesecure.net/articles/Pulse_Security_Advisories/SA44676",
+      },
+      {
+        "type": "url",
+        "value": "https://linux.oracle.com/cve/CVE-2020-1971.html",
+      },
+      {
+        "type": "url",
+        "value": "https://linux.oracle.com/errata/ELSA-2021-9150.html",
+      },
+      {
+        "type": "url",
+        "value": "https://lists.apache.org/thread.html/r63c6f2dd363d9b514d0a4bcf624580616a679898cc14c109a49b750c@%3Cdev.tomcat.apache.org%3E",
+      },
+      {
+        "type": "url",
+        "value": "https://lists.apache.org/thread.html/rbb769f771711fb274e0a4acb1b5911c8aab544a6ac5e8c12d40c5143@%3Ccommits.pulsar.apache.org%3E",
+      },
+      {
+        "type": "url",
+        "value": "https://lists.debian.org/debian-lts-announce/2020/12/msg00020.html",
+      },
+      {
+        "type": "url",
+        "value": "https://lists.debian.org/debian-lts-announce/2020/12/msg00021.html",
+      },
+      {
+        "type": "url",
+        "value": "https://lists.fedoraproject.org/archives/list/package-announce@lists.fedoraproject.org/message/DGSI34Y5LQ5RYXN4M2I5ZQT65LFVDOUU/",
+      },
+      {
+        "type": "url",
+        "value": "https://lists.fedoraproject.org/archives/list/package-announce@lists.fedoraproject.org/message/PWPSSZNZOBJU2YR6Z4TGHXKYW3YP5QG7/",
+      },
+      {
+        "type": "url",
+        "value": "https://security.FreeBSD.org/advisories/FreeBSD-SA-20:33.openssl.asc",
+      },
+      {
+        "type": "url",
+        "value": "https://security.gentoo.org/glsa/202012-13",
+      },
+      {
+        "type": "url",
+        "value": "https://security.netapp.com/advisory/ntap-20201218-0005/",
+      },
+      {
+        "type": "url",
+        "value": "https://security.netapp.com/advisory/ntap-20210513-0002/",
+      },
+      {
+        "type": "url",
+        "value": "https://ubuntu.com/security/notices/USN-4662-1",
+      },
+      {
+        "type": "url",
+        "value": "https://ubuntu.com/security/notices/USN-4745-1",
+      },
+      {
+        "type": "url",
+        "value": "https://www.debian.org/security/2020/dsa-4807",
+      },
+      {
+        "type": "url",
+        "value": "https://www.openssl.org/news/secadv/20201208.txt",
+      },
+      {
+        "type": "url",
+        "value": "https://www.oracle.com//security-alerts/cpujul2021.html",
+      },
+      {
+        "type": "url",
+        "value": "https://www.oracle.com/security-alerts/cpuApr2021.html",
+      },
+      {
+        "type": "url",
+        "value": "https://www.oracle.com/security-alerts/cpujan2021.html",
+      },
+      {
+        "type": "url",
+        "value": "https://www.oracle.com/security-alerts/cpuoct2021.html",
+      },
+      {
+        "type": "url",
+        "value": "https://www.tenable.com/security/tns-2020-11",
+      },
+      {
+        "type": "url",
+        "value": "https://www.tenable.com/security/tns-2021-09",
+      },
+      {
+        "type": "url",
+        "value": "https://www.tenable.com/security/tns-2021-10",
+      },
+    ],
     "severity": "MEDIUM",
   },
   {
@@ -392,10 +1054,112 @@ exports[`parses bkimminich/juice-shop:v10.2.0 result file into findings 1`] = `
     "mitigation": "Update the affected package libcrypto1.1 to the fixed version: 1.1.1j-r0 or remove the package from the image.",
     "name": "openssl: NULL pointer dereference in X509_issuer_and_serial_hash()",
     "osi_layer": "NOT_APPLICABLE",
-    "reference": {
-      "id": "CVE-2021-23841",
-      "source": "https://nvd.nist.gov/vuln/detail/CVE-2021-23841",
-    },
+    "references": [
+      {
+        "type": "CVE",
+        "value": "CVE-2021-23841",
+      },
+      {
+        "type": "url",
+        "value": "https://nvd.nist.gov/vuln/detail/CVE-2021-23841",
+      },
+      {
+        "type": "url",
+        "value": "http://seclists.org/fulldisclosure/2021/May/67",
+      },
+      {
+        "type": "url",
+        "value": "http://seclists.org/fulldisclosure/2021/May/68",
+      },
+      {
+        "type": "url",
+        "value": "http://seclists.org/fulldisclosure/2021/May/70",
+      },
+      {
+        "type": "url",
+        "value": "https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2021-23841",
+      },
+      {
+        "type": "url",
+        "value": "https://git.openssl.org/gitweb/?p=openssl.git;a=commitdiff;h=122a19ab48091c657f7cb1fb3af9fc07bd557bbf",
+      },
+      {
+        "type": "url",
+        "value": "https://git.openssl.org/gitweb/?p=openssl.git;a=commitdiff;h=8252ee4d90f3f2004d3d0aeeed003ad49c9a7807",
+      },
+      {
+        "type": "url",
+        "value": "https://kb.pulsesecure.net/articles/Pulse_Security_Advisories/SA44846",
+      },
+      {
+        "type": "url",
+        "value": "https://linux.oracle.com/cve/CVE-2021-23841.html",
+      },
+      {
+        "type": "url",
+        "value": "https://linux.oracle.com/errata/ELSA-2021-9528.html",
+      },
+      {
+        "type": "url",
+        "value": "https://security.gentoo.org/glsa/202103-03",
+      },
+      {
+        "type": "url",
+        "value": "https://security.netapp.com/advisory/ntap-20210219-0009/",
+      },
+      {
+        "type": "url",
+        "value": "https://security.netapp.com/advisory/ntap-20210513-0002/",
+      },
+      {
+        "type": "url",
+        "value": "https://support.apple.com/kb/HT212528",
+      },
+      {
+        "type": "url",
+        "value": "https://support.apple.com/kb/HT212529",
+      },
+      {
+        "type": "url",
+        "value": "https://support.apple.com/kb/HT212534",
+      },
+      {
+        "type": "url",
+        "value": "https://ubuntu.com/security/notices/USN-4738-1",
+      },
+      {
+        "type": "url",
+        "value": "https://ubuntu.com/security/notices/USN-4745-1",
+      },
+      {
+        "type": "url",
+        "value": "https://www.debian.org/security/2021/dsa-4855",
+      },
+      {
+        "type": "url",
+        "value": "https://www.openssl.org/news/secadv/20210216.txt",
+      },
+      {
+        "type": "url",
+        "value": "https://www.oracle.com//security-alerts/cpujul2021.html",
+      },
+      {
+        "type": "url",
+        "value": "https://www.oracle.com/security-alerts/cpuApr2021.html",
+      },
+      {
+        "type": "url",
+        "value": "https://www.oracle.com/security-alerts/cpuoct2021.html",
+      },
+      {
+        "type": "url",
+        "value": "https://www.tenable.com/security/tns-2021-03",
+      },
+      {
+        "type": "url",
+        "value": "https://www.tenable.com/security/tns-2021-09",
+      },
+    ],
     "severity": "MEDIUM",
   },
   {
@@ -444,10 +1208,136 @@ exports[`parses bkimminich/juice-shop:v10.2.0 result file into findings 1`] = `
     "mitigation": "Update the affected package libcrypto1.1 to the fixed version: 1.1.1k-r0 or remove the package from the image.",
     "name": "openssl: NULL pointer dereference in signature_algorithms processing",
     "osi_layer": "NOT_APPLICABLE",
-    "reference": {
-      "id": "CVE-2021-3449",
-      "source": "https://nvd.nist.gov/vuln/detail/CVE-2021-3449",
-    },
+    "references": [
+      {
+        "type": "CVE",
+        "value": "CVE-2021-3449",
+      },
+      {
+        "type": "url",
+        "value": "https://nvd.nist.gov/vuln/detail/CVE-2021-3449",
+      },
+      {
+        "type": "url",
+        "value": "http://www.openwall.com/lists/oss-security/2021/03/27/1",
+      },
+      {
+        "type": "url",
+        "value": "http://www.openwall.com/lists/oss-security/2021/03/27/2",
+      },
+      {
+        "type": "url",
+        "value": "http://www.openwall.com/lists/oss-security/2021/03/28/3",
+      },
+      {
+        "type": "url",
+        "value": "http://www.openwall.com/lists/oss-security/2021/03/28/4",
+      },
+      {
+        "type": "url",
+        "value": "https://cert-portal.siemens.com/productcert/pdf/ssa-772220.pdf",
+      },
+      {
+        "type": "url",
+        "value": "https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2021-3449",
+      },
+      {
+        "type": "url",
+        "value": "https://git.openssl.org/gitweb/?p=openssl.git;a=commitdiff;h=fb9fa6b51defd48157eeb207f52181f735d96148",
+      },
+      {
+        "type": "url",
+        "value": "https://kb.pulsesecure.net/articles/Pulse_Security_Advisories/SA44845",
+      },
+      {
+        "type": "url",
+        "value": "https://kc.mcafee.com/corporate/index?page=content&id=SB10356",
+      },
+      {
+        "type": "url",
+        "value": "https://linux.oracle.com/cve/CVE-2021-3449.html",
+      },
+      {
+        "type": "url",
+        "value": "https://linux.oracle.com/errata/ELSA-2021-9151.html",
+      },
+      {
+        "type": "url",
+        "value": "https://lists.debian.org/debian-lts-announce/2021/08/msg00029.html",
+      },
+      {
+        "type": "url",
+        "value": "https://lists.fedoraproject.org/archives/list/package-announce@lists.fedoraproject.org/message/CCBFLLVQVILIVGZMBJL3IXZGKWQISYNP/",
+      },
+      {
+        "type": "url",
+        "value": "https://psirt.global.sonicwall.com/vuln-detail/SNWLID-2021-0013",
+      },
+      {
+        "type": "url",
+        "value": "https://security.FreeBSD.org/advisories/FreeBSD-SA-21:07.openssl.asc",
+      },
+      {
+        "type": "url",
+        "value": "https://security.gentoo.org/glsa/202103-03",
+      },
+      {
+        "type": "url",
+        "value": "https://security.netapp.com/advisory/ntap-20210326-0006/",
+      },
+      {
+        "type": "url",
+        "value": "https://security.netapp.com/advisory/ntap-20210513-0002/",
+      },
+      {
+        "type": "url",
+        "value": "https://tools.cisco.com/security/center/content/CiscoSecurityAdvisory/cisco-sa-openssl-2021-GHY28dJd",
+      },
+      {
+        "type": "url",
+        "value": "https://ubuntu.com/security/notices/USN-4891-1",
+      },
+      {
+        "type": "url",
+        "value": "https://ubuntu.com/security/notices/USN-5038-1",
+      },
+      {
+        "type": "url",
+        "value": "https://www.debian.org/security/2021/dsa-4875",
+      },
+      {
+        "type": "url",
+        "value": "https://www.openssl.org/news/secadv/20210325.txt",
+      },
+      {
+        "type": "url",
+        "value": "https://www.oracle.com//security-alerts/cpujul2021.html",
+      },
+      {
+        "type": "url",
+        "value": "https://www.oracle.com/security-alerts/cpuApr2021.html",
+      },
+      {
+        "type": "url",
+        "value": "https://www.oracle.com/security-alerts/cpuoct2021.html",
+      },
+      {
+        "type": "url",
+        "value": "https://www.tenable.com/security/tns-2021-05",
+      },
+      {
+        "type": "url",
+        "value": "https://www.tenable.com/security/tns-2021-06",
+      },
+      {
+        "type": "url",
+        "value": "https://www.tenable.com/security/tns-2021-09",
+      },
+      {
+        "type": "url",
+        "value": "https://www.tenable.com/security/tns-2021-10",
+      },
+    ],
     "severity": "MEDIUM",
   },
   {
@@ -473,10 +1363,44 @@ exports[`parses bkimminich/juice-shop:v10.2.0 result file into findings 1`] = `
     "mitigation": "Update the affected package libcrypto1.1 to the fixed version: 1.1.1j-r0 or remove the package from the image.",
     "name": "openssl: incorrect SSLv2 rollback protection",
     "osi_layer": "NOT_APPLICABLE",
-    "reference": {
-      "id": "CVE-2021-23839",
-      "source": "https://nvd.nist.gov/vuln/detail/CVE-2021-23839",
-    },
+    "references": [
+      {
+        "type": "CVE",
+        "value": "CVE-2021-23839",
+      },
+      {
+        "type": "url",
+        "value": "https://nvd.nist.gov/vuln/detail/CVE-2021-23839",
+      },
+      {
+        "type": "url",
+        "value": "https://git.openssl.org/gitweb/?p=openssl.git;a=commitdiff;h=30919ab80a478f2d81f2e9acdcca3fa4740cd547",
+      },
+      {
+        "type": "url",
+        "value": "https://kb.pulsesecure.net/articles/Pulse_Security_Advisories/SA44846",
+      },
+      {
+        "type": "url",
+        "value": "https://security.netapp.com/advisory/ntap-20210219-0009/",
+      },
+      {
+        "type": "url",
+        "value": "https://www.openssl.org/news/secadv/20210216.txt",
+      },
+      {
+        "type": "url",
+        "value": "https://www.oracle.com//security-alerts/cpujul2021.html",
+      },
+      {
+        "type": "url",
+        "value": "https://www.oracle.com/security-alerts/cpuApr2021.html",
+      },
+      {
+        "type": "url",
+        "value": "https://www.oracle.com/security-alerts/cpuoct2021.html",
+      },
+    ],
     "severity": "LOW",
   },
   {
@@ -501,10 +1425,40 @@ exports[`parses bkimminich/juice-shop:v10.2.0 result file into findings 1`] = `
     "mitigation": "Update the affected package libgcc to the fixed version: 9.3.0-r0 or remove the package from the image.",
     "name": "gcc: POWER9 "DARN" RNG intrinsic produces repeated output",
     "osi_layer": "NOT_APPLICABLE",
-    "reference": {
-      "id": "CVE-2019-15847",
-      "source": "https://nvd.nist.gov/vuln/detail/CVE-2019-15847",
-    },
+    "references": [
+      {
+        "type": "CVE",
+        "value": "CVE-2019-15847",
+      },
+      {
+        "type": "url",
+        "value": "https://nvd.nist.gov/vuln/detail/CVE-2019-15847",
+      },
+      {
+        "type": "url",
+        "value": "http://lists.opensuse.org/opensuse-security-announce/2019-10/msg00056.html",
+      },
+      {
+        "type": "url",
+        "value": "http://lists.opensuse.org/opensuse-security-announce/2019-10/msg00057.html",
+      },
+      {
+        "type": "url",
+        "value": "http://lists.opensuse.org/opensuse-security-announce/2020-05/msg00058.html",
+      },
+      {
+        "type": "url",
+        "value": "https://gcc.gnu.org/bugzilla/show_bug.cgi?id=91481",
+      },
+      {
+        "type": "url",
+        "value": "https://linux.oracle.com/cve/CVE-2019-15847.html",
+      },
+      {
+        "type": "url",
+        "value": "https://linux.oracle.com/errata/ELSA-2020-1864.html",
+      },
+    ],
     "severity": "HIGH",
   },
   {
@@ -535,10 +1489,64 @@ exports[`parses bkimminich/juice-shop:v10.2.0 result file into findings 1`] = `
     "mitigation": "Update the affected package libssl1.1 to the fixed version: 1.1.1l-r0 or remove the package from the image.",
     "name": "openssl: SM2 Decryption Buffer Overflow",
     "osi_layer": "NOT_APPLICABLE",
-    "reference": {
-      "id": "CVE-2021-3711",
-      "source": "https://nvd.nist.gov/vuln/detail/CVE-2021-3711",
-    },
+    "references": [
+      {
+        "type": "CVE",
+        "value": "CVE-2021-3711",
+      },
+      {
+        "type": "url",
+        "value": "https://nvd.nist.gov/vuln/detail/CVE-2021-3711",
+      },
+      {
+        "type": "url",
+        "value": "http://www.openwall.com/lists/oss-security/2021/08/26/2",
+      },
+      {
+        "type": "url",
+        "value": "https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2021-3711",
+      },
+      {
+        "type": "url",
+        "value": "https://git.openssl.org/gitweb/?p=openssl.git;a=commitdiff;h=59f5e75f3bced8fc0e130d72a3f582cf7b480b46",
+      },
+      {
+        "type": "url",
+        "value": "https://lists.apache.org/thread.html/r18995de860f0e63635f3008fd2a6aca82394249476d21691e7c59c9e@%3Cdev.tomcat.apache.org%3E",
+      },
+      {
+        "type": "url",
+        "value": "https://lists.apache.org/thread.html/rad5d9f83f0d11fb3f8bb148d179b8a9ad7c6a17f18d70e5805a713d1@%3Cdev.tomcat.apache.org%3E",
+      },
+      {
+        "type": "url",
+        "value": "https://security.netapp.com/advisory/ntap-20210827-0010/",
+      },
+      {
+        "type": "url",
+        "value": "https://security.netapp.com/advisory/ntap-20211022-0003/",
+      },
+      {
+        "type": "url",
+        "value": "https://ubuntu.com/security/notices/USN-5051-1",
+      },
+      {
+        "type": "url",
+        "value": "https://www.debian.org/security/2021/dsa-4963",
+      },
+      {
+        "type": "url",
+        "value": "https://www.openssl.org/news/secadv/20210824.txt",
+      },
+      {
+        "type": "url",
+        "value": "https://www.oracle.com/security-alerts/cpuoct2021.html",
+      },
+      {
+        "type": "url",
+        "value": "https://www.tenable.com/security/tns-2021-16",
+      },
+    ],
     "severity": "HIGH",
   },
   {
@@ -591,10 +1599,152 @@ exports[`parses bkimminich/juice-shop:v10.2.0 result file into findings 1`] = `
     "mitigation": "Update the affected package libssl1.1 to the fixed version: 1.1.1g-r0 or remove the package from the image.",
     "name": "openssl: Segmentation fault in SSL_check_chain causes denial of service",
     "osi_layer": "NOT_APPLICABLE",
-    "reference": {
-      "id": "CVE-2020-1967",
-      "source": "https://nvd.nist.gov/vuln/detail/CVE-2020-1967",
-    },
+    "references": [
+      {
+        "type": "CVE",
+        "value": "CVE-2020-1967",
+      },
+      {
+        "type": "url",
+        "value": "https://nvd.nist.gov/vuln/detail/CVE-2020-1967",
+      },
+      {
+        "type": "url",
+        "value": "http://lists.opensuse.org/opensuse-security-announce/2020-07/msg00004.html",
+      },
+      {
+        "type": "url",
+        "value": "http://lists.opensuse.org/opensuse-security-announce/2020-07/msg00011.html",
+      },
+      {
+        "type": "url",
+        "value": "http://packetstormsecurity.com/files/157527/OpenSSL-signature_algorithms_cert-Denial-Of-Service.html",
+      },
+      {
+        "type": "url",
+        "value": "http://seclists.org/fulldisclosure/2020/May/5",
+      },
+      {
+        "type": "url",
+        "value": "http://www.openwall.com/lists/oss-security/2020/04/22/2",
+      },
+      {
+        "type": "url",
+        "value": "https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2020-1967",
+      },
+      {
+        "type": "url",
+        "value": "https://git.openssl.org/gitweb/?p=openssl.git;a=commitdiff;h=eb563247aef3e83dda7679c43f9649270462e5b1",
+      },
+      {
+        "type": "url",
+        "value": "https://github.com/irsl/CVE-2020-1967",
+      },
+      {
+        "type": "url",
+        "value": "https://kb.pulsesecure.net/articles/Pulse_Security_Advisories/SA44440",
+      },
+      {
+        "type": "url",
+        "value": "https://lists.apache.org/thread.html/r66ea9c436da150683432db5fbc8beb8ae01886c6459ac30c2cea7345@%3Cdev.tomcat.apache.org%3E",
+      },
+      {
+        "type": "url",
+        "value": "https://lists.apache.org/thread.html/r94d6ac3f010a38fccf4f432b12180a13fa1cf303559bd805648c9064@%3Cdev.tomcat.apache.org%3E",
+      },
+      {
+        "type": "url",
+        "value": "https://lists.apache.org/thread.html/r9a41e304992ce6aec6585a87842b4f2e692604f5c892c37e3b0587ee@%3Cdev.tomcat.apache.org%3E",
+      },
+      {
+        "type": "url",
+        "value": "https://lists.fedoraproject.org/archives/list/package-announce@lists.fedoraproject.org/message/DDHOAATPWJCXRNFMJ2SASDBBNU5RJONY/",
+      },
+      {
+        "type": "url",
+        "value": "https://lists.fedoraproject.org/archives/list/package-announce@lists.fedoraproject.org/message/EXDDAOWSAIEFQNBHWYE6PPYFV4QXGMCD/",
+      },
+      {
+        "type": "url",
+        "value": "https://lists.fedoraproject.org/archives/list/package-announce@lists.fedoraproject.org/message/XVEP3LAK4JSPRXFO4QF4GG2IVXADV3SO/",
+      },
+      {
+        "type": "url",
+        "value": "https://nvd.nist.gov/vuln/detail/CVE-2020-1967",
+      },
+      {
+        "type": "url",
+        "value": "https://security.FreeBSD.org/advisories/FreeBSD-SA-20:11.openssl.asc",
+      },
+      {
+        "type": "url",
+        "value": "https://security.gentoo.org/glsa/202004-10",
+      },
+      {
+        "type": "url",
+        "value": "https://security.netapp.com/advisory/ntap-20200424-0003/",
+      },
+      {
+        "type": "url",
+        "value": "https://security.netapp.com/advisory/ntap-20200717-0004/",
+      },
+      {
+        "type": "url",
+        "value": "https://www.debian.org/security/2020/dsa-4661",
+      },
+      {
+        "type": "url",
+        "value": "https://www.openssl.org/news/secadv/20200421.txt",
+      },
+      {
+        "type": "url",
+        "value": "https://www.oracle.com//security-alerts/cpujul2021.html",
+      },
+      {
+        "type": "url",
+        "value": "https://www.oracle.com/security-alerts/cpuApr2021.html",
+      },
+      {
+        "type": "url",
+        "value": "https://www.oracle.com/security-alerts/cpujan2021.html",
+      },
+      {
+        "type": "url",
+        "value": "https://www.oracle.com/security-alerts/cpujul2020.html",
+      },
+      {
+        "type": "url",
+        "value": "https://www.oracle.com/security-alerts/cpuoct2020.html",
+      },
+      {
+        "type": "url",
+        "value": "https://www.oracle.com/security-alerts/cpuoct2021.html",
+      },
+      {
+        "type": "url",
+        "value": "https://www.synology.com/security/advisory/Synology_SA_20_05",
+      },
+      {
+        "type": "url",
+        "value": "https://www.synology.com/security/advisory/Synology_SA_20_05_OpenSSL",
+      },
+      {
+        "type": "url",
+        "value": "https://www.tenable.com/security/tns-2020-03",
+      },
+      {
+        "type": "url",
+        "value": "https://www.tenable.com/security/tns-2020-04",
+      },
+      {
+        "type": "url",
+        "value": "https://www.tenable.com/security/tns-2020-11",
+      },
+      {
+        "type": "url",
+        "value": "https://www.tenable.com/security/tns-2021-10",
+      },
+    ],
     "severity": "HIGH",
   },
   {
@@ -634,10 +1784,100 @@ exports[`parses bkimminich/juice-shop:v10.2.0 result file into findings 1`] = `
     "mitigation": "Update the affected package libssl1.1 to the fixed version: 1.1.1j-r0 or remove the package from the image.",
     "name": "openssl: integer overflow in CipherUpdate",
     "osi_layer": "NOT_APPLICABLE",
-    "reference": {
-      "id": "CVE-2021-23840",
-      "source": "https://nvd.nist.gov/vuln/detail/CVE-2021-23840",
-    },
+    "references": [
+      {
+        "type": "CVE",
+        "value": "CVE-2021-23840",
+      },
+      {
+        "type": "url",
+        "value": "https://nvd.nist.gov/vuln/detail/CVE-2021-23840",
+      },
+      {
+        "type": "url",
+        "value": "https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2021-23840",
+      },
+      {
+        "type": "url",
+        "value": "https://git.openssl.org/gitweb/?p=openssl.git;a=commitdiff;h=6a51b9e1d0cf0bf8515f7201b68fb0a3482b3dc1",
+      },
+      {
+        "type": "url",
+        "value": "https://git.openssl.org/gitweb/?p=openssl.git;a=commitdiff;h=9b1129239f3ebb1d1c98ce9ed41d5c9476c47cb2",
+      },
+      {
+        "type": "url",
+        "value": "https://kb.pulsesecure.net/articles/Pulse_Security_Advisories/SA44846",
+      },
+      {
+        "type": "url",
+        "value": "https://kc.mcafee.com/corporate/index?page=content&id=SB10366",
+      },
+      {
+        "type": "url",
+        "value": "https://linux.oracle.com/cve/CVE-2021-23840.html",
+      },
+      {
+        "type": "url",
+        "value": "https://linux.oracle.com/errata/ELSA-2021-9528.html",
+      },
+      {
+        "type": "url",
+        "value": "https://lists.apache.org/thread.html/r58af02e294bd07f487e2c64ffc0a29b837db5600e33b6e698b9d696b@%3Cissues.bookkeeper.apache.org%3E",
+      },
+      {
+        "type": "url",
+        "value": "https://lists.apache.org/thread.html/rf4c02775860db415b4955778a131c2795223f61cb8c6a450893651e4@%3Cissues.bookkeeper.apache.org%3E",
+      },
+      {
+        "type": "url",
+        "value": "https://security.gentoo.org/glsa/202103-03",
+      },
+      {
+        "type": "url",
+        "value": "https://security.netapp.com/advisory/ntap-20210219-0009/",
+      },
+      {
+        "type": "url",
+        "value": "https://ubuntu.com/security/notices/USN-4738-1",
+      },
+      {
+        "type": "url",
+        "value": "https://ubuntu.com/security/notices/USN-5088-1",
+      },
+      {
+        "type": "url",
+        "value": "https://www.debian.org/security/2021/dsa-4855",
+      },
+      {
+        "type": "url",
+        "value": "https://www.openssl.org/news/secadv/20210216.txt",
+      },
+      {
+        "type": "url",
+        "value": "https://www.oracle.com//security-alerts/cpujul2021.html",
+      },
+      {
+        "type": "url",
+        "value": "https://www.oracle.com/security-alerts/cpuApr2021.html",
+      },
+      {
+        "type": "url",
+        "value": "https://www.oracle.com/security-alerts/cpuoct2021.html",
+      },
+      {
+        "type": "url",
+        "value": "https://www.tenable.com/security/tns-2021-03",
+      },
+      {
+        "type": "url",
+        "value": "https://www.tenable.com/security/tns-2021-09",
+      },
+      {
+        "type": "url",
+        "value": "https://www.tenable.com/security/tns-2021-10",
+      },
+    ],
     "severity": "HIGH",
   },
   {
@@ -679,10 +1919,108 @@ exports[`parses bkimminich/juice-shop:v10.2.0 result file into findings 1`] = `
     "mitigation": "Update the affected package libssl1.1 to the fixed version: 1.1.1k-r0 or remove the package from the image.",
     "name": "openssl: CA certificate check bypass with X509_V_FLAG_X509_STRICT",
     "osi_layer": "NOT_APPLICABLE",
-    "reference": {
-      "id": "CVE-2021-3450",
-      "source": "https://nvd.nist.gov/vuln/detail/CVE-2021-3450",
-    },
+    "references": [
+      {
+        "type": "CVE",
+        "value": "CVE-2021-3450",
+      },
+      {
+        "type": "url",
+        "value": "https://nvd.nist.gov/vuln/detail/CVE-2021-3450",
+      },
+      {
+        "type": "url",
+        "value": "http://www.openwall.com/lists/oss-security/2021/03/27/1",
+      },
+      {
+        "type": "url",
+        "value": "http://www.openwall.com/lists/oss-security/2021/03/27/2",
+      },
+      {
+        "type": "url",
+        "value": "http://www.openwall.com/lists/oss-security/2021/03/28/3",
+      },
+      {
+        "type": "url",
+        "value": "http://www.openwall.com/lists/oss-security/2021/03/28/4",
+      },
+      {
+        "type": "url",
+        "value": "https://git.openssl.org/gitweb/?p=openssl.git;a=commitdiff;h=2a40b7bc7b94dd7de897a74571e7024f0cf0d63b",
+      },
+      {
+        "type": "url",
+        "value": "https://kb.pulsesecure.net/articles/Pulse_Security_Advisories/SA44845",
+      },
+      {
+        "type": "url",
+        "value": "https://kc.mcafee.com/corporate/index?page=content&id=SB10356",
+      },
+      {
+        "type": "url",
+        "value": "https://linux.oracle.com/cve/CVE-2021-3450.html",
+      },
+      {
+        "type": "url",
+        "value": "https://linux.oracle.com/errata/ELSA-2021-9151.html",
+      },
+      {
+        "type": "url",
+        "value": "https://lists.fedoraproject.org/archives/list/package-announce@lists.fedoraproject.org/message/CCBFLLVQVILIVGZMBJL3IXZGKWQISYNP/",
+      },
+      {
+        "type": "url",
+        "value": "https://mta.openssl.org/pipermail/openssl-announce/2021-March/000198.html",
+      },
+      {
+        "type": "url",
+        "value": "https://psirt.global.sonicwall.com/vuln-detail/SNWLID-2021-0013",
+      },
+      {
+        "type": "url",
+        "value": "https://security.FreeBSD.org/advisories/FreeBSD-SA-21:07.openssl.asc",
+      },
+      {
+        "type": "url",
+        "value": "https://security.gentoo.org/glsa/202103-03",
+      },
+      {
+        "type": "url",
+        "value": "https://security.netapp.com/advisory/ntap-20210326-0006/",
+      },
+      {
+        "type": "url",
+        "value": "https://tools.cisco.com/security/center/content/CiscoSecurityAdvisory/cisco-sa-openssl-2021-GHY28dJd",
+      },
+      {
+        "type": "url",
+        "value": "https://www.openssl.org/news/secadv/20210325.txt",
+      },
+      {
+        "type": "url",
+        "value": "https://www.oracle.com//security-alerts/cpujul2021.html",
+      },
+      {
+        "type": "url",
+        "value": "https://www.oracle.com/security-alerts/cpuApr2021.html",
+      },
+      {
+        "type": "url",
+        "value": "https://www.oracle.com/security-alerts/cpuoct2021.html",
+      },
+      {
+        "type": "url",
+        "value": "https://www.tenable.com/security/tns-2021-05",
+      },
+      {
+        "type": "url",
+        "value": "https://www.tenable.com/security/tns-2021-08",
+      },
+      {
+        "type": "url",
+        "value": "https://www.tenable.com/security/tns-2021-09",
+      },
+    ],
     "severity": "HIGH",
   },
   {
@@ -720,10 +2058,92 @@ exports[`parses bkimminich/juice-shop:v10.2.0 result file into findings 1`] = `
     "mitigation": "Update the affected package libssl1.1 to the fixed version: 1.1.1l-r0 or remove the package from the image.",
     "name": "openssl: Read buffer overruns processing ASN.1 strings",
     "osi_layer": "NOT_APPLICABLE",
-    "reference": {
-      "id": "CVE-2021-3712",
-      "source": "https://nvd.nist.gov/vuln/detail/CVE-2021-3712",
-    },
+    "references": [
+      {
+        "type": "CVE",
+        "value": "CVE-2021-3712",
+      },
+      {
+        "type": "url",
+        "value": "https://nvd.nist.gov/vuln/detail/CVE-2021-3712",
+      },
+      {
+        "type": "url",
+        "value": "http://www.openwall.com/lists/oss-security/2021/08/26/2",
+      },
+      {
+        "type": "url",
+        "value": "https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2021-3712",
+      },
+      {
+        "type": "url",
+        "value": "https://git.openssl.org/gitweb/?p=openssl.git;a=commitdiff;h=94d23fcff9b2a7a8368dfe52214d5c2569882c11",
+      },
+      {
+        "type": "url",
+        "value": "https://git.openssl.org/gitweb/?p=openssl.git;a=commitdiff;h=ccb0a11145ee72b042d10593a64eaf9e8a55ec12",
+      },
+      {
+        "type": "url",
+        "value": "https://kc.mcafee.com/corporate/index?page=content&id=SB10366",
+      },
+      {
+        "type": "url",
+        "value": "https://lists.apache.org/thread.html/r18995de860f0e63635f3008fd2a6aca82394249476d21691e7c59c9e@%3Cdev.tomcat.apache.org%3E",
+      },
+      {
+        "type": "url",
+        "value": "https://lists.apache.org/thread.html/rad5d9f83f0d11fb3f8bb148d179b8a9ad7c6a17f18d70e5805a713d1@%3Cdev.tomcat.apache.org%3E",
+      },
+      {
+        "type": "url",
+        "value": "https://lists.debian.org/debian-lts-announce/2021/09/msg00014.html",
+      },
+      {
+        "type": "url",
+        "value": "https://lists.debian.org/debian-lts-announce/2021/09/msg00021.html",
+      },
+      {
+        "type": "url",
+        "value": "https://security.netapp.com/advisory/ntap-20210827-0010/",
+      },
+      {
+        "type": "url",
+        "value": "https://ubuntu.com/security/notices/USN-5051-1",
+      },
+      {
+        "type": "url",
+        "value": "https://ubuntu.com/security/notices/USN-5051-2",
+      },
+      {
+        "type": "url",
+        "value": "https://ubuntu.com/security/notices/USN-5051-3",
+      },
+      {
+        "type": "url",
+        "value": "https://ubuntu.com/security/notices/USN-5051-4 (regression only in trusty/esm)",
+      },
+      {
+        "type": "url",
+        "value": "https://ubuntu.com/security/notices/USN-5088-1",
+      },
+      {
+        "type": "url",
+        "value": "https://www.debian.org/security/2021/dsa-4963",
+      },
+      {
+        "type": "url",
+        "value": "https://www.openssl.org/news/secadv/20210824.txt",
+      },
+      {
+        "type": "url",
+        "value": "https://www.oracle.com/security-alerts/cpuoct2021.html",
+      },
+      {
+        "type": "url",
+        "value": "https://www.tenable.com/security/tns-2021-16",
+      },
+    ],
     "severity": "HIGH",
   },
   {
@@ -770,10 +2190,128 @@ exports[`parses bkimminich/juice-shop:v10.2.0 result file into findings 1`] = `
     "mitigation": "Update the affected package libssl1.1 to the fixed version: 1.1.1i-r0 or remove the package from the image.",
     "name": "openssl: EDIPARTYNAME NULL pointer de-reference",
     "osi_layer": "NOT_APPLICABLE",
-    "reference": {
-      "id": "CVE-2020-1971",
-      "source": "https://nvd.nist.gov/vuln/detail/CVE-2020-1971",
-    },
+    "references": [
+      {
+        "type": "CVE",
+        "value": "CVE-2020-1971",
+      },
+      {
+        "type": "url",
+        "value": "https://nvd.nist.gov/vuln/detail/CVE-2020-1971",
+      },
+      {
+        "type": "url",
+        "value": "http://www.openwall.com/lists/oss-security/2021/09/14/2",
+      },
+      {
+        "type": "url",
+        "value": "https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2020-1971",
+      },
+      {
+        "type": "url",
+        "value": "https://git.openssl.org/gitweb/?p=openssl.git;a=commitdiff;h=2154ab83e14ede338d2ede9bbe5cdfce5d5a6c9e",
+      },
+      {
+        "type": "url",
+        "value": "https://git.openssl.org/gitweb/?p=openssl.git;a=commitdiff;h=f960d81215ebf3f65e03d4d5d857fb9b666d6920",
+      },
+      {
+        "type": "url",
+        "value": "https://kb.pulsesecure.net/articles/Pulse_Security_Advisories/SA44676",
+      },
+      {
+        "type": "url",
+        "value": "https://linux.oracle.com/cve/CVE-2020-1971.html",
+      },
+      {
+        "type": "url",
+        "value": "https://linux.oracle.com/errata/ELSA-2021-9150.html",
+      },
+      {
+        "type": "url",
+        "value": "https://lists.apache.org/thread.html/r63c6f2dd363d9b514d0a4bcf624580616a679898cc14c109a49b750c@%3Cdev.tomcat.apache.org%3E",
+      },
+      {
+        "type": "url",
+        "value": "https://lists.apache.org/thread.html/rbb769f771711fb274e0a4acb1b5911c8aab544a6ac5e8c12d40c5143@%3Ccommits.pulsar.apache.org%3E",
+      },
+      {
+        "type": "url",
+        "value": "https://lists.debian.org/debian-lts-announce/2020/12/msg00020.html",
+      },
+      {
+        "type": "url",
+        "value": "https://lists.debian.org/debian-lts-announce/2020/12/msg00021.html",
+      },
+      {
+        "type": "url",
+        "value": "https://lists.fedoraproject.org/archives/list/package-announce@lists.fedoraproject.org/message/DGSI34Y5LQ5RYXN4M2I5ZQT65LFVDOUU/",
+      },
+      {
+        "type": "url",
+        "value": "https://lists.fedoraproject.org/archives/list/package-announce@lists.fedoraproject.org/message/PWPSSZNZOBJU2YR6Z4TGHXKYW3YP5QG7/",
+      },
+      {
+        "type": "url",
+        "value": "https://security.FreeBSD.org/advisories/FreeBSD-SA-20:33.openssl.asc",
+      },
+      {
+        "type": "url",
+        "value": "https://security.gentoo.org/glsa/202012-13",
+      },
+      {
+        "type": "url",
+        "value": "https://security.netapp.com/advisory/ntap-20201218-0005/",
+      },
+      {
+        "type": "url",
+        "value": "https://security.netapp.com/advisory/ntap-20210513-0002/",
+      },
+      {
+        "type": "url",
+        "value": "https://ubuntu.com/security/notices/USN-4662-1",
+      },
+      {
+        "type": "url",
+        "value": "https://ubuntu.com/security/notices/USN-4745-1",
+      },
+      {
+        "type": "url",
+        "value": "https://www.debian.org/security/2020/dsa-4807",
+      },
+      {
+        "type": "url",
+        "value": "https://www.openssl.org/news/secadv/20201208.txt",
+      },
+      {
+        "type": "url",
+        "value": "https://www.oracle.com//security-alerts/cpujul2021.html",
+      },
+      {
+        "type": "url",
+        "value": "https://www.oracle.com/security-alerts/cpuApr2021.html",
+      },
+      {
+        "type": "url",
+        "value": "https://www.oracle.com/security-alerts/cpujan2021.html",
+      },
+      {
+        "type": "url",
+        "value": "https://www.oracle.com/security-alerts/cpuoct2021.html",
+      },
+      {
+        "type": "url",
+        "value": "https://www.tenable.com/security/tns-2020-11",
+      },
+      {
+        "type": "url",
+        "value": "https://www.tenable.com/security/tns-2021-09",
+      },
+      {
+        "type": "url",
+        "value": "https://www.tenable.com/security/tns-2021-10",
+      },
+    ],
     "severity": "MEDIUM",
   },
   {
@@ -816,10 +2354,112 @@ exports[`parses bkimminich/juice-shop:v10.2.0 result file into findings 1`] = `
     "mitigation": "Update the affected package libssl1.1 to the fixed version: 1.1.1j-r0 or remove the package from the image.",
     "name": "openssl: NULL pointer dereference in X509_issuer_and_serial_hash()",
     "osi_layer": "NOT_APPLICABLE",
-    "reference": {
-      "id": "CVE-2021-23841",
-      "source": "https://nvd.nist.gov/vuln/detail/CVE-2021-23841",
-    },
+    "references": [
+      {
+        "type": "CVE",
+        "value": "CVE-2021-23841",
+      },
+      {
+        "type": "url",
+        "value": "https://nvd.nist.gov/vuln/detail/CVE-2021-23841",
+      },
+      {
+        "type": "url",
+        "value": "http://seclists.org/fulldisclosure/2021/May/67",
+      },
+      {
+        "type": "url",
+        "value": "http://seclists.org/fulldisclosure/2021/May/68",
+      },
+      {
+        "type": "url",
+        "value": "http://seclists.org/fulldisclosure/2021/May/70",
+      },
+      {
+        "type": "url",
+        "value": "https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2021-23841",
+      },
+      {
+        "type": "url",
+        "value": "https://git.openssl.org/gitweb/?p=openssl.git;a=commitdiff;h=122a19ab48091c657f7cb1fb3af9fc07bd557bbf",
+      },
+      {
+        "type": "url",
+        "value": "https://git.openssl.org/gitweb/?p=openssl.git;a=commitdiff;h=8252ee4d90f3f2004d3d0aeeed003ad49c9a7807",
+      },
+      {
+        "type": "url",
+        "value": "https://kb.pulsesecure.net/articles/Pulse_Security_Advisories/SA44846",
+      },
+      {
+        "type": "url",
+        "value": "https://linux.oracle.com/cve/CVE-2021-23841.html",
+      },
+      {
+        "type": "url",
+        "value": "https://linux.oracle.com/errata/ELSA-2021-9528.html",
+      },
+      {
+        "type": "url",
+        "value": "https://security.gentoo.org/glsa/202103-03",
+      },
+      {
+        "type": "url",
+        "value": "https://security.netapp.com/advisory/ntap-20210219-0009/",
+      },
+      {
+        "type": "url",
+        "value": "https://security.netapp.com/advisory/ntap-20210513-0002/",
+      },
+      {
+        "type": "url",
+        "value": "https://support.apple.com/kb/HT212528",
+      },
+      {
+        "type": "url",
+        "value": "https://support.apple.com/kb/HT212529",
+      },
+      {
+        "type": "url",
+        "value": "https://support.apple.com/kb/HT212534",
+      },
+      {
+        "type": "url",
+        "value": "https://ubuntu.com/security/notices/USN-4738-1",
+      },
+      {
+        "type": "url",
+        "value": "https://ubuntu.com/security/notices/USN-4745-1",
+      },
+      {
+        "type": "url",
+        "value": "https://www.debian.org/security/2021/dsa-4855",
+      },
+      {
+        "type": "url",
+        "value": "https://www.openssl.org/news/secadv/20210216.txt",
+      },
+      {
+        "type": "url",
+        "value": "https://www.oracle.com//security-alerts/cpujul2021.html",
+      },
+      {
+        "type": "url",
+        "value": "https://www.oracle.com/security-alerts/cpuApr2021.html",
+      },
+      {
+        "type": "url",
+        "value": "https://www.oracle.com/security-alerts/cpuoct2021.html",
+      },
+      {
+        "type": "url",
+        "value": "https://www.tenable.com/security/tns-2021-03",
+      },
+      {
+        "type": "url",
+        "value": "https://www.tenable.com/security/tns-2021-09",
+      },
+    ],
     "severity": "MEDIUM",
   },
   {
@@ -868,10 +2508,136 @@ exports[`parses bkimminich/juice-shop:v10.2.0 result file into findings 1`] = `
     "mitigation": "Update the affected package libssl1.1 to the fixed version: 1.1.1k-r0 or remove the package from the image.",
     "name": "openssl: NULL pointer dereference in signature_algorithms processing",
     "osi_layer": "NOT_APPLICABLE",
-    "reference": {
-      "id": "CVE-2021-3449",
-      "source": "https://nvd.nist.gov/vuln/detail/CVE-2021-3449",
-    },
+    "references": [
+      {
+        "type": "CVE",
+        "value": "CVE-2021-3449",
+      },
+      {
+        "type": "url",
+        "value": "https://nvd.nist.gov/vuln/detail/CVE-2021-3449",
+      },
+      {
+        "type": "url",
+        "value": "http://www.openwall.com/lists/oss-security/2021/03/27/1",
+      },
+      {
+        "type": "url",
+        "value": "http://www.openwall.com/lists/oss-security/2021/03/27/2",
+      },
+      {
+        "type": "url",
+        "value": "http://www.openwall.com/lists/oss-security/2021/03/28/3",
+      },
+      {
+        "type": "url",
+        "value": "http://www.openwall.com/lists/oss-security/2021/03/28/4",
+      },
+      {
+        "type": "url",
+        "value": "https://cert-portal.siemens.com/productcert/pdf/ssa-772220.pdf",
+      },
+      {
+        "type": "url",
+        "value": "https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2021-3449",
+      },
+      {
+        "type": "url",
+        "value": "https://git.openssl.org/gitweb/?p=openssl.git;a=commitdiff;h=fb9fa6b51defd48157eeb207f52181f735d96148",
+      },
+      {
+        "type": "url",
+        "value": "https://kb.pulsesecure.net/articles/Pulse_Security_Advisories/SA44845",
+      },
+      {
+        "type": "url",
+        "value": "https://kc.mcafee.com/corporate/index?page=content&id=SB10356",
+      },
+      {
+        "type": "url",
+        "value": "https://linux.oracle.com/cve/CVE-2021-3449.html",
+      },
+      {
+        "type": "url",
+        "value": "https://linux.oracle.com/errata/ELSA-2021-9151.html",
+      },
+      {
+        "type": "url",
+        "value": "https://lists.debian.org/debian-lts-announce/2021/08/msg00029.html",
+      },
+      {
+        "type": "url",
+        "value": "https://lists.fedoraproject.org/archives/list/package-announce@lists.fedoraproject.org/message/CCBFLLVQVILIVGZMBJL3IXZGKWQISYNP/",
+      },
+      {
+        "type": "url",
+        "value": "https://psirt.global.sonicwall.com/vuln-detail/SNWLID-2021-0013",
+      },
+      {
+        "type": "url",
+        "value": "https://security.FreeBSD.org/advisories/FreeBSD-SA-21:07.openssl.asc",
+      },
+      {
+        "type": "url",
+        "value": "https://security.gentoo.org/glsa/202103-03",
+      },
+      {
+        "type": "url",
+        "value": "https://security.netapp.com/advisory/ntap-20210326-0006/",
+      },
+      {
+        "type": "url",
+        "value": "https://security.netapp.com/advisory/ntap-20210513-0002/",
+      },
+      {
+        "type": "url",
+        "value": "https://tools.cisco.com/security/center/content/CiscoSecurityAdvisory/cisco-sa-openssl-2021-GHY28dJd",
+      },
+      {
+        "type": "url",
+        "value": "https://ubuntu.com/security/notices/USN-4891-1",
+      },
+      {
+        "type": "url",
+        "value": "https://ubuntu.com/security/notices/USN-5038-1",
+      },
+      {
+        "type": "url",
+        "value": "https://www.debian.org/security/2021/dsa-4875",
+      },
+      {
+        "type": "url",
+        "value": "https://www.openssl.org/news/secadv/20210325.txt",
+      },
+      {
+        "type": "url",
+        "value": "https://www.oracle.com//security-alerts/cpujul2021.html",
+      },
+      {
+        "type": "url",
+        "value": "https://www.oracle.com/security-alerts/cpuApr2021.html",
+      },
+      {
+        "type": "url",
+        "value": "https://www.oracle.com/security-alerts/cpuoct2021.html",
+      },
+      {
+        "type": "url",
+        "value": "https://www.tenable.com/security/tns-2021-05",
+      },
+      {
+        "type": "url",
+        "value": "https://www.tenable.com/security/tns-2021-06",
+      },
+      {
+        "type": "url",
+        "value": "https://www.tenable.com/security/tns-2021-09",
+      },
+      {
+        "type": "url",
+        "value": "https://www.tenable.com/security/tns-2021-10",
+      },
+    ],
     "severity": "MEDIUM",
   },
   {
@@ -897,10 +2663,44 @@ exports[`parses bkimminich/juice-shop:v10.2.0 result file into findings 1`] = `
     "mitigation": "Update the affected package libssl1.1 to the fixed version: 1.1.1j-r0 or remove the package from the image.",
     "name": "openssl: incorrect SSLv2 rollback protection",
     "osi_layer": "NOT_APPLICABLE",
-    "reference": {
-      "id": "CVE-2021-23839",
-      "source": "https://nvd.nist.gov/vuln/detail/CVE-2021-23839",
-    },
+    "references": [
+      {
+        "type": "CVE",
+        "value": "CVE-2021-23839",
+      },
+      {
+        "type": "url",
+        "value": "https://nvd.nist.gov/vuln/detail/CVE-2021-23839",
+      },
+      {
+        "type": "url",
+        "value": "https://git.openssl.org/gitweb/?p=openssl.git;a=commitdiff;h=30919ab80a478f2d81f2e9acdcca3fa4740cd547",
+      },
+      {
+        "type": "url",
+        "value": "https://kb.pulsesecure.net/articles/Pulse_Security_Advisories/SA44846",
+      },
+      {
+        "type": "url",
+        "value": "https://security.netapp.com/advisory/ntap-20210219-0009/",
+      },
+      {
+        "type": "url",
+        "value": "https://www.openssl.org/news/secadv/20210216.txt",
+      },
+      {
+        "type": "url",
+        "value": "https://www.oracle.com//security-alerts/cpujul2021.html",
+      },
+      {
+        "type": "url",
+        "value": "https://www.oracle.com/security-alerts/cpuApr2021.html",
+      },
+      {
+        "type": "url",
+        "value": "https://www.oracle.com/security-alerts/cpuoct2021.html",
+      },
+    ],
     "severity": "LOW",
   },
   {
@@ -925,10 +2725,40 @@ exports[`parses bkimminich/juice-shop:v10.2.0 result file into findings 1`] = `
     "mitigation": "Update the affected package libstdc++ to the fixed version: 9.3.0-r0 or remove the package from the image.",
     "name": "gcc: POWER9 "DARN" RNG intrinsic produces repeated output",
     "osi_layer": "NOT_APPLICABLE",
-    "reference": {
-      "id": "CVE-2019-15847",
-      "source": "https://nvd.nist.gov/vuln/detail/CVE-2019-15847",
-    },
+    "references": [
+      {
+        "type": "CVE",
+        "value": "CVE-2019-15847",
+      },
+      {
+        "type": "url",
+        "value": "https://nvd.nist.gov/vuln/detail/CVE-2019-15847",
+      },
+      {
+        "type": "url",
+        "value": "http://lists.opensuse.org/opensuse-security-announce/2019-10/msg00056.html",
+      },
+      {
+        "type": "url",
+        "value": "http://lists.opensuse.org/opensuse-security-announce/2019-10/msg00057.html",
+      },
+      {
+        "type": "url",
+        "value": "http://lists.opensuse.org/opensuse-security-announce/2020-05/msg00058.html",
+      },
+      {
+        "type": "url",
+        "value": "https://gcc.gnu.org/bugzilla/show_bug.cgi?id=91481",
+      },
+      {
+        "type": "url",
+        "value": "https://linux.oracle.com/cve/CVE-2019-15847.html",
+      },
+      {
+        "type": "url",
+        "value": "https://linux.oracle.com/errata/ELSA-2020-1864.html",
+      },
+    ],
     "severity": "HIGH",
   },
   {
@@ -957,10 +2787,56 @@ exports[`parses bkimminich/juice-shop:v10.2.0 result file into findings 1`] = `
     "mitigation": "Update the affected package musl to the fixed version: 1.1.24-r3 or remove the package from the image.",
     "name": "Vulnerability in Dependency musl (1.1.24-r2)",
     "osi_layer": "NOT_APPLICABLE",
-    "reference": {
-      "id": "CVE-2020-28928",
-      "source": "https://nvd.nist.gov/vuln/detail/CVE-2020-28928",
-    },
+    "references": [
+      {
+        "type": "CVE",
+        "value": "CVE-2020-28928",
+      },
+      {
+        "type": "url",
+        "value": "https://nvd.nist.gov/vuln/detail/CVE-2020-28928",
+      },
+      {
+        "type": "url",
+        "value": "http://www.openwall.com/lists/oss-security/2020/11/20/4",
+      },
+      {
+        "type": "url",
+        "value": "https://lists.apache.org/thread.html/r2134abfe847bea7795f0e53756d10a47e6643f35ab8169df8b8a9eb1@%3Cnotifications.apisix.apache.org%3E",
+      },
+      {
+        "type": "url",
+        "value": "https://lists.apache.org/thread.html/r90b60cf49348e515257b4950900c1bd3ab95a960cf2469d919c7264e@%3Cnotifications.apisix.apache.org%3E",
+      },
+      {
+        "type": "url",
+        "value": "https://lists.apache.org/thread.html/ra63e8dc5137d952afc55dbbfa63be83304ecf842d1eab1ff3ebb29e2@%3Cnotifications.apisix.apache.org%3E",
+      },
+      {
+        "type": "url",
+        "value": "https://lists.debian.org/debian-lts-announce/2020/11/msg00050.html",
+      },
+      {
+        "type": "url",
+        "value": "https://lists.fedoraproject.org/archives/list/package-announce@lists.fedoraproject.org/message/LKQ3RVSMVZNZNO4D65W2CZZ4DMYFZN2Q/",
+      },
+      {
+        "type": "url",
+        "value": "https://lists.fedoraproject.org/archives/list/package-announce@lists.fedoraproject.org/message/UW27QVY7ERPTSGKS4KAWE5TU7EJWHKVQ/",
+      },
+      {
+        "type": "url",
+        "value": "https://musl.libc.org/releases.html",
+      },
+      {
+        "type": "url",
+        "value": "https://www.oracle.com//security-alerts/cpujul2021.html",
+      },
+      {
+        "type": "url",
+        "value": "https://www.oracle.com/security-alerts/cpuoct2021.html",
+      },
+    ],
     "severity": "MEDIUM",
   },
   {
@@ -989,10 +2865,56 @@ exports[`parses bkimminich/juice-shop:v10.2.0 result file into findings 1`] = `
     "mitigation": "Update the affected package musl-utils to the fixed version: 1.1.24-r3 or remove the package from the image.",
     "name": "Vulnerability in Dependency musl-utils (1.1.24-r2)",
     "osi_layer": "NOT_APPLICABLE",
-    "reference": {
-      "id": "CVE-2020-28928",
-      "source": "https://nvd.nist.gov/vuln/detail/CVE-2020-28928",
-    },
+    "references": [
+      {
+        "type": "CVE",
+        "value": "CVE-2020-28928",
+      },
+      {
+        "type": "url",
+        "value": "https://nvd.nist.gov/vuln/detail/CVE-2020-28928",
+      },
+      {
+        "type": "url",
+        "value": "http://www.openwall.com/lists/oss-security/2020/11/20/4",
+      },
+      {
+        "type": "url",
+        "value": "https://lists.apache.org/thread.html/r2134abfe847bea7795f0e53756d10a47e6643f35ab8169df8b8a9eb1@%3Cnotifications.apisix.apache.org%3E",
+      },
+      {
+        "type": "url",
+        "value": "https://lists.apache.org/thread.html/r90b60cf49348e515257b4950900c1bd3ab95a960cf2469d919c7264e@%3Cnotifications.apisix.apache.org%3E",
+      },
+      {
+        "type": "url",
+        "value": "https://lists.apache.org/thread.html/ra63e8dc5137d952afc55dbbfa63be83304ecf842d1eab1ff3ebb29e2@%3Cnotifications.apisix.apache.org%3E",
+      },
+      {
+        "type": "url",
+        "value": "https://lists.debian.org/debian-lts-announce/2020/11/msg00050.html",
+      },
+      {
+        "type": "url",
+        "value": "https://lists.fedoraproject.org/archives/list/package-announce@lists.fedoraproject.org/message/LKQ3RVSMVZNZNO4D65W2CZZ4DMYFZN2Q/",
+      },
+      {
+        "type": "url",
+        "value": "https://lists.fedoraproject.org/archives/list/package-announce@lists.fedoraproject.org/message/UW27QVY7ERPTSGKS4KAWE5TU7EJWHKVQ/",
+      },
+      {
+        "type": "url",
+        "value": "https://musl.libc.org/releases.html",
+      },
+      {
+        "type": "url",
+        "value": "https://www.oracle.com//security-alerts/cpujul2021.html",
+      },
+      {
+        "type": "url",
+        "value": "https://www.oracle.com/security-alerts/cpuoct2021.html",
+      },
+    ],
     "severity": "MEDIUM",
   },
   {
@@ -1018,10 +2940,44 @@ exports[`parses bkimminich/juice-shop:v10.2.0 result file into findings 1`] = `
     "mitigation": "Update the affected package ssl_client to the fixed version: 1.31.1-r10 or remove the package from the image.",
     "name": "busybox: invalid free or segmentation fault via malformed gzip data",
     "osi_layer": "NOT_APPLICABLE",
-    "reference": {
-      "id": "CVE-2021-28831",
-      "source": "https://nvd.nist.gov/vuln/detail/CVE-2021-28831",
-    },
+    "references": [
+      {
+        "type": "CVE",
+        "value": "CVE-2021-28831",
+      },
+      {
+        "type": "url",
+        "value": "https://nvd.nist.gov/vuln/detail/CVE-2021-28831",
+      },
+      {
+        "type": "url",
+        "value": "https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2021-28831",
+      },
+      {
+        "type": "url",
+        "value": "https://git.busybox.net/busybox/commit/?id=f25d254dfd4243698c31a4f3153d4ac72aa9e9bd",
+      },
+      {
+        "type": "url",
+        "value": "https://lists.debian.org/debian-lts-announce/2021/04/msg00001.html",
+      },
+      {
+        "type": "url",
+        "value": "https://lists.fedoraproject.org/archives/list/package-announce@lists.fedoraproject.org/message/3UDQGJRECXFS5EZVDH2OI45FMO436AC4/",
+      },
+      {
+        "type": "url",
+        "value": "https://lists.fedoraproject.org/archives/list/package-announce@lists.fedoraproject.org/message/Z7ZIFKPRR32ZYA3WAA2NXFA3QHHOU6FJ/",
+      },
+      {
+        "type": "url",
+        "value": "https://lists.fedoraproject.org/archives/list/package-announce@lists.fedoraproject.org/message/ZASBW7QRRLY5V2R44MQ4QQM4CZIDHM2U/",
+      },
+      {
+        "type": "url",
+        "value": "https://security.gentoo.org/glsa/202105-09",
+      },
+    ],
     "severity": "HIGH",
   },
   {
@@ -1044,10 +3000,32 @@ exports[`parses bkimminich/juice-shop:v10.2.0 result file into findings 1`] = `
     "mitigation": "Update the affected package ansi-regex to the fixed version: 5.0.1, 6.0.1 or remove the package from the image.",
     "name": "nodejs-ansi-regex: Regular expression denial of service (ReDoS) matching ANSI escape codes",
     "osi_layer": "NOT_APPLICABLE",
-    "reference": {
-      "id": "CVE-2021-3807",
-      "source": "https://nvd.nist.gov/vuln/detail/CVE-2021-3807",
-    },
+    "references": [
+      {
+        "type": "CVE",
+        "value": "CVE-2021-3807",
+      },
+      {
+        "type": "url",
+        "value": "https://nvd.nist.gov/vuln/detail/CVE-2021-3807",
+      },
+      {
+        "type": "url",
+        "value": "https://github.com/advisories/GHSA-93q8-gq69-wqmw",
+      },
+      {
+        "type": "url",
+        "value": "https://github.com/chalk/ansi-regex/commit/8d1d7cdb586269882c4bdc1b7325d0c58c8f76f9",
+      },
+      {
+        "type": "url",
+        "value": "https://huntr.dev/bounties/5b3cf33b-ede0-4398-9974-800876dfd994",
+      },
+      {
+        "type": "url",
+        "value": "https://nvd.nist.gov/vuln/detail/CVE-2021-3807",
+      },
+    ],
     "severity": "HIGH",
   },
   {
@@ -1070,10 +3048,32 @@ exports[`parses bkimminich/juice-shop:v10.2.0 result file into findings 1`] = `
     "mitigation": "Update the affected package ansi-regex to the fixed version: 5.0.1, 6.0.1 or remove the package from the image.",
     "name": "nodejs-ansi-regex: Regular expression denial of service (ReDoS) matching ANSI escape codes",
     "osi_layer": "NOT_APPLICABLE",
-    "reference": {
-      "id": "CVE-2021-3807",
-      "source": "https://nvd.nist.gov/vuln/detail/CVE-2021-3807",
-    },
+    "references": [
+      {
+        "type": "CVE",
+        "value": "CVE-2021-3807",
+      },
+      {
+        "type": "url",
+        "value": "https://nvd.nist.gov/vuln/detail/CVE-2021-3807",
+      },
+      {
+        "type": "url",
+        "value": "https://github.com/advisories/GHSA-93q8-gq69-wqmw",
+      },
+      {
+        "type": "url",
+        "value": "https://github.com/chalk/ansi-regex/commit/8d1d7cdb586269882c4bdc1b7325d0c58c8f76f9",
+      },
+      {
+        "type": "url",
+        "value": "https://huntr.dev/bounties/5b3cf33b-ede0-4398-9974-800876dfd994",
+      },
+      {
+        "type": "url",
+        "value": "https://nvd.nist.gov/vuln/detail/CVE-2021-3807",
+      },
+    ],
     "severity": "HIGH",
   },
   {
@@ -1094,10 +3094,24 @@ exports[`parses bkimminich/juice-shop:v10.2.0 result file into findings 1`] = `
     "mitigation": "Update the affected package base64url to the fixed version: >=3.0.0 or remove the package from the image.",
     "name": "Out-of-bounds Read",
     "osi_layer": "NOT_APPLICABLE",
-    "reference": {
-      "id": "NSWG-ECO-428",
-      "source": "https://github.com/nodejs/security-wg/tree/master/vuln",
-    },
+    "references": [
+      {
+        "type": "NSWG",
+        "value": "NSWG-ECO-428",
+      },
+      {
+        "type": "url",
+        "value": "https://github.com/nodejs/security-wg/tree/master/vuln",
+      },
+      {
+        "type": "url",
+        "value": "https://github.com/brianloveswords/base64url/pull/25",
+      },
+      {
+        "type": "url",
+        "value": "https://hackerone.com/reports/321687",
+      },
+    ],
     "severity": "HIGH",
   },
   {
@@ -1123,7 +3137,16 @@ Update to version 3.0.0 or later.",
     "mitigation": "Update the affected package base64url to the fixed version: 3.0.0 or remove the package from the image.",
     "name": "Out-of-bounds Read in base64url",
     "osi_layer": "NOT_APPLICABLE",
-    "reference": null,
+    "references": [
+      {
+        "type": "url",
+        "value": "https://github.com/advisories/GHSA-rvg8-pwq2-xj7q",
+      },
+      {
+        "type": "url",
+        "value": "https://github.com/brianloveswords/base64url/pull/25",
+      },
+    ],
     "severity": "MEDIUM",
   },
   {
@@ -1148,10 +3171,40 @@ Update to version 3.0.0 or later.",
     "mitigation": "Update the affected package bl to the fixed version: 2.2.1, 1.2.3, 4.0.3, 3.0.1 or remove the package from the image.",
     "name": "nodejs-bl: buffer over-read vulnerability leads to corrupted BufferList which can result in uninitialized memory being leaked",
     "osi_layer": "NOT_APPLICABLE",
-    "reference": {
-      "id": "CVE-2020-8244",
-      "source": "https://nvd.nist.gov/vuln/detail/CVE-2020-8244",
-    },
+    "references": [
+      {
+        "type": "CVE",
+        "value": "CVE-2020-8244",
+      },
+      {
+        "type": "url",
+        "value": "https://nvd.nist.gov/vuln/detail/CVE-2020-8244",
+      },
+      {
+        "type": "url",
+        "value": "https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2020-8244",
+      },
+      {
+        "type": "url",
+        "value": "https://github.com/advisories/GHSA-pp7h-53gx-mx7r",
+      },
+      {
+        "type": "url",
+        "value": "https://github.com/rvagg/bl/commit/d3e240e3b8ba4048d3c76ef5fb9dd1f8872d3190",
+      },
+      {
+        "type": "url",
+        "value": "https://hackerone.com/reports/966347",
+      },
+      {
+        "type": "url",
+        "value": "https://nvd.nist.gov/vuln/detail/CVE-2020-8244",
+      },
+      {
+        "type": "url",
+        "value": "https://ubuntu.com/security/notices/USN-5098-1",
+      },
+    ],
     "severity": "MEDIUM",
   },
   {
@@ -1176,10 +3229,40 @@ Update to version 3.0.0 or later.",
     "mitigation": "Update the affected package bl to the fixed version: 2.2.1, 1.2.3, 4.0.3, 3.0.1 or remove the package from the image.",
     "name": "nodejs-bl: buffer over-read vulnerability leads to corrupted BufferList which can result in uninitialized memory being leaked",
     "osi_layer": "NOT_APPLICABLE",
-    "reference": {
-      "id": "CVE-2020-8244",
-      "source": "https://nvd.nist.gov/vuln/detail/CVE-2020-8244",
-    },
+    "references": [
+      {
+        "type": "CVE",
+        "value": "CVE-2020-8244",
+      },
+      {
+        "type": "url",
+        "value": "https://nvd.nist.gov/vuln/detail/CVE-2020-8244",
+      },
+      {
+        "type": "url",
+        "value": "https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2020-8244",
+      },
+      {
+        "type": "url",
+        "value": "https://github.com/advisories/GHSA-pp7h-53gx-mx7r",
+      },
+      {
+        "type": "url",
+        "value": "https://github.com/rvagg/bl/commit/d3e240e3b8ba4048d3c76ef5fb9dd1f8872d3190",
+      },
+      {
+        "type": "url",
+        "value": "https://hackerone.com/reports/966347",
+      },
+      {
+        "type": "url",
+        "value": "https://nvd.nist.gov/vuln/detail/CVE-2020-8244",
+      },
+      {
+        "type": "url",
+        "value": "https://ubuntu.com/security/notices/USN-5098-1",
+      },
+    ],
     "severity": "MEDIUM",
   },
   {
@@ -1205,10 +3288,44 @@ Update to version 3.0.0 or later.",
     "mitigation": "Update the affected package color-string to the fixed version: 1.5.5 or remove the package from the image.",
     "name": "nodejs-color-string: Regular expression denial of service when the application is provided and checks a crafted invalid HWB string",
     "osi_layer": "NOT_APPLICABLE",
-    "reference": {
-      "id": "CVE-2021-29060",
-      "source": "https://nvd.nist.gov/vuln/detail/CVE-2021-29060",
-    },
+    "references": [
+      {
+        "type": "CVE",
+        "value": "CVE-2021-29060",
+      },
+      {
+        "type": "url",
+        "value": "https://nvd.nist.gov/vuln/detail/CVE-2021-29060",
+      },
+      {
+        "type": "url",
+        "value": "https://github.com/Qix-/color-string/commit/0789e21284c33d89ebc4ab4ca6f759b9375ac9d3",
+      },
+      {
+        "type": "url",
+        "value": "https://github.com/advisories/GHSA-257v-vj4p-3w2h",
+      },
+      {
+        "type": "url",
+        "value": "https://github.com/yetingli/PoCs/blob/main/CVE-2021-29060/Color-String.md",
+      },
+      {
+        "type": "url",
+        "value": "https://github.com/yetingli/SaveResults/blob/main/js/color-string.js",
+      },
+      {
+        "type": "url",
+        "value": "https://nvd.nist.gov/vuln/detail/CVE-2021-29060",
+      },
+      {
+        "type": "url",
+        "value": "https://snyk.io/vuln/SNYK-JS-COLORSTRING-1082939",
+      },
+      {
+        "type": "url",
+        "value": "https://www.npmjs.com/package/color-string",
+      },
+    ],
     "severity": "MEDIUM",
   },
   {
@@ -1229,7 +3346,16 @@ Update to version 3.0.0 or later.",
     "mitigation": "Update the affected package diff to the fixed version: 3.5.0 or remove the package from the image.",
     "name": "Regular Expression Denial of Service (ReDoS)",
     "osi_layer": "NOT_APPLICABLE",
-    "reference": null,
+    "references": [
+      {
+        "type": "url",
+        "value": "https://github.com/advisories/GHSA-h6ch-v84p-w6p9",
+      },
+      {
+        "type": "url",
+        "value": "https://github.com/kpdecker/jsdiff/commit/2aec4298639bf30fb88a00b356bf404d3551b8c0",
+      },
+    ],
     "severity": "HIGH",
   },
   {
@@ -1255,10 +3381,44 @@ Update to version 3.0.0 or later.",
     "mitigation": "Update the affected package dot-prop to the fixed version: 5.1.1, 4.2.1 or remove the package from the image.",
     "name": "nodejs-dot-prop: prototype pollution",
     "osi_layer": "NOT_APPLICABLE",
-    "reference": {
-      "id": "CVE-2020-8116",
-      "source": "https://nvd.nist.gov/vuln/detail/CVE-2020-8116",
-    },
+    "references": [
+      {
+        "type": "CVE",
+        "value": "CVE-2020-8116",
+      },
+      {
+        "type": "url",
+        "value": "https://nvd.nist.gov/vuln/detail/CVE-2020-8116",
+      },
+      {
+        "type": "url",
+        "value": "https://github.com/advisories/GHSA-ff7x-qrg7-qggm",
+      },
+      {
+        "type": "url",
+        "value": "https://github.com/sindresorhus/dot-prop/issues/63",
+      },
+      {
+        "type": "url",
+        "value": "https://github.com/sindresorhus/dot-prop/tree/v4",
+      },
+      {
+        "type": "url",
+        "value": "https://hackerone.com/reports/719856",
+      },
+      {
+        "type": "url",
+        "value": "https://linux.oracle.com/cve/CVE-2020-8116.html",
+      },
+      {
+        "type": "url",
+        "value": "https://linux.oracle.com/errata/ELSA-2021-0548.html",
+      },
+      {
+        "type": "url",
+        "value": "https://nvd.nist.gov/vuln/detail/CVE-2020-8116",
+      },
+    ],
     "severity": "HIGH",
   },
   {
@@ -1281,10 +3441,32 @@ Update to version 3.0.0 or later.",
     "mitigation": "Update the affected package express-jwt to the fixed version: 6.0.0 or remove the package from the image.",
     "name": "Authorization bypass in express-jwt",
     "osi_layer": "NOT_APPLICABLE",
-    "reference": {
-      "id": "CVE-2020-15084",
-      "source": "https://nvd.nist.gov/vuln/detail/CVE-2020-15084",
-    },
+    "references": [
+      {
+        "type": "CVE",
+        "value": "CVE-2020-15084",
+      },
+      {
+        "type": "url",
+        "value": "https://nvd.nist.gov/vuln/detail/CVE-2020-15084",
+      },
+      {
+        "type": "url",
+        "value": "https://github.com/advisories/GHSA-6g6m-m6h5-w9gf",
+      },
+      {
+        "type": "url",
+        "value": "https://github.com/auth0/express-jwt/commit/7ecab5f8f0cab5297c2b863596566eb0c019cdef",
+      },
+      {
+        "type": "url",
+        "value": "https://github.com/auth0/express-jwt/security/advisories/GHSA-6g6m-m6h5-w9gf",
+      },
+      {
+        "type": "url",
+        "value": "https://nvd.nist.gov/vuln/detail/CVE-2020-15084",
+      },
+    ],
     "severity": "HIGH",
   },
   {
@@ -1307,10 +3489,32 @@ Update to version 3.0.0 or later.",
     "mitigation": "Update the affected package getobject to the fixed version: 1.0.0 or remove the package from the image.",
     "name": "nodejs-getobject: Prototype pollution could result in DoS and RCE",
     "osi_layer": "NOT_APPLICABLE",
-    "reference": {
-      "id": "CVE-2020-28282",
-      "source": "https://nvd.nist.gov/vuln/detail/CVE-2020-28282",
-    },
+    "references": [
+      {
+        "type": "CVE",
+        "value": "CVE-2020-28282",
+      },
+      {
+        "type": "url",
+        "value": "https://nvd.nist.gov/vuln/detail/CVE-2020-28282",
+      },
+      {
+        "type": "url",
+        "value": "https://github.com/advisories/GHSA-957j-59c2-j692",
+      },
+      {
+        "type": "url",
+        "value": "https://github.com/cowboy/node-getobject/blob/aba04a8e1d6180eb39eff09990c3a43886ba8937/lib/getobject.js#L48",
+      },
+      {
+        "type": "url",
+        "value": "https://nvd.nist.gov/vuln/detail/CVE-2020-28282",
+      },
+      {
+        "type": "url",
+        "value": "https://www.whitesourcesoftware.com/vulnerability-database/CVE-2020-28282",
+      },
+    ],
     "severity": "HIGH",
   },
   {
@@ -1335,10 +3539,40 @@ Update to version 3.0.0 or later.",
     "mitigation": "Update the affected package growl to the fixed version: 1.10.0 or remove the package from the image.",
     "name": "nodejs-growl: Does not properly sanitize input before passing it to exec",
     "osi_layer": "NOT_APPLICABLE",
-    "reference": {
-      "id": "CVE-2017-16042",
-      "source": "https://nvd.nist.gov/vuln/detail/CVE-2017-16042",
-    },
+    "references": [
+      {
+        "type": "CVE",
+        "value": "CVE-2017-16042",
+      },
+      {
+        "type": "url",
+        "value": "https://nvd.nist.gov/vuln/detail/CVE-2017-16042",
+      },
+      {
+        "type": "url",
+        "value": "https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2017-16042",
+      },
+      {
+        "type": "url",
+        "value": "https://github.com/advisories/GHSA-qh2h-chj9-jffq",
+      },
+      {
+        "type": "url",
+        "value": "https://github.com/tj/node-growl/issues/60",
+      },
+      {
+        "type": "url",
+        "value": "https://github.com/tj/node-growl/pull/61",
+      },
+      {
+        "type": "url",
+        "value": "https://nodesecurity.io/advisories/146",
+      },
+      {
+        "type": "url",
+        "value": "https://nvd.nist.gov/vuln/detail/CVE-2017-16042",
+      },
+    ],
     "severity": "HIGH",
   },
   {
@@ -1367,10 +3601,56 @@ Update to version 3.0.0 or later.",
     "mitigation": "Update the affected package grunt to the fixed version: 1.3.0 or remove the package from the image.",
     "name": "Arbitrary Code Execution in grunt",
     "osi_layer": "NOT_APPLICABLE",
-    "reference": {
-      "id": "CVE-2020-7729",
-      "source": "https://nvd.nist.gov/vuln/detail/CVE-2020-7729",
-    },
+    "references": [
+      {
+        "type": "CVE",
+        "value": "CVE-2020-7729",
+      },
+      {
+        "type": "url",
+        "value": "https://nvd.nist.gov/vuln/detail/CVE-2020-7729",
+      },
+      {
+        "type": "url",
+        "value": "https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2020-7729",
+      },
+      {
+        "type": "url",
+        "value": "https://github.com/advisories/GHSA-m5pj-vjjf-4m3h",
+      },
+      {
+        "type": "url",
+        "value": "https://github.com/gruntjs/grunt/blob/master/lib/grunt/file.js%23L249",
+      },
+      {
+        "type": "url",
+        "value": "https://github.com/gruntjs/grunt/commit/e350cea1724eb3476464561a380fb6a64e61e4e7",
+      },
+      {
+        "type": "url",
+        "value": "https://lists.debian.org/debian-lts-announce/2020/09/msg00008.html",
+      },
+      {
+        "type": "url",
+        "value": "https://nvd.nist.gov/vuln/detail/CVE-2020-7729",
+      },
+      {
+        "type": "url",
+        "value": "https://snyk.io/vuln/SNYK-JAVA-ORGWEBJARSNPM-607922",
+      },
+      {
+        "type": "url",
+        "value": "https://snyk.io/vuln/SNYK-JS-GRUNT-597546",
+      },
+      {
+        "type": "url",
+        "value": "https://ubuntu.com/security/notices/USN-4595-1",
+      },
+      {
+        "type": "url",
+        "value": "https://usn.ubuntu.com/4595-1/",
+      },
+    ],
     "severity": "HIGH",
   },
   {
@@ -1399,10 +3679,56 @@ Update to version 3.0.0 or later.",
     "mitigation": "Update the affected package hosted-git-info to the fixed version: 2.8.9, 3.0.8 or remove the package from the image.",
     "name": "nodejs-hosted-git-info: Regular Expression denial of service via shortcutMatch in fromUrl()",
     "osi_layer": "NOT_APPLICABLE",
-    "reference": {
-      "id": "CVE-2021-23362",
-      "source": "https://nvd.nist.gov/vuln/detail/CVE-2021-23362",
-    },
+    "references": [
+      {
+        "type": "CVE",
+        "value": "CVE-2021-23362",
+      },
+      {
+        "type": "url",
+        "value": "https://nvd.nist.gov/vuln/detail/CVE-2021-23362",
+      },
+      {
+        "type": "url",
+        "value": "https://github.com/advisories/GHSA-43f8-2h32-f4cj",
+      },
+      {
+        "type": "url",
+        "value": "https://github.com/npm/hosted-git-info/commit/29adfe5ef789784c861b2cdeb15051ec2ba651a7",
+      },
+      {
+        "type": "url",
+        "value": "https://github.com/npm/hosted-git-info/commit/8d4b3697d79bcd89cdb36d1db165e3696c783a01",
+      },
+      {
+        "type": "url",
+        "value": "https://github.com/npm/hosted-git-info/commit/bede0dc38e1785e732bf0a48ba6f81a4a908eba3",
+      },
+      {
+        "type": "url",
+        "value": "https://github.com/npm/hosted-git-info/commits/v2",
+      },
+      {
+        "type": "url",
+        "value": "https://linux.oracle.com/cve/CVE-2021-23362.html",
+      },
+      {
+        "type": "url",
+        "value": "https://linux.oracle.com/errata/ELSA-2021-3074.html",
+      },
+      {
+        "type": "url",
+        "value": "https://nvd.nist.gov/vuln/detail/CVE-2021-23362",
+      },
+      {
+        "type": "url",
+        "value": "https://snyk.io/vuln/SNYK-JAVA-ORGWEBJARSNPM-1088356",
+      },
+      {
+        "type": "url",
+        "value": "https://snyk.io/vuln/SNYK-JS-HOSTEDGITINFO-1088355",
+      },
+    ],
     "severity": "MEDIUM",
   },
   {
@@ -1430,10 +3756,52 @@ Update to version 3.0.0 or later.",
     "mitigation": "Update the affected package ini to the fixed version: 1.3.6 or remove the package from the image.",
     "name": "nodejs-ini: Prototype pollution via malicious INI file",
     "osi_layer": "NOT_APPLICABLE",
-    "reference": {
-      "id": "CVE-2020-7788",
-      "source": "https://nvd.nist.gov/vuln/detail/CVE-2020-7788",
-    },
+    "references": [
+      {
+        "type": "CVE",
+        "value": "CVE-2020-7788",
+      },
+      {
+        "type": "url",
+        "value": "https://nvd.nist.gov/vuln/detail/CVE-2020-7788",
+      },
+      {
+        "type": "url",
+        "value": "https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2020-7788",
+      },
+      {
+        "type": "url",
+        "value": "https://github.com/advisories/GHSA-qqgx-2p2h-9c37",
+      },
+      {
+        "type": "url",
+        "value": "https://github.com/npm/ini/commit/56d2805e07ccd94e2ba0984ac9240ff02d44b6f1",
+      },
+      {
+        "type": "url",
+        "value": "https://github.com/npm/ini/commit/56d2805e07ccd94e2ba0984ac9240ff02d44b6f1 (v1.3.6)",
+      },
+      {
+        "type": "url",
+        "value": "https://linux.oracle.com/cve/CVE-2020-7788.html",
+      },
+      {
+        "type": "url",
+        "value": "https://linux.oracle.com/errata/ELSA-2021-0551.html",
+      },
+      {
+        "type": "url",
+        "value": "https://lists.debian.org/debian-lts-announce/2020/12/msg00032.html",
+      },
+      {
+        "type": "url",
+        "value": "https://nvd.nist.gov/vuln/detail/CVE-2020-7788",
+      },
+      {
+        "type": "url",
+        "value": "https://snyk.io/vuln/SNYK-JS-INI-1048974",
+      },
+    ],
     "severity": "HIGH",
   },
   {
@@ -1458,10 +3826,40 @@ Update to version 3.0.0 or later.",
     "mitigation": "Update the affected package jsonwebtoken to the fixed version: 4.2.2 or remove the package from the image.",
     "name": "nodejs-jsonwebtoken: verification step bypass with an altered token",
     "osi_layer": "NOT_APPLICABLE",
-    "reference": {
-      "id": "CVE-2015-9235",
-      "source": "https://nvd.nist.gov/vuln/detail/CVE-2015-9235",
-    },
+    "references": [
+      {
+        "type": "CVE",
+        "value": "CVE-2015-9235",
+      },
+      {
+        "type": "url",
+        "value": "https://nvd.nist.gov/vuln/detail/CVE-2015-9235",
+      },
+      {
+        "type": "url",
+        "value": "https://auth0.com/blog/2015/03/31/critical-vulnerabilities-in-json-web-token-libraries/",
+      },
+      {
+        "type": "url",
+        "value": "https://github.com/advisories/GHSA-c7hr-j4mj-j2w6",
+      },
+      {
+        "type": "url",
+        "value": "https://github.com/auth0/node-jsonwebtoken/commit/1bb584bc382295eeb7ee8c4452a673a77a68b687",
+      },
+      {
+        "type": "url",
+        "value": "https://nodesecurity.io/advisories/17",
+      },
+      {
+        "type": "url",
+        "value": "https://nvd.nist.gov/vuln/detail/CVE-2015-9235",
+      },
+      {
+        "type": "url",
+        "value": "https://www.timmclean.net/2015/02/25/jwt-alg-none.html",
+      },
+    ],
     "severity": "HIGH",
   },
   {
@@ -1483,10 +3881,28 @@ Update to version 3.0.0 or later.",
     "mitigation": "Update the affected package jsonwebtoken to the fixed version: >=4.2.2 or remove the package from the image.",
     "name": "Verification Bypass",
     "osi_layer": "NOT_APPLICABLE",
-    "reference": {
-      "id": "NSWG-ECO-17",
-      "source": "https://github.com/nodejs/security-wg/tree/master/vuln",
-    },
+    "references": [
+      {
+        "type": "NSWG",
+        "value": "NSWG-ECO-17",
+      },
+      {
+        "type": "url",
+        "value": "https://github.com/nodejs/security-wg/tree/master/vuln",
+      },
+      {
+        "type": "url",
+        "value": "https://auth0.com/blog/2015/03/31/critical-vulnerabilities-in-json-web-token-libraries/",
+      },
+      {
+        "type": "url",
+        "value": "https://github.com/auth0/node-jsonwebtoken/commit/1bb584bc382295eeb7ee8c4452a673a77a68b687",
+      },
+      {
+        "type": "url",
+        "value": "https://www.timmclean.net/2015/02/25/jwt-alg-none.html",
+      },
+    ],
     "severity": "HIGH",
   },
   {
@@ -1511,10 +3927,40 @@ Update to version 3.0.0 or later.",
     "mitigation": "Update the affected package jsonwebtoken to the fixed version: 4.2.2 or remove the package from the image.",
     "name": "nodejs-jsonwebtoken: verification step bypass with an altered token",
     "osi_layer": "NOT_APPLICABLE",
-    "reference": {
-      "id": "CVE-2015-9235",
-      "source": "https://nvd.nist.gov/vuln/detail/CVE-2015-9235",
-    },
+    "references": [
+      {
+        "type": "CVE",
+        "value": "CVE-2015-9235",
+      },
+      {
+        "type": "url",
+        "value": "https://nvd.nist.gov/vuln/detail/CVE-2015-9235",
+      },
+      {
+        "type": "url",
+        "value": "https://auth0.com/blog/2015/03/31/critical-vulnerabilities-in-json-web-token-libraries/",
+      },
+      {
+        "type": "url",
+        "value": "https://github.com/advisories/GHSA-c7hr-j4mj-j2w6",
+      },
+      {
+        "type": "url",
+        "value": "https://github.com/auth0/node-jsonwebtoken/commit/1bb584bc382295eeb7ee8c4452a673a77a68b687",
+      },
+      {
+        "type": "url",
+        "value": "https://nodesecurity.io/advisories/17",
+      },
+      {
+        "type": "url",
+        "value": "https://nvd.nist.gov/vuln/detail/CVE-2015-9235",
+      },
+      {
+        "type": "url",
+        "value": "https://www.timmclean.net/2015/02/25/jwt-alg-none.html",
+      },
+    ],
     "severity": "HIGH",
   },
   {
@@ -1536,10 +3982,28 @@ Update to version 3.0.0 or later.",
     "mitigation": "Update the affected package jsonwebtoken to the fixed version: >=4.2.2 or remove the package from the image.",
     "name": "Verification Bypass",
     "osi_layer": "NOT_APPLICABLE",
-    "reference": {
-      "id": "NSWG-ECO-17",
-      "source": "https://github.com/nodejs/security-wg/tree/master/vuln",
-    },
+    "references": [
+      {
+        "type": "NSWG",
+        "value": "NSWG-ECO-17",
+      },
+      {
+        "type": "url",
+        "value": "https://github.com/nodejs/security-wg/tree/master/vuln",
+      },
+      {
+        "type": "url",
+        "value": "https://auth0.com/blog/2015/03/31/critical-vulnerabilities-in-json-web-token-libraries/",
+      },
+      {
+        "type": "url",
+        "value": "https://github.com/auth0/node-jsonwebtoken/commit/1bb584bc382295eeb7ee8c4452a673a77a68b687",
+      },
+      {
+        "type": "url",
+        "value": "https://www.timmclean.net/2015/02/25/jwt-alg-none.html",
+      },
+    ],
     "severity": "HIGH",
   },
   {
@@ -1566,10 +4030,32 @@ In addition, there is the \`none\` algorithm to be concerned about.  In versions
     "mitigation": "Update the affected package jws to the fixed version: 3.0.0 or remove the package from the image.",
     "name": "Forgeable Public/Private Tokens",
     "osi_layer": "NOT_APPLICABLE",
-    "reference": {
-      "id": "CVE-2016-1000223",
-      "source": "https://nvd.nist.gov/vuln/detail/CVE-2016-1000223",
-    },
+    "references": [
+      {
+        "type": "CVE",
+        "value": "CVE-2016-1000223",
+      },
+      {
+        "type": "url",
+        "value": "https://nvd.nist.gov/vuln/detail/CVE-2016-1000223",
+      },
+      {
+        "type": "url",
+        "value": "https://auth0.com/blog/2015/03/31/critical-vulnerabilities-in-json-web-token-libraries/",
+      },
+      {
+        "type": "url",
+        "value": "https://github.com/advisories/GHSA-gjcw-v447-2w7q",
+      },
+      {
+        "type": "url",
+        "value": "https://github.com/brianloveswords/node-jws/commit/585d0e1e97b6747c10cf5b7689ccc5618a89b299#diff-4ac32a78649ca5bdd8e0ba38b7006a1e",
+      },
+      {
+        "type": "url",
+        "value": "https://nvd.nist.gov/vuln/detail/CVE-2016-1000223",
+      },
+    ],
     "severity": "HIGH",
   },
   {
@@ -1596,10 +4082,48 @@ In addition, there is the \`none\` algorithm to be concerned about.  In versions
     "mitigation": "Update the affected package lodash to the fixed version: 4.17.12 or remove the package from the image.",
     "name": "nodejs-lodash: prototype pollution in defaultsDeep function leading to modifying properties",
     "osi_layer": "NOT_APPLICABLE",
-    "reference": {
-      "id": "CVE-2019-10744",
-      "source": "https://nvd.nist.gov/vuln/detail/CVE-2019-10744",
-    },
+    "references": [
+      {
+        "type": "CVE",
+        "value": "CVE-2019-10744",
+      },
+      {
+        "type": "url",
+        "value": "https://nvd.nist.gov/vuln/detail/CVE-2019-10744",
+      },
+      {
+        "type": "url",
+        "value": "https://access.redhat.com/errata/RHSA-2019:3024",
+      },
+      {
+        "type": "url",
+        "value": "https://github.com/advisories/GHSA-jf85-cpcp-j695",
+      },
+      {
+        "type": "url",
+        "value": "https://nvd.nist.gov/vuln/detail/CVE-2019-10744",
+      },
+      {
+        "type": "url",
+        "value": "https://security.netapp.com/advisory/ntap-20191004-0005/",
+      },
+      {
+        "type": "url",
+        "value": "https://snyk.io/vuln/SNYK-JS-LODASH-450202",
+      },
+      {
+        "type": "url",
+        "value": "https://support.f5.com/csp/article/K47105354?utm_source=f5support&amp;utm_medium=RSS",
+      },
+      {
+        "type": "url",
+        "value": "https://www.oracle.com/security-alerts/cpujan2021.html",
+      },
+      {
+        "type": "url",
+        "value": "https://www.oracle.com/security-alerts/cpuoct2020.html",
+      },
+    ],
     "severity": "HIGH",
   },
   {
@@ -1627,10 +4151,52 @@ In addition, there is the \`none\` algorithm to be concerned about.  In versions
     "mitigation": "Update the affected package lodash to the fixed version: 4.17.19 or remove the package from the image.",
     "name": "nodejs-lodash: prototype pollution in zipObjectDeep function",
     "osi_layer": "NOT_APPLICABLE",
-    "reference": {
-      "id": "CVE-2020-8203",
-      "source": "https://nvd.nist.gov/vuln/detail/CVE-2020-8203",
-    },
+    "references": [
+      {
+        "type": "CVE",
+        "value": "CVE-2020-8203",
+      },
+      {
+        "type": "url",
+        "value": "https://nvd.nist.gov/vuln/detail/CVE-2020-8203",
+      },
+      {
+        "type": "url",
+        "value": "https://github.com/advisories/GHSA-p6mc-m468-83gw",
+      },
+      {
+        "type": "url",
+        "value": "https://github.com/lodash/lodash/issues/4874",
+      },
+      {
+        "type": "url",
+        "value": "https://hackerone.com/reports/712065",
+      },
+      {
+        "type": "url",
+        "value": "https://nvd.nist.gov/vuln/detail/CVE-2020-8203",
+      },
+      {
+        "type": "url",
+        "value": "https://security.netapp.com/advisory/ntap-20200724-0006/",
+      },
+      {
+        "type": "url",
+        "value": "https://www.npmjs.com/advisories/1523",
+      },
+      {
+        "type": "url",
+        "value": "https://www.oracle.com//security-alerts/cpujul2021.html",
+      },
+      {
+        "type": "url",
+        "value": "https://www.oracle.com/security-alerts/cpuApr2021.html",
+      },
+      {
+        "type": "url",
+        "value": "https://www.oracle.com/security-alerts/cpuoct2021.html",
+      },
+    ],
     "severity": "HIGH",
   },
   {
@@ -1662,10 +4228,68 @@ In addition, there is the \`none\` algorithm to be concerned about.  In versions
     "mitigation": "Update the affected package lodash to the fixed version: 4.17.21 or remove the package from the image.",
     "name": "nodejs-lodash: command injection via template",
     "osi_layer": "NOT_APPLICABLE",
-    "reference": {
-      "id": "CVE-2021-23337",
-      "source": "https://nvd.nist.gov/vuln/detail/CVE-2021-23337",
-    },
+    "references": [
+      {
+        "type": "CVE",
+        "value": "CVE-2021-23337",
+      },
+      {
+        "type": "url",
+        "value": "https://nvd.nist.gov/vuln/detail/CVE-2021-23337",
+      },
+      {
+        "type": "url",
+        "value": "https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2021-23337",
+      },
+      {
+        "type": "url",
+        "value": "https://github.com/advisories/GHSA-35jh-r3h4-6jhm",
+      },
+      {
+        "type": "url",
+        "value": "https://github.com/lodash/lodash/blob/ddfd9b11a0126db2302cb70ec9973b66baec0975/lodash.js%23L14851",
+      },
+      {
+        "type": "url",
+        "value": "https://nvd.nist.gov/vuln/detail/CVE-2021-23337",
+      },
+      {
+        "type": "url",
+        "value": "https://security.netapp.com/advisory/ntap-20210312-0006/",
+      },
+      {
+        "type": "url",
+        "value": "https://snyk.io/vuln/SNYK-JAVA-ORGFUJIONWEBJARS-1074932",
+      },
+      {
+        "type": "url",
+        "value": "https://snyk.io/vuln/SNYK-JAVA-ORGWEBJARS-1074930",
+      },
+      {
+        "type": "url",
+        "value": "https://snyk.io/vuln/SNYK-JAVA-ORGWEBJARSBOWER-1074928",
+      },
+      {
+        "type": "url",
+        "value": "https://snyk.io/vuln/SNYK-JAVA-ORGWEBJARSBOWERGITHUBLODASH-1074931",
+      },
+      {
+        "type": "url",
+        "value": "https://snyk.io/vuln/SNYK-JAVA-ORGWEBJARSNPM-1074929",
+      },
+      {
+        "type": "url",
+        "value": "https://snyk.io/vuln/SNYK-JS-LODASH-1040724",
+      },
+      {
+        "type": "url",
+        "value": "https://www.oracle.com//security-alerts/cpujul2021.html",
+      },
+      {
+        "type": "url",
+        "value": "https://www.oracle.com/security-alerts/cpuoct2021.html",
+      },
+    ],
     "severity": "HIGH",
   },
   {
@@ -1689,10 +4313,36 @@ In addition, there is the \`none\` algorithm to be concerned about.  In versions
     "mitigation": "Update the affected package lodash to the fixed version: 4.17.11 or remove the package from the image.",
     "name": "lodash: Prototype pollution in utilities function",
     "osi_layer": "NOT_APPLICABLE",
-    "reference": {
-      "id": "CVE-2018-16487",
-      "source": "https://nvd.nist.gov/vuln/detail/CVE-2018-16487",
-    },
+    "references": [
+      {
+        "type": "CVE",
+        "value": "CVE-2018-16487",
+      },
+      {
+        "type": "url",
+        "value": "https://nvd.nist.gov/vuln/detail/CVE-2018-16487",
+      },
+      {
+        "type": "url",
+        "value": "https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2018-16487",
+      },
+      {
+        "type": "url",
+        "value": "https://github.com/advisories/GHSA-4xc9-xhrj-v574",
+      },
+      {
+        "type": "url",
+        "value": "https://hackerone.com/reports/380873",
+      },
+      {
+        "type": "url",
+        "value": "https://nvd.nist.gov/vuln/detail/CVE-2018-16487",
+      },
+      {
+        "type": "url",
+        "value": "https://security.netapp.com/advisory/ntap-20190919-0004/",
+      },
+    ],
     "severity": "MEDIUM",
   },
   {
@@ -1719,10 +4369,48 @@ In addition, there is the \`none\` algorithm to be concerned about.  In versions
     "mitigation": "Update the affected package lodash to the fixed version: 4.17.5 or remove the package from the image.",
     "name": "lodash: Prototype pollution in utilities function",
     "osi_layer": "NOT_APPLICABLE",
-    "reference": {
-      "id": "CVE-2018-3721",
-      "source": "https://nvd.nist.gov/vuln/detail/CVE-2018-3721",
-    },
+    "references": [
+      {
+        "type": "CVE",
+        "value": "CVE-2018-3721",
+      },
+      {
+        "type": "url",
+        "value": "https://nvd.nist.gov/vuln/detail/CVE-2018-3721",
+      },
+      {
+        "type": "url",
+        "value": "https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2018-3721",
+      },
+      {
+        "type": "url",
+        "value": "https://github.com/advisories/GHSA-fvqr-27wr-82fm",
+      },
+      {
+        "type": "url",
+        "value": "https://github.com/lodash/lodash/commit/d8e069cc3410082e44eb18fcf8e7f3d08ebe1d4a",
+      },
+      {
+        "type": "url",
+        "value": "https://hackerone.com/reports/310443",
+      },
+      {
+        "type": "url",
+        "value": "https://nvd.nist.gov/vuln/detail/CVE-2018-3721",
+      },
+      {
+        "type": "url",
+        "value": "https://security.netapp.com/advisory/ntap-20190919-0004/",
+      },
+      {
+        "type": "url",
+        "value": "https://snyk.io/vuln/npm:lodash:20180130",
+      },
+      {
+        "type": "url",
+        "value": "https://www.npmjs.com/advisories/577",
+      },
+    ],
     "severity": "MEDIUM",
   },
   {
@@ -1748,10 +4436,44 @@ In addition, there is the \`none\` algorithm to be concerned about.  In versions
     "mitigation": "Update the affected package lodash to the fixed version: 4.17.11 or remove the package from the image.",
     "name": "lodash: uncontrolled resource consumption in Data handler causing denial of service",
     "osi_layer": "NOT_APPLICABLE",
-    "reference": {
-      "id": "CVE-2019-1010266",
-      "source": "https://nvd.nist.gov/vuln/detail/CVE-2019-1010266",
-    },
+    "references": [
+      {
+        "type": "CVE",
+        "value": "CVE-2019-1010266",
+      },
+      {
+        "type": "url",
+        "value": "https://nvd.nist.gov/vuln/detail/CVE-2019-1010266",
+      },
+      {
+        "type": "url",
+        "value": "https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2019-1010266",
+      },
+      {
+        "type": "url",
+        "value": "https://github.com/advisories/GHSA-x5rq-j2xg-h7qm",
+      },
+      {
+        "type": "url",
+        "value": "https://github.com/lodash/lodash/issues/3359",
+      },
+      {
+        "type": "url",
+        "value": "https://github.com/lodash/lodash/wiki/Changelog",
+      },
+      {
+        "type": "url",
+        "value": "https://nvd.nist.gov/vuln/detail/CVE-2019-1010266",
+      },
+      {
+        "type": "url",
+        "value": "https://security.netapp.com/advisory/ntap-20190919-0004/",
+      },
+      {
+        "type": "url",
+        "value": "https://snyk.io/vuln/SNYK-JS-LODASH-73639",
+      },
+    ],
     "severity": "MEDIUM",
   },
   {
@@ -1778,10 +4500,48 @@ In addition, there is the \`none\` algorithm to be concerned about.  In versions
     "mitigation": "Update the affected package lodash to the fixed version: 4.17.12 or remove the package from the image.",
     "name": "nodejs-lodash: prototype pollution in defaultsDeep function leading to modifying properties",
     "osi_layer": "NOT_APPLICABLE",
-    "reference": {
-      "id": "CVE-2019-10744",
-      "source": "https://nvd.nist.gov/vuln/detail/CVE-2019-10744",
-    },
+    "references": [
+      {
+        "type": "CVE",
+        "value": "CVE-2019-10744",
+      },
+      {
+        "type": "url",
+        "value": "https://nvd.nist.gov/vuln/detail/CVE-2019-10744",
+      },
+      {
+        "type": "url",
+        "value": "https://access.redhat.com/errata/RHSA-2019:3024",
+      },
+      {
+        "type": "url",
+        "value": "https://github.com/advisories/GHSA-jf85-cpcp-j695",
+      },
+      {
+        "type": "url",
+        "value": "https://nvd.nist.gov/vuln/detail/CVE-2019-10744",
+      },
+      {
+        "type": "url",
+        "value": "https://security.netapp.com/advisory/ntap-20191004-0005/",
+      },
+      {
+        "type": "url",
+        "value": "https://snyk.io/vuln/SNYK-JS-LODASH-450202",
+      },
+      {
+        "type": "url",
+        "value": "https://support.f5.com/csp/article/K47105354?utm_source=f5support&amp;utm_medium=RSS",
+      },
+      {
+        "type": "url",
+        "value": "https://www.oracle.com/security-alerts/cpujan2021.html",
+      },
+      {
+        "type": "url",
+        "value": "https://www.oracle.com/security-alerts/cpuoct2020.html",
+      },
+    ],
     "severity": "HIGH",
   },
   {
@@ -1809,10 +4569,52 @@ In addition, there is the \`none\` algorithm to be concerned about.  In versions
     "mitigation": "Update the affected package lodash to the fixed version: 4.17.19 or remove the package from the image.",
     "name": "nodejs-lodash: prototype pollution in zipObjectDeep function",
     "osi_layer": "NOT_APPLICABLE",
-    "reference": {
-      "id": "CVE-2020-8203",
-      "source": "https://nvd.nist.gov/vuln/detail/CVE-2020-8203",
-    },
+    "references": [
+      {
+        "type": "CVE",
+        "value": "CVE-2020-8203",
+      },
+      {
+        "type": "url",
+        "value": "https://nvd.nist.gov/vuln/detail/CVE-2020-8203",
+      },
+      {
+        "type": "url",
+        "value": "https://github.com/advisories/GHSA-p6mc-m468-83gw",
+      },
+      {
+        "type": "url",
+        "value": "https://github.com/lodash/lodash/issues/4874",
+      },
+      {
+        "type": "url",
+        "value": "https://hackerone.com/reports/712065",
+      },
+      {
+        "type": "url",
+        "value": "https://nvd.nist.gov/vuln/detail/CVE-2020-8203",
+      },
+      {
+        "type": "url",
+        "value": "https://security.netapp.com/advisory/ntap-20200724-0006/",
+      },
+      {
+        "type": "url",
+        "value": "https://www.npmjs.com/advisories/1523",
+      },
+      {
+        "type": "url",
+        "value": "https://www.oracle.com//security-alerts/cpujul2021.html",
+      },
+      {
+        "type": "url",
+        "value": "https://www.oracle.com/security-alerts/cpuApr2021.html",
+      },
+      {
+        "type": "url",
+        "value": "https://www.oracle.com/security-alerts/cpuoct2021.html",
+      },
+    ],
     "severity": "HIGH",
   },
   {
@@ -1844,10 +4646,68 @@ In addition, there is the \`none\` algorithm to be concerned about.  In versions
     "mitigation": "Update the affected package lodash to the fixed version: 4.17.21 or remove the package from the image.",
     "name": "nodejs-lodash: command injection via template",
     "osi_layer": "NOT_APPLICABLE",
-    "reference": {
-      "id": "CVE-2021-23337",
-      "source": "https://nvd.nist.gov/vuln/detail/CVE-2021-23337",
-    },
+    "references": [
+      {
+        "type": "CVE",
+        "value": "CVE-2021-23337",
+      },
+      {
+        "type": "url",
+        "value": "https://nvd.nist.gov/vuln/detail/CVE-2021-23337",
+      },
+      {
+        "type": "url",
+        "value": "https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2021-23337",
+      },
+      {
+        "type": "url",
+        "value": "https://github.com/advisories/GHSA-35jh-r3h4-6jhm",
+      },
+      {
+        "type": "url",
+        "value": "https://github.com/lodash/lodash/blob/ddfd9b11a0126db2302cb70ec9973b66baec0975/lodash.js%23L14851",
+      },
+      {
+        "type": "url",
+        "value": "https://nvd.nist.gov/vuln/detail/CVE-2021-23337",
+      },
+      {
+        "type": "url",
+        "value": "https://security.netapp.com/advisory/ntap-20210312-0006/",
+      },
+      {
+        "type": "url",
+        "value": "https://snyk.io/vuln/SNYK-JAVA-ORGFUJIONWEBJARS-1074932",
+      },
+      {
+        "type": "url",
+        "value": "https://snyk.io/vuln/SNYK-JAVA-ORGWEBJARS-1074930",
+      },
+      {
+        "type": "url",
+        "value": "https://snyk.io/vuln/SNYK-JAVA-ORGWEBJARSBOWER-1074928",
+      },
+      {
+        "type": "url",
+        "value": "https://snyk.io/vuln/SNYK-JAVA-ORGWEBJARSBOWERGITHUBLODASH-1074931",
+      },
+      {
+        "type": "url",
+        "value": "https://snyk.io/vuln/SNYK-JAVA-ORGWEBJARSNPM-1074929",
+      },
+      {
+        "type": "url",
+        "value": "https://snyk.io/vuln/SNYK-JS-LODASH-1040724",
+      },
+      {
+        "type": "url",
+        "value": "https://www.oracle.com//security-alerts/cpujul2021.html",
+      },
+      {
+        "type": "url",
+        "value": "https://www.oracle.com/security-alerts/cpuoct2021.html",
+      },
+    ],
     "severity": "HIGH",
   },
   {
@@ -1875,10 +4735,52 @@ In addition, there is the \`none\` algorithm to be concerned about.  In versions
     "mitigation": "Update the affected package lodash to the fixed version: 4.17.19 or remove the package from the image.",
     "name": "nodejs-lodash: prototype pollution in zipObjectDeep function",
     "osi_layer": "NOT_APPLICABLE",
-    "reference": {
-      "id": "CVE-2020-8203",
-      "source": "https://nvd.nist.gov/vuln/detail/CVE-2020-8203",
-    },
+    "references": [
+      {
+        "type": "CVE",
+        "value": "CVE-2020-8203",
+      },
+      {
+        "type": "url",
+        "value": "https://nvd.nist.gov/vuln/detail/CVE-2020-8203",
+      },
+      {
+        "type": "url",
+        "value": "https://github.com/advisories/GHSA-p6mc-m468-83gw",
+      },
+      {
+        "type": "url",
+        "value": "https://github.com/lodash/lodash/issues/4874",
+      },
+      {
+        "type": "url",
+        "value": "https://hackerone.com/reports/712065",
+      },
+      {
+        "type": "url",
+        "value": "https://nvd.nist.gov/vuln/detail/CVE-2020-8203",
+      },
+      {
+        "type": "url",
+        "value": "https://security.netapp.com/advisory/ntap-20200724-0006/",
+      },
+      {
+        "type": "url",
+        "value": "https://www.npmjs.com/advisories/1523",
+      },
+      {
+        "type": "url",
+        "value": "https://www.oracle.com//security-alerts/cpujul2021.html",
+      },
+      {
+        "type": "url",
+        "value": "https://www.oracle.com/security-alerts/cpuApr2021.html",
+      },
+      {
+        "type": "url",
+        "value": "https://www.oracle.com/security-alerts/cpuoct2021.html",
+      },
+    ],
     "severity": "HIGH",
   },
   {
@@ -1910,10 +4812,68 @@ In addition, there is the \`none\` algorithm to be concerned about.  In versions
     "mitigation": "Update the affected package lodash to the fixed version: 4.17.21 or remove the package from the image.",
     "name": "nodejs-lodash: command injection via template",
     "osi_layer": "NOT_APPLICABLE",
-    "reference": {
-      "id": "CVE-2021-23337",
-      "source": "https://nvd.nist.gov/vuln/detail/CVE-2021-23337",
-    },
+    "references": [
+      {
+        "type": "CVE",
+        "value": "CVE-2021-23337",
+      },
+      {
+        "type": "url",
+        "value": "https://nvd.nist.gov/vuln/detail/CVE-2021-23337",
+      },
+      {
+        "type": "url",
+        "value": "https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2021-23337",
+      },
+      {
+        "type": "url",
+        "value": "https://github.com/advisories/GHSA-35jh-r3h4-6jhm",
+      },
+      {
+        "type": "url",
+        "value": "https://github.com/lodash/lodash/blob/ddfd9b11a0126db2302cb70ec9973b66baec0975/lodash.js%23L14851",
+      },
+      {
+        "type": "url",
+        "value": "https://nvd.nist.gov/vuln/detail/CVE-2021-23337",
+      },
+      {
+        "type": "url",
+        "value": "https://security.netapp.com/advisory/ntap-20210312-0006/",
+      },
+      {
+        "type": "url",
+        "value": "https://snyk.io/vuln/SNYK-JAVA-ORGFUJIONWEBJARS-1074932",
+      },
+      {
+        "type": "url",
+        "value": "https://snyk.io/vuln/SNYK-JAVA-ORGWEBJARS-1074930",
+      },
+      {
+        "type": "url",
+        "value": "https://snyk.io/vuln/SNYK-JAVA-ORGWEBJARSBOWER-1074928",
+      },
+      {
+        "type": "url",
+        "value": "https://snyk.io/vuln/SNYK-JAVA-ORGWEBJARSBOWERGITHUBLODASH-1074931",
+      },
+      {
+        "type": "url",
+        "value": "https://snyk.io/vuln/SNYK-JAVA-ORGWEBJARSNPM-1074929",
+      },
+      {
+        "type": "url",
+        "value": "https://snyk.io/vuln/SNYK-JS-LODASH-1040724",
+      },
+      {
+        "type": "url",
+        "value": "https://www.oracle.com//security-alerts/cpujul2021.html",
+      },
+      {
+        "type": "url",
+        "value": "https://www.oracle.com/security-alerts/cpuoct2021.html",
+      },
+    ],
     "severity": "HIGH",
   },
   {
@@ -1935,10 +4895,28 @@ In addition, there is the \`none\` algorithm to be concerned about.  In versions
     "mitigation": "Update the affected package lodash to the fixed version: >=4.17.19 or remove the package from the image.",
     "name": "Allocation of Resources Without Limits or Throttling",
     "osi_layer": "NOT_APPLICABLE",
-    "reference": {
-      "id": "NSWG-ECO-516",
-      "source": "https://github.com/nodejs/security-wg/tree/master/vuln",
-    },
+    "references": [
+      {
+        "type": "NSWG",
+        "value": "NSWG-ECO-516",
+      },
+      {
+        "type": "url",
+        "value": "https://github.com/nodejs/security-wg/tree/master/vuln",
+      },
+      {
+        "type": "url",
+        "value": "https://github.com/lodash/lodash/pull/4759",
+      },
+      {
+        "type": "url",
+        "value": "https://hackerone.com/reports/712065",
+      },
+      {
+        "type": "url",
+        "value": "https://www.npmjs.com/advisories/1523",
+      },
+    ],
     "severity": "HIGH",
   },
   {
@@ -1964,7 +4942,16 @@ No fix is currently available. Consider using an alternative package until a fix
     "mitigation": "Update the affected package marsdb to the fixed version: undefined or remove the package from the image.",
     "name": "Command Injection in marsdb",
     "osi_layer": "NOT_APPLICABLE",
-    "reference": null,
+    "references": [
+      {
+        "type": "url",
+        "value": "https://github.com/advisories/GHSA-5mrr-rgp6-x4gr",
+      },
+      {
+        "type": "url",
+        "value": "https://github.com/bkimminich/juice-shop/issues/1173",
+      },
+    ],
     "severity": "HIGH",
   },
   {
@@ -1989,10 +4976,40 @@ No fix is currently available. Consider using an alternative package until a fix
     "mitigation": "Update the affected package minimist to the fixed version: 1.2.3, 0.2.1 or remove the package from the image.",
     "name": "nodejs-minimist: prototype pollution allows adding or modifying properties of Object.prototype using a constructor or __proto__ payload",
     "osi_layer": "NOT_APPLICABLE",
-    "reference": {
-      "id": "CVE-2020-7598",
-      "source": "https://nvd.nist.gov/vuln/detail/CVE-2020-7598",
-    },
+    "references": [
+      {
+        "type": "CVE",
+        "value": "CVE-2020-7598",
+      },
+      {
+        "type": "url",
+        "value": "https://nvd.nist.gov/vuln/detail/CVE-2020-7598",
+      },
+      {
+        "type": "url",
+        "value": "http://lists.opensuse.org/opensuse-security-announce/2020-06/msg00024.html",
+      },
+      {
+        "type": "url",
+        "value": "https://github.com/advisories/GHSA-vh95-rmgr-6w4m",
+      },
+      {
+        "type": "url",
+        "value": "https://linux.oracle.com/cve/CVE-2020-7598.html",
+      },
+      {
+        "type": "url",
+        "value": "https://linux.oracle.com/errata/ELSA-2020-2852.html",
+      },
+      {
+        "type": "url",
+        "value": "https://nvd.nist.gov/vuln/detail/CVE-2020-7598",
+      },
+      {
+        "type": "url",
+        "value": "https://snyk.io/vuln/SNYK-JS-MINIMIST-559764",
+      },
+    ],
     "severity": "MEDIUM",
   },
   {
@@ -2016,10 +5033,36 @@ No fix is currently available. Consider using an alternative package until a fix
     "mitigation": "Update the affected package moment to the fixed version: 2.19.3 or remove the package from the image.",
     "name": "nodejs-moment: Regular expression denial of service",
     "osi_layer": "NOT_APPLICABLE",
-    "reference": {
-      "id": "CVE-2017-18214",
-      "source": "https://nvd.nist.gov/vuln/detail/CVE-2017-18214",
-    },
+    "references": [
+      {
+        "type": "CVE",
+        "value": "CVE-2017-18214",
+      },
+      {
+        "type": "url",
+        "value": "https://nvd.nist.gov/vuln/detail/CVE-2017-18214",
+      },
+      {
+        "type": "url",
+        "value": "https://github.com/advisories/GHSA-446m-mv8f-q348",
+      },
+      {
+        "type": "url",
+        "value": "https://github.com/moment/moment/issues/4163",
+      },
+      {
+        "type": "url",
+        "value": "https://nodesecurity.io/advisories/532",
+      },
+      {
+        "type": "url",
+        "value": "https://nvd.nist.gov/vuln/detail/CVE-2017-18214",
+      },
+      {
+        "type": "url",
+        "value": "https://www.tenable.com/security/tns-2019-02",
+      },
+    ],
     "severity": "HIGH",
   },
   {
@@ -2050,10 +5093,64 @@ No fix is currently available. Consider using an alternative package until a fix
     "mitigation": "Update the affected package moment to the fixed version: 2.11.2 or remove the package from the image.",
     "name": "moment.js: regular expression denial of service",
     "osi_layer": "NOT_APPLICABLE",
-    "reference": {
-      "id": "CVE-2016-4055",
-      "source": "https://nvd.nist.gov/vuln/detail/CVE-2016-4055",
-    },
+    "references": [
+      {
+        "type": "CVE",
+        "value": "CVE-2016-4055",
+      },
+      {
+        "type": "url",
+        "value": "https://nvd.nist.gov/vuln/detail/CVE-2016-4055",
+      },
+      {
+        "type": "url",
+        "value": "http://www.openwall.com/lists/oss-security/2016/04/20/11",
+      },
+      {
+        "type": "url",
+        "value": "http://www.oracle.com/technetwork/security-advisory/cpujul2018-4258247.html",
+      },
+      {
+        "type": "url",
+        "value": "http://www.securityfocus.com/bid/95849",
+      },
+      {
+        "type": "url",
+        "value": "https://github.com/advisories/GHSA-87vv-r9j6-g5qv",
+      },
+      {
+        "type": "url",
+        "value": "https://lists.apache.org/thread.html/10f0f3aefd51444d1198c65f44ffdf2d78ca3359423dbc1c168c9731@%3Cdev.flink.apache.org%3E",
+      },
+      {
+        "type": "url",
+        "value": "https://lists.apache.org/thread.html/17ff53f7999e74fbe3cc0ceb4e1c3b00b180b7c5afec8e978837bc49@%3Cuser.flink.apache.org%3E",
+      },
+      {
+        "type": "url",
+        "value": "https://lists.apache.org/thread.html/52bafac05ad174000ea465fe275fd3cc7bd5c25535a7631c0bc9bfb2@%3Cuser.flink.apache.org%3E",
+      },
+      {
+        "type": "url",
+        "value": "https://lists.apache.org/thread.html/54df3aeb4239b64b50b356f0ca6f986e3c4ca5b84c515dce077c7854@%3Cuser.flink.apache.org%3E",
+      },
+      {
+        "type": "url",
+        "value": "https://nodesecurity.io/advisories/55",
+      },
+      {
+        "type": "url",
+        "value": "https://nvd.nist.gov/vuln/detail/CVE-2016-4055",
+      },
+      {
+        "type": "url",
+        "value": "https://www.owasp.org/index.php/Regular_expression_Denial_of_Service_-_ReDoS",
+      },
+      {
+        "type": "url",
+        "value": "https://www.tenable.com/security/tns-2019-02",
+      },
+    ],
     "severity": "MEDIUM",
   },
   {
@@ -2084,10 +5181,64 @@ No fix is currently available. Consider using an alternative package until a fix
     "mitigation": "Update the affected package npm to the fixed version: 6.14.6 or remove the package from the image.",
     "name": "npm: sensitive information exposure through logs",
     "osi_layer": "NOT_APPLICABLE",
-    "reference": {
-      "id": "CVE-2020-15095",
-      "source": "https://nvd.nist.gov/vuln/detail/CVE-2020-15095",
-    },
+    "references": [
+      {
+        "type": "CVE",
+        "value": "CVE-2020-15095",
+      },
+      {
+        "type": "url",
+        "value": "https://nvd.nist.gov/vuln/detail/CVE-2020-15095",
+      },
+      {
+        "type": "url",
+        "value": "http://lists.opensuse.org/opensuse-security-announce/2020-10/msg00011.html",
+      },
+      {
+        "type": "url",
+        "value": "http://lists.opensuse.org/opensuse-security-announce/2020-10/msg00015.html",
+      },
+      {
+        "type": "url",
+        "value": "http://lists.opensuse.org/opensuse-security-announce/2020-10/msg00023.html",
+      },
+      {
+        "type": "url",
+        "value": "https://github.com/advisories/GHSA-93f3-23rq-pjfp",
+      },
+      {
+        "type": "url",
+        "value": "https://github.com/npm/cli/blob/66aab417f836a901f8afb265251f761bb0422463/CHANGELOG.md#6146-2020-07-07",
+      },
+      {
+        "type": "url",
+        "value": "https://github.com/npm/cli/commit/a9857b8f6869451ff058789c4631fadfde5bbcbc",
+      },
+      {
+        "type": "url",
+        "value": "https://github.com/npm/cli/security/advisories/GHSA-93f3-23rq-pjfp",
+      },
+      {
+        "type": "url",
+        "value": "https://linux.oracle.com/cve/CVE-2020-15095.html",
+      },
+      {
+        "type": "url",
+        "value": "https://linux.oracle.com/errata/ELSA-2021-0548.html",
+      },
+      {
+        "type": "url",
+        "value": "https://lists.fedoraproject.org/archives/list/package-announce@lists.fedoraproject.org/message/4OOYAMJVLLCLXDTHW3V5UXNULZBBK4O6/",
+      },
+      {
+        "type": "url",
+        "value": "https://nvd.nist.gov/vuln/detail/CVE-2020-15095",
+      },
+      {
+        "type": "url",
+        "value": "https://security.gentoo.org/glsa/202101-07",
+      },
+    ],
     "severity": "MEDIUM",
   },
   {
@@ -2108,7 +5259,16 @@ No fix is currently available. Consider using an alternative package until a fix
     "mitigation": "Update the affected package npm-registry-fetch to the fixed version: 8.1.1, 4.0.5 or remove the package from the image.",
     "name": "Sensitive information exposure through logs in npm-registry-fetch",
     "osi_layer": "NOT_APPLICABLE",
-    "reference": null,
+    "references": [
+      {
+        "type": "url",
+        "value": "https://github.com/advisories/GHSA-jmqm-f2gx-4fjv",
+      },
+      {
+        "type": "url",
+        "value": "https://github.com/npm/npm-registry-fetch/security/advisories/GHSA-jmqm-f2gx-4fjv",
+      },
+    ],
     "severity": "MEDIUM",
   },
   {
@@ -2135,10 +5295,48 @@ No fix is currently available. Consider using an alternative package until a fix
     "mitigation": "Update the affected package npm-user-validate to the fixed version: 1.0.1 or remove the package from the image.",
     "name": "nodejs-npm-user-validate: improper input validation when validating user emails leads to ReDoS",
     "osi_layer": "NOT_APPLICABLE",
-    "reference": {
-      "id": "CVE-2020-7754",
-      "source": "https://nvd.nist.gov/vuln/detail/CVE-2020-7754",
-    },
+    "references": [
+      {
+        "type": "CVE",
+        "value": "CVE-2020-7754",
+      },
+      {
+        "type": "url",
+        "value": "https://nvd.nist.gov/vuln/detail/CVE-2020-7754",
+      },
+      {
+        "type": "url",
+        "value": "https://github.com/advisories/GHSA-pw54-mh39-w3hc",
+      },
+      {
+        "type": "url",
+        "value": "https://github.com/npm/npm-user-validate/commit/c8a87dac1a4cc6988b5418f30411a8669bef204e",
+      },
+      {
+        "type": "url",
+        "value": "https://github.com/npm/npm-user-validate/security/advisories/GHSA-xgh6-85xh-479p",
+      },
+      {
+        "type": "url",
+        "value": "https://linux.oracle.com/cve/CVE-2020-7754.html",
+      },
+      {
+        "type": "url",
+        "value": "https://linux.oracle.com/errata/ELSA-2021-0551.html",
+      },
+      {
+        "type": "url",
+        "value": "https://nvd.nist.gov/vuln/detail/CVE-2020-7754",
+      },
+      {
+        "type": "url",
+        "value": "https://snyk.io/vuln/SNYK-JAVA-ORGWEBJARSNPM-1019353",
+      },
+      {
+        "type": "url",
+        "value": "https://snyk.io/vuln/SNYK-JS-NPMUSERVALIDATE-1019352",
+      },
+    ],
     "severity": "HIGH",
   },
   {
@@ -2168,7 +5366,16 @@ Restrict the character length to a reasonable degree before passing a value to \
     "mitigation": "Update the affected package npm-user-validate to the fixed version: 1.0.1 or remove the package from the image.",
     "name": "Regular Expression Denial of Service in npm-user-validate",
     "osi_layer": "NOT_APPLICABLE",
-    "reference": null,
+    "references": [
+      {
+        "type": "url",
+        "value": "https://github.com/advisories/GHSA-xgh6-85xh-479p",
+      },
+      {
+        "type": "url",
+        "value": "https://github.com/npm/npm-user-validate/security/advisories/GHSA-xgh6-85xh-479p",
+      },
+    ],
     "severity": "LOW",
   },
   {
@@ -2195,10 +5402,48 @@ Restrict the character length to a reasonable degree before passing a value to \
     "mitigation": "Update the affected package path-parse to the fixed version: 1.0.7 or remove the package from the image.",
     "name": "nodejs-path-parse: ReDoS via splitDeviceRe, splitTailRe and splitPathRe",
     "osi_layer": "NOT_APPLICABLE",
-    "reference": {
-      "id": "CVE-2021-23343",
-      "source": "https://nvd.nist.gov/vuln/detail/CVE-2021-23343",
-    },
+    "references": [
+      {
+        "type": "CVE",
+        "value": "CVE-2021-23343",
+      },
+      {
+        "type": "url",
+        "value": "https://nvd.nist.gov/vuln/detail/CVE-2021-23343",
+      },
+      {
+        "type": "url",
+        "value": "https://github.com/advisories/GHSA-hj48-42vr-x3v9",
+      },
+      {
+        "type": "url",
+        "value": "https://github.com/jbgutierrez/path-parse/issues/8",
+      },
+      {
+        "type": "url",
+        "value": "https://linux.oracle.com/cve/CVE-2021-23343.html",
+      },
+      {
+        "type": "url",
+        "value": "https://linux.oracle.com/errata/ELSA-2021-3666.html",
+      },
+      {
+        "type": "url",
+        "value": "https://lists.apache.org/thread.html/r6a32cb3eda3b19096ad48ef1e7aa8f26e005f2f63765abb69ce08b85@%3Cdev.myfaces.apache.org%3E",
+      },
+      {
+        "type": "url",
+        "value": "https://nvd.nist.gov/vuln/detail/CVE-2021-23343",
+      },
+      {
+        "type": "url",
+        "value": "https://snyk.io/vuln/SNYK-JAVA-ORGWEBJARSNPM-1279028",
+      },
+      {
+        "type": "url",
+        "value": "https://snyk.io/vuln/SNYK-JS-PATHPARSE-1077067",
+      },
+    ],
     "severity": "HIGH",
   },
   {
@@ -2226,10 +5471,52 @@ Restrict the character length to a reasonable degree before passing a value to \
     "mitigation": "Update the affected package pug to the fixed version: 3.0.1 or remove the package from the image.",
     "name": "Remote code execution via the \`pretty\` option.",
     "osi_layer": "NOT_APPLICABLE",
-    "reference": {
-      "id": "CVE-2021-21353",
-      "source": "https://nvd.nist.gov/vuln/detail/CVE-2021-21353",
-    },
+    "references": [
+      {
+        "type": "CVE",
+        "value": "CVE-2021-21353",
+      },
+      {
+        "type": "url",
+        "value": "https://nvd.nist.gov/vuln/detail/CVE-2021-21353",
+      },
+      {
+        "type": "url",
+        "value": "https://github.com/advisories/GHSA-p493-635q-r6gr",
+      },
+      {
+        "type": "url",
+        "value": "https://github.com/pugjs/pug/commit/991e78f7c4220b2f8da042877c6f0ef5a4683be0",
+      },
+      {
+        "type": "url",
+        "value": "https://github.com/pugjs/pug/issues/3312",
+      },
+      {
+        "type": "url",
+        "value": "https://github.com/pugjs/pug/pull/3314",
+      },
+      {
+        "type": "url",
+        "value": "https://github.com/pugjs/pug/releases/tag/pug%403.0.1",
+      },
+      {
+        "type": "url",
+        "value": "https://github.com/pugjs/pug/security/advisories/GHSA-p493-635q-r6gr",
+      },
+      {
+        "type": "url",
+        "value": "https://nvd.nist.gov/vuln/detail/CVE-2021-21353",
+      },
+      {
+        "type": "url",
+        "value": "https://www.npmjs.com/package/pug",
+      },
+      {
+        "type": "url",
+        "value": "https://www.npmjs.com/package/pug-code-gen",
+      },
+    ],
     "severity": "HIGH",
   },
   {
@@ -2257,10 +5544,52 @@ Restrict the character length to a reasonable degree before passing a value to \
     "mitigation": "Update the affected package pug-code-gen to the fixed version: 3.0.2, 2.0.3 or remove the package from the image.",
     "name": "Remote code execution via the \`pretty\` option.",
     "osi_layer": "NOT_APPLICABLE",
-    "reference": {
-      "id": "CVE-2021-21353",
-      "source": "https://nvd.nist.gov/vuln/detail/CVE-2021-21353",
-    },
+    "references": [
+      {
+        "type": "CVE",
+        "value": "CVE-2021-21353",
+      },
+      {
+        "type": "url",
+        "value": "https://nvd.nist.gov/vuln/detail/CVE-2021-21353",
+      },
+      {
+        "type": "url",
+        "value": "https://github.com/advisories/GHSA-p493-635q-r6gr",
+      },
+      {
+        "type": "url",
+        "value": "https://github.com/pugjs/pug/commit/991e78f7c4220b2f8da042877c6f0ef5a4683be0",
+      },
+      {
+        "type": "url",
+        "value": "https://github.com/pugjs/pug/issues/3312",
+      },
+      {
+        "type": "url",
+        "value": "https://github.com/pugjs/pug/pull/3314",
+      },
+      {
+        "type": "url",
+        "value": "https://github.com/pugjs/pug/releases/tag/pug%403.0.1",
+      },
+      {
+        "type": "url",
+        "value": "https://github.com/pugjs/pug/security/advisories/GHSA-p493-635q-r6gr",
+      },
+      {
+        "type": "url",
+        "value": "https://nvd.nist.gov/vuln/detail/CVE-2021-21353",
+      },
+      {
+        "type": "url",
+        "value": "https://www.npmjs.com/package/pug",
+      },
+      {
+        "type": "url",
+        "value": "https://www.npmjs.com/package/pug-code-gen",
+      },
+    ],
     "severity": "HIGH",
   },
   {
@@ -2284,10 +5613,36 @@ Restrict the character length to a reasonable degree before passing a value to \
     "mitigation": "Update the affected package sanitize-html to the fixed version: 1.4.3 or remove the package from the image.",
     "name": "XSS - Sanitization not applied recursively",
     "osi_layer": "NOT_APPLICABLE",
-    "reference": {
-      "id": "CVE-2016-1000237",
-      "source": "https://nvd.nist.gov/vuln/detail/CVE-2016-1000237",
-    },
+    "references": [
+      {
+        "type": "CVE",
+        "value": "CVE-2016-1000237",
+      },
+      {
+        "type": "url",
+        "value": "https://nvd.nist.gov/vuln/detail/CVE-2016-1000237",
+      },
+      {
+        "type": "url",
+        "value": "https://github.com/advisories/GHSA-3j7m-hmh3-9jmp",
+      },
+      {
+        "type": "url",
+        "value": "https://github.com/punkave/sanitize-html/issues/29",
+      },
+      {
+        "type": "url",
+        "value": "https://nodesecurity.io/advisories/135",
+      },
+      {
+        "type": "url",
+        "value": "https://nvd.nist.gov/vuln/detail/CVE-2016-1000237",
+      },
+      {
+        "type": "url",
+        "value": "https://raw.githubusercontent.com/distributedweaknessfiling/cvelist/master/2016/1000xxx/CVE-2016-1000237.json",
+      },
+    ],
     "severity": "MEDIUM",
   },
   {
@@ -2311,10 +5666,36 @@ Restrict the character length to a reasonable degree before passing a value to \
     "mitigation": "Update the affected package sanitize-html to the fixed version: 1.11.4 or remove the package from the image.",
     "name": "Cross-Site Scripting in sanitize-html",
     "osi_layer": "NOT_APPLICABLE",
-    "reference": {
-      "id": "CVE-2017-16016",
-      "source": "https://nvd.nist.gov/vuln/detail/CVE-2017-16016",
-    },
+    "references": [
+      {
+        "type": "CVE",
+        "value": "CVE-2017-16016",
+      },
+      {
+        "type": "url",
+        "value": "https://nvd.nist.gov/vuln/detail/CVE-2017-16016",
+      },
+      {
+        "type": "url",
+        "value": "https://github.com/advisories/GHSA-xc6g-ggrc-qq4r",
+      },
+      {
+        "type": "url",
+        "value": "https://github.com/punkave/sanitize-html/commit/5d205a1005ba0df80e21d8c64a15bb3accdb2403",
+      },
+      {
+        "type": "url",
+        "value": "https://github.com/punkave/sanitize-html/issues/100",
+      },
+      {
+        "type": "url",
+        "value": "https://nodesecurity.io/advisories/154",
+      },
+      {
+        "type": "url",
+        "value": "https://nvd.nist.gov/vuln/detail/CVE-2017-16016",
+      },
+    ],
     "severity": "MEDIUM",
   },
   {
@@ -2338,10 +5719,36 @@ Restrict the character length to a reasonable degree before passing a value to \
     "mitigation": "Update the affected package sanitize-html to the fixed version: 2.3.1 or remove the package from the image.",
     "name": "sanitize-html: improper handling of internationalized domain name (IDN) can lead to bypass hostname whitelist validation",
     "osi_layer": "NOT_APPLICABLE",
-    "reference": {
-      "id": "CVE-2021-26539",
-      "source": "https://nvd.nist.gov/vuln/detail/CVE-2021-26539",
-    },
+    "references": [
+      {
+        "type": "CVE",
+        "value": "CVE-2021-26539",
+      },
+      {
+        "type": "url",
+        "value": "https://nvd.nist.gov/vuln/detail/CVE-2021-26539",
+      },
+      {
+        "type": "url",
+        "value": "https://advisory.checkmarx.net/advisory/CX-2021-4308",
+      },
+      {
+        "type": "url",
+        "value": "https://github.com/advisories/GHSA-rjqq-98f6-6j3r",
+      },
+      {
+        "type": "url",
+        "value": "https://github.com/apostrophecms/sanitize-html/blob/main/CHANGELOG.md#231-2021-01-22",
+      },
+      {
+        "type": "url",
+        "value": "https://github.com/apostrophecms/sanitize-html/pull/458",
+      },
+      {
+        "type": "url",
+        "value": "https://nvd.nist.gov/vuln/detail/CVE-2021-26539",
+      },
+    ],
     "severity": "MEDIUM",
   },
   {
@@ -2365,10 +5772,36 @@ Restrict the character length to a reasonable degree before passing a value to \
     "mitigation": "Update the affected package sanitize-html to the fixed version: 2.3.2 or remove the package from the image.",
     "name": "sanitize-html: improper validation of hostnames set by the "allowedIframeHostnames" option can lead to bypass hostname whitelist for iframe element",
     "osi_layer": "NOT_APPLICABLE",
-    "reference": {
-      "id": "CVE-2021-26540",
-      "source": "https://nvd.nist.gov/vuln/detail/CVE-2021-26540",
-    },
+    "references": [
+      {
+        "type": "CVE",
+        "value": "CVE-2021-26540",
+      },
+      {
+        "type": "url",
+        "value": "https://nvd.nist.gov/vuln/detail/CVE-2021-26540",
+      },
+      {
+        "type": "url",
+        "value": "https://advisory.checkmarx.net/advisory/CX-2021-4309",
+      },
+      {
+        "type": "url",
+        "value": "https://github.com/advisories/GHSA-mjxr-4v3x-q3m4",
+      },
+      {
+        "type": "url",
+        "value": "https://github.com/apostrophecms/sanitize-html/blob/main/CHANGELOG.md#232-2021-01-26",
+      },
+      {
+        "type": "url",
+        "value": "https://github.com/apostrophecms/sanitize-html/pull/460",
+      },
+      {
+        "type": "url",
+        "value": "https://nvd.nist.gov/vuln/detail/CVE-2021-26540",
+      },
+    ],
     "severity": "MEDIUM",
   },
   {
@@ -2407,10 +5840,24 @@ console.log(clean);
     "mitigation": "Update the affected package sanitize-html to the fixed version: >=1.11.4 or remove the package from the image.",
     "name": "Cross Site Scripting",
     "osi_layer": "NOT_APPLICABLE",
-    "reference": {
-      "id": "NSWG-ECO-154",
-      "source": "https://github.com/nodejs/security-wg/tree/master/vuln",
-    },
+    "references": [
+      {
+        "type": "NSWG",
+        "value": "NSWG-ECO-154",
+      },
+      {
+        "type": "url",
+        "value": "https://github.com/nodejs/security-wg/tree/master/vuln",
+      },
+      {
+        "type": "url",
+        "value": "https://github.com/punkave/sanitize-html/commit/5d205a1005ba0df80e21d8c64a15bb3accdb2403",
+      },
+      {
+        "type": "url",
+        "value": "https://github.com/punkave/sanitize-html/issues/100",
+      },
+    ],
     "severity": "MEDIUM",
   },
   {
@@ -2436,10 +5883,44 @@ console.log(clean);
     "mitigation": "Update the affected package set-value to the fixed version: 4.0.1 or remove the package from the image.",
     "name": "nodejs-set-value: type confusion allows bypass of CVE-2019-10747",
     "osi_layer": "NOT_APPLICABLE",
-    "reference": {
-      "id": "CVE-2021-23440",
-      "source": "https://nvd.nist.gov/vuln/detail/CVE-2021-23440",
-    },
+    "references": [
+      {
+        "type": "CVE",
+        "value": "CVE-2021-23440",
+      },
+      {
+        "type": "url",
+        "value": "https://nvd.nist.gov/vuln/detail/CVE-2021-23440",
+      },
+      {
+        "type": "url",
+        "value": "https://github.com/advisories/GHSA-4jqc-8m5r-9rpr",
+      },
+      {
+        "type": "url",
+        "value": "https://github.com/jonschlinkert/set-value/commit/7cf8073bb06bf0c15e08475f9f952823b4576452",
+      },
+      {
+        "type": "url",
+        "value": "https://github.com/jonschlinkert/set-value/pull/33",
+      },
+      {
+        "type": "url",
+        "value": "https://nvd.nist.gov/vuln/detail/CVE-2021-23440",
+      },
+      {
+        "type": "url",
+        "value": "https://snyk.io/vuln/SNYK-JAVA-ORGWEBJARSNPM-1584212",
+      },
+      {
+        "type": "url",
+        "value": "https://snyk.io/vuln/SNYK-JS-SETVALUE-1540541",
+      },
+      {
+        "type": "url",
+        "value": "https://www.huntr.dev/bounties/2eae1159-01de-4f82-a177-7478a408c4a2/",
+      },
+    ],
     "severity": "HIGH",
   },
   {
@@ -2464,10 +5945,40 @@ console.log(clean);
     "mitigation": "Update the affected package socket.io to the fixed version: 2.4.0 or remove the package from the image.",
     "name": "Insecure defaults due to CORS misconfiguration in socket.io",
     "osi_layer": "NOT_APPLICABLE",
-    "reference": {
-      "id": "CVE-2020-28481",
-      "source": "https://nvd.nist.gov/vuln/detail/CVE-2020-28481",
-    },
+    "references": [
+      {
+        "type": "CVE",
+        "value": "CVE-2020-28481",
+      },
+      {
+        "type": "url",
+        "value": "https://nvd.nist.gov/vuln/detail/CVE-2020-28481",
+      },
+      {
+        "type": "url",
+        "value": "https://github.com/advisories/GHSA-fxwf-4rqh-v8g3",
+      },
+      {
+        "type": "url",
+        "value": "https://github.com/socketio/socket.io/issues/3671",
+      },
+      {
+        "type": "url",
+        "value": "https://nvd.nist.gov/vuln/detail/CVE-2020-28481",
+      },
+      {
+        "type": "url",
+        "value": "https://snyk.io/vuln/SNYK-JAVA-ORGWEBJARSBOWER-1056358",
+      },
+      {
+        "type": "url",
+        "value": "https://snyk.io/vuln/SNYK-JAVA-ORGWEBJARSNPM-1056357",
+      },
+      {
+        "type": "url",
+        "value": "https://snyk.io/vuln/SNYK-JS-SOCKETIO-1024859",
+      },
+    ],
     "severity": "MEDIUM",
   },
   {
@@ -2492,10 +6003,40 @@ console.log(clean);
     "mitigation": "Update the affected package socket.io-parser to the fixed version: 3.4.1, 3.3.2 or remove the package from the image.",
     "name": "yarnpkg-socket.io-parser: a denial of service (memory consumption) via a large packet because a concatenation approach is used",
     "osi_layer": "NOT_APPLICABLE",
-    "reference": {
-      "id": "CVE-2020-36049",
-      "source": "https://nvd.nist.gov/vuln/detail/CVE-2020-36049",
-    },
+    "references": [
+      {
+        "type": "CVE",
+        "value": "CVE-2020-36049",
+      },
+      {
+        "type": "url",
+        "value": "https://nvd.nist.gov/vuln/detail/CVE-2020-36049",
+      },
+      {
+        "type": "url",
+        "value": "https://blog.caller.xyz/socketio-engineio-dos/",
+      },
+      {
+        "type": "url",
+        "value": "https://github.com/advisories/GHSA-xfhh-g9f5-x4m4",
+      },
+      {
+        "type": "url",
+        "value": "https://github.com/bcaller/kill-engine-io",
+      },
+      {
+        "type": "url",
+        "value": "https://github.com/socketio/socket.io-parser/commit/dcb942d24db97162ad16a67c2a0cf30875342d55",
+      },
+      {
+        "type": "url",
+        "value": "https://nvd.nist.gov/vuln/detail/CVE-2020-36049",
+      },
+      {
+        "type": "url",
+        "value": "https://snyk.io/vuln/SNYK-JAVA-ORGWEBJARSNPM-1056753",
+      },
+    ],
     "severity": "HIGH",
   },
   {
@@ -2520,10 +6061,40 @@ console.log(clean);
     "mitigation": "Update the affected package socket.io-parser to the fixed version: 3.4.1, 3.3.2 or remove the package from the image.",
     "name": "yarnpkg-socket.io-parser: a denial of service (memory consumption) via a large packet because a concatenation approach is used",
     "osi_layer": "NOT_APPLICABLE",
-    "reference": {
-      "id": "CVE-2020-36049",
-      "source": "https://nvd.nist.gov/vuln/detail/CVE-2020-36049",
-    },
+    "references": [
+      {
+        "type": "CVE",
+        "value": "CVE-2020-36049",
+      },
+      {
+        "type": "url",
+        "value": "https://nvd.nist.gov/vuln/detail/CVE-2020-36049",
+      },
+      {
+        "type": "url",
+        "value": "https://blog.caller.xyz/socketio-engineio-dos/",
+      },
+      {
+        "type": "url",
+        "value": "https://github.com/advisories/GHSA-xfhh-g9f5-x4m4",
+      },
+      {
+        "type": "url",
+        "value": "https://github.com/bcaller/kill-engine-io",
+      },
+      {
+        "type": "url",
+        "value": "https://github.com/socketio/socket.io-parser/commit/dcb942d24db97162ad16a67c2a0cf30875342d55",
+      },
+      {
+        "type": "url",
+        "value": "https://nvd.nist.gov/vuln/detail/CVE-2020-36049",
+      },
+      {
+        "type": "url",
+        "value": "https://snyk.io/vuln/SNYK-JAVA-ORGWEBJARSNPM-1056753",
+      },
+    ],
     "severity": "HIGH",
   },
   {
@@ -2551,10 +6122,52 @@ console.log(clean);
     "mitigation": "Update the affected package ssri to the fixed version: 8.0.1, 7.1.1, 6.0.2 or remove the package from the image.",
     "name": "nodejs-ssri: Regular expression DoS (ReDoS) when parsing malicious SRI in strict mode",
     "osi_layer": "NOT_APPLICABLE",
-    "reference": {
-      "id": "CVE-2021-27290",
-      "source": "https://nvd.nist.gov/vuln/detail/CVE-2021-27290",
-    },
+    "references": [
+      {
+        "type": "CVE",
+        "value": "CVE-2021-27290",
+      },
+      {
+        "type": "url",
+        "value": "https://nvd.nist.gov/vuln/detail/CVE-2021-27290",
+      },
+      {
+        "type": "url",
+        "value": "https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2021-27290",
+      },
+      {
+        "type": "url",
+        "value": "https://doyensec.com/resources/Doyensec_Advisory_ssri_redos.pdf",
+      },
+      {
+        "type": "url",
+        "value": "https://github.com/advisories/GHSA-vx3p-948g-6vhq",
+      },
+      {
+        "type": "url",
+        "value": "https://github.com/yetingli/SaveResults/blob/main/pdf/ssri-redos.pdf",
+      },
+      {
+        "type": "url",
+        "value": "https://linux.oracle.com/cve/CVE-2021-27290.html",
+      },
+      {
+        "type": "url",
+        "value": "https://linux.oracle.com/errata/ELSA-2021-3074.html",
+      },
+      {
+        "type": "url",
+        "value": "https://npmjs.com",
+      },
+      {
+        "type": "url",
+        "value": "https://nvd.nist.gov/vuln/detail/CVE-2021-27290",
+      },
+      {
+        "type": "url",
+        "value": "https://www.oracle.com/security-alerts/cpuoct2021.html",
+      },
+    ],
     "severity": "HIGH",
   },
   {
@@ -2582,10 +6195,52 @@ console.log(clean);
     "mitigation": "Update the affected package tar to the fixed version: 6.1.2, 5.0.7, 4.4.15, 3.2.3 or remove the package from the image.",
     "name": "nodejs-tar: Insufficient symlink protection allowing arbitrary file creation and overwrite",
     "osi_layer": "NOT_APPLICABLE",
-    "reference": {
-      "id": "CVE-2021-32803",
-      "source": "https://nvd.nist.gov/vuln/detail/CVE-2021-32803",
-    },
+    "references": [
+      {
+        "type": "CVE",
+        "value": "CVE-2021-32803",
+      },
+      {
+        "type": "url",
+        "value": "https://nvd.nist.gov/vuln/detail/CVE-2021-32803",
+      },
+      {
+        "type": "url",
+        "value": "https://github.com/advisories/GHSA-r628-mhmh-qjhw",
+      },
+      {
+        "type": "url",
+        "value": "https://github.com/npm/node-tar/commit/9dbdeb6df8e9dbd96fa9e84341b9d74734be6c20",
+      },
+      {
+        "type": "url",
+        "value": "https://github.com/npm/node-tar/security/advisories/GHSA-r628-mhmh-qjhw",
+      },
+      {
+        "type": "url",
+        "value": "https://linux.oracle.com/cve/CVE-2021-32803.html",
+      },
+      {
+        "type": "url",
+        "value": "https://linux.oracle.com/errata/ELSA-2021-3666.html",
+      },
+      {
+        "type": "url",
+        "value": "https://nvd.nist.gov/vuln/detail/CVE-2021-32803",
+      },
+      {
+        "type": "url",
+        "value": "https://www.npmjs.com/advisories/1771",
+      },
+      {
+        "type": "url",
+        "value": "https://www.npmjs.com/package/tar",
+      },
+      {
+        "type": "url",
+        "value": "https://www.oracle.com/security-alerts/cpuoct2021.html",
+      },
+    ],
     "severity": "HIGH",
   },
   {
@@ -2613,10 +6268,52 @@ console.log(clean);
     "mitigation": "Update the affected package tar to the fixed version: 6.1.1, 5.0.6, 4.4.14, 3.2.2 or remove the package from the image.",
     "name": "nodejs-tar: Insufficient absolute path sanitization allowing arbitrary file creation and overwrite",
     "osi_layer": "NOT_APPLICABLE",
-    "reference": {
-      "id": "CVE-2021-32804",
-      "source": "https://nvd.nist.gov/vuln/detail/CVE-2021-32804",
-    },
+    "references": [
+      {
+        "type": "CVE",
+        "value": "CVE-2021-32804",
+      },
+      {
+        "type": "url",
+        "value": "https://nvd.nist.gov/vuln/detail/CVE-2021-32804",
+      },
+      {
+        "type": "url",
+        "value": "https://github.com/advisories/GHSA-3jfq-g458-7qm9",
+      },
+      {
+        "type": "url",
+        "value": "https://github.com/npm/node-tar/commit/1f036ca23f64a547bdd6c79c1a44bc62e8115da4",
+      },
+      {
+        "type": "url",
+        "value": "https://github.com/npm/node-tar/security/advisories/GHSA-3jfq-g458-7qm9",
+      },
+      {
+        "type": "url",
+        "value": "https://linux.oracle.com/cve/CVE-2021-32804.html",
+      },
+      {
+        "type": "url",
+        "value": "https://linux.oracle.com/errata/ELSA-2021-3666.html",
+      },
+      {
+        "type": "url",
+        "value": "https://nvd.nist.gov/vuln/detail/CVE-2021-32804",
+      },
+      {
+        "type": "url",
+        "value": "https://www.npmjs.com/advisories/1770",
+      },
+      {
+        "type": "url",
+        "value": "https://www.npmjs.com/package/tar",
+      },
+      {
+        "type": "url",
+        "value": "https://www.oracle.com/security-alerts/cpuoct2021.html",
+      },
+    ],
     "severity": "HIGH",
   },
   {
@@ -2641,10 +6338,40 @@ console.log(clean);
     "mitigation": "Update the affected package tar to the fixed version: 6.1.7, 5.0.8, 4.4.16 or remove the package from the image.",
     "name": "nodejs-tar: insufficient symlink protection due to directory cache poisoning using symbolic links allowing arbitrary file creation and overwrite",
     "osi_layer": "NOT_APPLICABLE",
-    "reference": {
-      "id": "CVE-2021-37701",
-      "source": "https://nvd.nist.gov/vuln/detail/CVE-2021-37701",
-    },
+    "references": [
+      {
+        "type": "CVE",
+        "value": "CVE-2021-37701",
+      },
+      {
+        "type": "url",
+        "value": "https://nvd.nist.gov/vuln/detail/CVE-2021-37701",
+      },
+      {
+        "type": "url",
+        "value": "https://github.com/advisories/GHSA-9r2w-394v-53qc",
+      },
+      {
+        "type": "url",
+        "value": "https://github.com/npm/node-tar/security/advisories/GHSA-9r2w-394v-53qc",
+      },
+      {
+        "type": "url",
+        "value": "https://nvd.nist.gov/vuln/detail/CVE-2021-37701",
+      },
+      {
+        "type": "url",
+        "value": "https://www.npmjs.com/advisories/1779",
+      },
+      {
+        "type": "url",
+        "value": "https://www.npmjs.com/package/tar",
+      },
+      {
+        "type": "url",
+        "value": "https://www.oracle.com/security-alerts/cpuoct2021.html",
+      },
+    ],
     "severity": "HIGH",
   },
   {
@@ -2669,10 +6396,40 @@ console.log(clean);
     "mitigation": "Update the affected package tar to the fixed version: 6.1.9, 5.0.10, 4.4.18 or remove the package from the image.",
     "name": "nodejs-tar: insufficient symlink protection due to directory cache poisoning using symbolic links allowing arbitrary file creation and overwrite",
     "osi_layer": "NOT_APPLICABLE",
-    "reference": {
-      "id": "CVE-2021-37712",
-      "source": "https://nvd.nist.gov/vuln/detail/CVE-2021-37712",
-    },
+    "references": [
+      {
+        "type": "CVE",
+        "value": "CVE-2021-37712",
+      },
+      {
+        "type": "url",
+        "value": "https://nvd.nist.gov/vuln/detail/CVE-2021-37712",
+      },
+      {
+        "type": "url",
+        "value": "https://github.com/advisories/GHSA-qq89-hq3f-393p",
+      },
+      {
+        "type": "url",
+        "value": "https://github.com/npm/node-tar/security/advisories/GHSA-qq89-hq3f-393p",
+      },
+      {
+        "type": "url",
+        "value": "https://nvd.nist.gov/vuln/detail/CVE-2021-37712",
+      },
+      {
+        "type": "url",
+        "value": "https://www.npmjs.com/advisories/1780",
+      },
+      {
+        "type": "url",
+        "value": "https://www.npmjs.com/package/tar",
+      },
+      {
+        "type": "url",
+        "value": "https://www.oracle.com/security-alerts/cpuoct2021.html",
+      },
+    ],
     "severity": "HIGH",
   },
   {
@@ -2696,10 +6453,36 @@ console.log(clean);
     "mitigation": "Update the affected package tar to the fixed version: 6.1.9, 5.0.10, 4.4.18 or remove the package from the image.",
     "name": "Arbitrary File Creation/Overwrite on Windows via insufficient relative path sanitization",
     "osi_layer": "NOT_APPLICABLE",
-    "reference": {
-      "id": "CVE-2021-37713",
-      "source": "https://nvd.nist.gov/vuln/detail/CVE-2021-37713",
-    },
+    "references": [
+      {
+        "type": "CVE",
+        "value": "CVE-2021-37713",
+      },
+      {
+        "type": "url",
+        "value": "https://nvd.nist.gov/vuln/detail/CVE-2021-37713",
+      },
+      {
+        "type": "url",
+        "value": "https://github.com/advisories/GHSA-5955-9wpr-37jh",
+      },
+      {
+        "type": "url",
+        "value": "https://github.com/npm/node-tar/security/advisories/GHSA-5955-9wpr-37jh",
+      },
+      {
+        "type": "url",
+        "value": "https://nvd.nist.gov/vuln/detail/CVE-2021-37713",
+      },
+      {
+        "type": "url",
+        "value": "https://www.npmjs.com/package/tar",
+      },
+      {
+        "type": "url",
+        "value": "https://www.oracle.com/security-alerts/cpuoct2021.html",
+      },
+    ],
     "severity": "HIGH",
   },
   {
@@ -2722,10 +6505,32 @@ console.log(clean);
     "mitigation": "Update the affected package trim-newlines to the fixed version: 4.0.1, 3.0.1 or remove the package from the image.",
     "name": "nodejs-trim-newlines: ReDoS in .end() method",
     "osi_layer": "NOT_APPLICABLE",
-    "reference": {
-      "id": "CVE-2021-33623",
-      "source": "https://nvd.nist.gov/vuln/detail/CVE-2021-33623",
-    },
+    "references": [
+      {
+        "type": "CVE",
+        "value": "CVE-2021-33623",
+      },
+      {
+        "type": "url",
+        "value": "https://nvd.nist.gov/vuln/detail/CVE-2021-33623",
+      },
+      {
+        "type": "url",
+        "value": "https://github.com/advisories/GHSA-7p7h-4mm5-852v",
+      },
+      {
+        "type": "url",
+        "value": "https://github.com/sindresorhus/trim-newlines/releases/tag/v4.0.1",
+      },
+      {
+        "type": "url",
+        "value": "https://nvd.nist.gov/vuln/detail/CVE-2021-33623",
+      },
+      {
+        "type": "url",
+        "value": "https://www.npmjs.com/package/trim-newlines",
+      },
+    ],
     "severity": "HIGH",
   },
   {
@@ -2748,10 +6553,32 @@ console.log(clean);
     "mitigation": "Update the affected package validator to the fixed version: 13.7.0 or remove the package from the image.",
     "name": "Inefficient Regular Expression Complexity in validator.js",
     "osi_layer": "NOT_APPLICABLE",
-    "reference": {
-      "id": "CVE-2021-3765",
-      "source": "https://nvd.nist.gov/vuln/detail/CVE-2021-3765",
-    },
+    "references": [
+      {
+        "type": "CVE",
+        "value": "CVE-2021-3765",
+      },
+      {
+        "type": "url",
+        "value": "https://nvd.nist.gov/vuln/detail/CVE-2021-3765",
+      },
+      {
+        "type": "url",
+        "value": "https://github.com/advisories/GHSA-qgmg-gppg-76g5",
+      },
+      {
+        "type": "url",
+        "value": "https://github.com/validatorjs/validator.js/commit/496fc8b2a7f5997acaaec33cc44d0b8dba5fb5e1",
+      },
+      {
+        "type": "url",
+        "value": "https://huntr.dev/bounties/c37e975c-21a3-4c5f-9b57-04d63b28cfc9",
+      },
+      {
+        "type": "url",
+        "value": "https://nvd.nist.gov/vuln/detail/CVE-2021-3765",
+      },
+    ],
     "severity": "MEDIUM",
   },
   {
@@ -2775,10 +6602,36 @@ console.log(clean);
     "mitigation": "Update the affected package ws to the fixed version: 5.2.3, 6.2.2, 7.4.6 or remove the package from the image.",
     "name": "nodejs-ws: Specially crafted value of the \`Sec-Websocket-Protocol\` header can be used to significantly slow down a ws server",
     "osi_layer": "NOT_APPLICABLE",
-    "reference": {
-      "id": "CVE-2021-32640",
-      "source": "https://nvd.nist.gov/vuln/detail/CVE-2021-32640",
-    },
+    "references": [
+      {
+        "type": "CVE",
+        "value": "CVE-2021-32640",
+      },
+      {
+        "type": "url",
+        "value": "https://nvd.nist.gov/vuln/detail/CVE-2021-32640",
+      },
+      {
+        "type": "url",
+        "value": "https://github.com/advisories/GHSA-6fc8-4gx4-v693",
+      },
+      {
+        "type": "url",
+        "value": "https://github.com/websockets/ws/commit/00c425ec77993773d823f018f64a5c44e17023ff",
+      },
+      {
+        "type": "url",
+        "value": "https://github.com/websockets/ws/security/advisories/GHSA-6fc8-4gx4-v693",
+      },
+      {
+        "type": "url",
+        "value": "https://lists.apache.org/thread.html/rdfa7b6253c4d6271e31566ecd5f30b7ce1b8fb2c89d52b8c4e0f4e30@%3Ccommits.tinkerpop.apache.org%3E",
+      },
+      {
+        "type": "url",
+        "value": "https://nvd.nist.gov/vuln/detail/CVE-2021-32640",
+      },
+    ],
     "severity": "MEDIUM",
   },
   {
@@ -2802,10 +6655,36 @@ console.log(clean);
     "mitigation": "Update the affected package ws to the fixed version: 5.2.3, 6.2.2, 7.4.6 or remove the package from the image.",
     "name": "nodejs-ws: Specially crafted value of the \`Sec-Websocket-Protocol\` header can be used to significantly slow down a ws server",
     "osi_layer": "NOT_APPLICABLE",
-    "reference": {
-      "id": "CVE-2021-32640",
-      "source": "https://nvd.nist.gov/vuln/detail/CVE-2021-32640",
-    },
+    "references": [
+      {
+        "type": "CVE",
+        "value": "CVE-2021-32640",
+      },
+      {
+        "type": "url",
+        "value": "https://nvd.nist.gov/vuln/detail/CVE-2021-32640",
+      },
+      {
+        "type": "url",
+        "value": "https://github.com/advisories/GHSA-6fc8-4gx4-v693",
+      },
+      {
+        "type": "url",
+        "value": "https://github.com/websockets/ws/commit/00c425ec77993773d823f018f64a5c44e17023ff",
+      },
+      {
+        "type": "url",
+        "value": "https://github.com/websockets/ws/security/advisories/GHSA-6fc8-4gx4-v693",
+      },
+      {
+        "type": "url",
+        "value": "https://lists.apache.org/thread.html/rdfa7b6253c4d6271e31566ecd5f30b7ce1b8fb2c89d52b8c4e0f4e30@%3Ccommits.tinkerpop.apache.org%3E",
+      },
+      {
+        "type": "url",
+        "value": "https://nvd.nist.gov/vuln/detail/CVE-2021-32640",
+      },
+    ],
     "severity": "MEDIUM",
   },
   {
@@ -2830,10 +6709,40 @@ console.log(clean);
     "mitigation": "Update the affected package xmlhttprequest-ssl to the fixed version: 1.6.1 or remove the package from the image.",
     "name": "xmlhttprequest-ssl: SSL certificate validation disabled by default",
     "osi_layer": "NOT_APPLICABLE",
-    "reference": {
-      "id": "CVE-2021-31597",
-      "source": "https://nvd.nist.gov/vuln/detail/CVE-2021-31597",
-    },
+    "references": [
+      {
+        "type": "CVE",
+        "value": "CVE-2021-31597",
+      },
+      {
+        "type": "url",
+        "value": "https://nvd.nist.gov/vuln/detail/CVE-2021-31597",
+      },
+      {
+        "type": "url",
+        "value": "https://github.com/advisories/GHSA-72mh-269x-7mh5",
+      },
+      {
+        "type": "url",
+        "value": "https://github.com/mjwwit/node-XMLHttpRequest/commit/bf53329b61ca6afc5d28f6b8d2dc2e3ca740a9b2",
+      },
+      {
+        "type": "url",
+        "value": "https://github.com/mjwwit/node-XMLHttpRequest/compare/v1.6.0...1.6.1",
+      },
+      {
+        "type": "url",
+        "value": "https://nvd.nist.gov/vuln/detail/CVE-2021-31597",
+      },
+      {
+        "type": "url",
+        "value": "https://people.kingsds.network/wesgarland/xmlhttprequest-ssl-vuln.txt",
+      },
+      {
+        "type": "url",
+        "value": "https://security.netapp.com/advisory/ntap-20210618-0004/",
+      },
+    ],
     "severity": "HIGH",
   },
   {
@@ -2859,10 +6768,44 @@ console.log(clean);
     "mitigation": "Update the affected package xmlhttprequest-ssl to the fixed version: 1.6.2 or remove the package from the image.",
     "name": "nodejs-xmlhttprequest: Code injection through user input to xhr.send",
     "osi_layer": "NOT_APPLICABLE",
-    "reference": {
-      "id": "CVE-2020-28502",
-      "source": "https://nvd.nist.gov/vuln/detail/CVE-2020-28502",
-    },
+    "references": [
+      {
+        "type": "CVE",
+        "value": "CVE-2020-28502",
+      },
+      {
+        "type": "url",
+        "value": "https://nvd.nist.gov/vuln/detail/CVE-2020-28502",
+      },
+      {
+        "type": "url",
+        "value": "https://github.com/advisories/GHSA-h4j5-c7cj-74xg",
+      },
+      {
+        "type": "url",
+        "value": "https://github.com/driverdan/node-XMLHttpRequest/blob/1.6.0/lib/XMLHttpRequest.js%23L480",
+      },
+      {
+        "type": "url",
+        "value": "https://nvd.nist.gov/vuln/detail/CVE-2020-28502",
+      },
+      {
+        "type": "url",
+        "value": "https://snyk.io/vuln/SNYK-JAVA-ORGWEBJARSNPM-1082937",
+      },
+      {
+        "type": "url",
+        "value": "https://snyk.io/vuln/SNYK-JAVA-ORGWEBJARSNPM-1082938",
+      },
+      {
+        "type": "url",
+        "value": "https://snyk.io/vuln/SNYK-JS-XMLHTTPREQUEST-1082935",
+      },
+      {
+        "type": "url",
+        "value": "https://snyk.io/vuln/SNYK-JS-XMLHTTPREQUESTSSL-1082936",
+      },
+    ],
     "severity": "HIGH",
   },
   {
@@ -2890,10 +6833,52 @@ console.log(clean);
     "mitigation": "Update the affected package y18n to the fixed version: 5.0.5, 4.0.1, 3.2.2 or remove the package from the image.",
     "name": "nodejs-y18n: prototype pollution vulnerability",
     "osi_layer": "NOT_APPLICABLE",
-    "reference": {
-      "id": "CVE-2020-7774",
-      "source": "https://nvd.nist.gov/vuln/detail/CVE-2020-7774",
-    },
+    "references": [
+      {
+        "type": "CVE",
+        "value": "CVE-2020-7774",
+      },
+      {
+        "type": "url",
+        "value": "https://nvd.nist.gov/vuln/detail/CVE-2020-7774",
+      },
+      {
+        "type": "url",
+        "value": "https://github.com/advisories/GHSA-c4w7-xm78-47vh",
+      },
+      {
+        "type": "url",
+        "value": "https://github.com/yargs/y18n/issues/96",
+      },
+      {
+        "type": "url",
+        "value": "https://github.com/yargs/y18n/pull/108",
+      },
+      {
+        "type": "url",
+        "value": "https://linux.oracle.com/cve/CVE-2020-7774.html",
+      },
+      {
+        "type": "url",
+        "value": "https://linux.oracle.com/errata/ELSA-2021-0551.html",
+      },
+      {
+        "type": "url",
+        "value": "https://nvd.nist.gov/vuln/detail/CVE-2020-7774",
+      },
+      {
+        "type": "url",
+        "value": "https://snyk.io/vuln/SNYK-JAVA-ORGWEBJARSNPM-1038306",
+      },
+      {
+        "type": "url",
+        "value": "https://snyk.io/vuln/SNYK-JS-Y18N-1021887",
+      },
+      {
+        "type": "url",
+        "value": "https://www.oracle.com/security-alerts/cpuApr2021.html",
+      },
+    ],
     "severity": "HIGH",
   },
   {
@@ -2921,10 +6906,52 @@ console.log(clean);
     "mitigation": "Update the affected package y18n to the fixed version: 5.0.5, 4.0.1, 3.2.2 or remove the package from the image.",
     "name": "nodejs-y18n: prototype pollution vulnerability",
     "osi_layer": "NOT_APPLICABLE",
-    "reference": {
-      "id": "CVE-2020-7774",
-      "source": "https://nvd.nist.gov/vuln/detail/CVE-2020-7774",
-    },
+    "references": [
+      {
+        "type": "CVE",
+        "value": "CVE-2020-7774",
+      },
+      {
+        "type": "url",
+        "value": "https://nvd.nist.gov/vuln/detail/CVE-2020-7774",
+      },
+      {
+        "type": "url",
+        "value": "https://github.com/advisories/GHSA-c4w7-xm78-47vh",
+      },
+      {
+        "type": "url",
+        "value": "https://github.com/yargs/y18n/issues/96",
+      },
+      {
+        "type": "url",
+        "value": "https://github.com/yargs/y18n/pull/108",
+      },
+      {
+        "type": "url",
+        "value": "https://linux.oracle.com/cve/CVE-2020-7774.html",
+      },
+      {
+        "type": "url",
+        "value": "https://linux.oracle.com/errata/ELSA-2021-0551.html",
+      },
+      {
+        "type": "url",
+        "value": "https://nvd.nist.gov/vuln/detail/CVE-2020-7774",
+      },
+      {
+        "type": "url",
+        "value": "https://snyk.io/vuln/SNYK-JAVA-ORGWEBJARSNPM-1038306",
+      },
+      {
+        "type": "url",
+        "value": "https://snyk.io/vuln/SNYK-JS-Y18N-1021887",
+      },
+      {
+        "type": "url",
+        "value": "https://www.oracle.com/security-alerts/cpuApr2021.html",
+      },
+    ],
     "severity": "HIGH",
   },
   {
@@ -2948,10 +6975,36 @@ console.log(clean);
     "mitigation": "Update the affected package yargs-parser to the fixed version: 5.0.1, 13.1.2, 18.1.2, 15.0.1 or remove the package from the image.",
     "name": "nodejs-yargs-parser: prototype pollution vulnerability",
     "osi_layer": "NOT_APPLICABLE",
-    "reference": {
-      "id": "CVE-2020-7608",
-      "source": "https://nvd.nist.gov/vuln/detail/CVE-2020-7608",
-    },
+    "references": [
+      {
+        "type": "CVE",
+        "value": "CVE-2020-7608",
+      },
+      {
+        "type": "url",
+        "value": "https://nvd.nist.gov/vuln/detail/CVE-2020-7608",
+      },
+      {
+        "type": "url",
+        "value": "https://github.com/advisories/GHSA-p9pc-299p-vxgp",
+      },
+      {
+        "type": "url",
+        "value": "https://linux.oracle.com/cve/CVE-2020-7608.html",
+      },
+      {
+        "type": "url",
+        "value": "https://linux.oracle.com/errata/ELSA-2021-0548.html",
+      },
+      {
+        "type": "url",
+        "value": "https://nvd.nist.gov/vuln/detail/CVE-2020-7608",
+      },
+      {
+        "type": "url",
+        "value": "https://snyk.io/vuln/SNYK-JS-YARGSPARSER-560381",
+      },
+    ],
     "severity": "MEDIUM",
   },
   {
@@ -2975,10 +7028,36 @@ console.log(clean);
     "mitigation": "Update the affected package yargs-parser to the fixed version: 5.0.1, 13.1.2, 18.1.2, 15.0.1 or remove the package from the image.",
     "name": "nodejs-yargs-parser: prototype pollution vulnerability",
     "osi_layer": "NOT_APPLICABLE",
-    "reference": {
-      "id": "CVE-2020-7608",
-      "source": "https://nvd.nist.gov/vuln/detail/CVE-2020-7608",
-    },
+    "references": [
+      {
+        "type": "CVE",
+        "value": "CVE-2020-7608",
+      },
+      {
+        "type": "url",
+        "value": "https://nvd.nist.gov/vuln/detail/CVE-2020-7608",
+      },
+      {
+        "type": "url",
+        "value": "https://github.com/advisories/GHSA-p9pc-299p-vxgp",
+      },
+      {
+        "type": "url",
+        "value": "https://linux.oracle.com/cve/CVE-2020-7608.html",
+      },
+      {
+        "type": "url",
+        "value": "https://linux.oracle.com/errata/ELSA-2021-0548.html",
+      },
+      {
+        "type": "url",
+        "value": "https://nvd.nist.gov/vuln/detail/CVE-2020-7608",
+      },
+      {
+        "type": "url",
+        "value": "https://snyk.io/vuln/SNYK-JS-YARGSPARSER-560381",
+      },
+    ],
     "severity": "MEDIUM",
   },
 ]
@@ -3006,10 +7085,32 @@ exports[`parses bkimminich/juice-shop:v12.10.2 result file into findings 1`] = `
     "mitigation": "Update the affected package ansi-regex to the fixed version: 5.0.1, 6.0.1 or remove the package from the image.",
     "name": "nodejs-ansi-regex: Regular expression denial of service (ReDoS) matching ANSI escape codes",
     "osi_layer": "NOT_APPLICABLE",
-    "reference": {
-      "id": "CVE-2021-3807",
-      "source": "https://nvd.nist.gov/vuln/detail/CVE-2021-3807",
-    },
+    "references": [
+      {
+        "type": "CVE",
+        "value": "CVE-2021-3807",
+      },
+      {
+        "type": "url",
+        "value": "https://nvd.nist.gov/vuln/detail/CVE-2021-3807",
+      },
+      {
+        "type": "url",
+        "value": "https://github.com/advisories/GHSA-93q8-gq69-wqmw",
+      },
+      {
+        "type": "url",
+        "value": "https://github.com/chalk/ansi-regex/commit/8d1d7cdb586269882c4bdc1b7325d0c58c8f76f9",
+      },
+      {
+        "type": "url",
+        "value": "https://huntr.dev/bounties/5b3cf33b-ede0-4398-9974-800876dfd994",
+      },
+      {
+        "type": "url",
+        "value": "https://nvd.nist.gov/vuln/detail/CVE-2021-3807",
+      },
+    ],
     "severity": "HIGH",
   },
   {
@@ -3032,10 +7133,32 @@ exports[`parses bkimminich/juice-shop:v12.10.2 result file into findings 1`] = `
     "mitigation": "Update the affected package ansi-regex to the fixed version: 5.0.1, 6.0.1 or remove the package from the image.",
     "name": "nodejs-ansi-regex: Regular expression denial of service (ReDoS) matching ANSI escape codes",
     "osi_layer": "NOT_APPLICABLE",
-    "reference": {
-      "id": "CVE-2021-3807",
-      "source": "https://nvd.nist.gov/vuln/detail/CVE-2021-3807",
-    },
+    "references": [
+      {
+        "type": "CVE",
+        "value": "CVE-2021-3807",
+      },
+      {
+        "type": "url",
+        "value": "https://nvd.nist.gov/vuln/detail/CVE-2021-3807",
+      },
+      {
+        "type": "url",
+        "value": "https://github.com/advisories/GHSA-93q8-gq69-wqmw",
+      },
+      {
+        "type": "url",
+        "value": "https://github.com/chalk/ansi-regex/commit/8d1d7cdb586269882c4bdc1b7325d0c58c8f76f9",
+      },
+      {
+        "type": "url",
+        "value": "https://huntr.dev/bounties/5b3cf33b-ede0-4398-9974-800876dfd994",
+      },
+      {
+        "type": "url",
+        "value": "https://nvd.nist.gov/vuln/detail/CVE-2021-3807",
+      },
+    ],
     "severity": "HIGH",
   },
   {
@@ -3056,10 +7179,24 @@ exports[`parses bkimminich/juice-shop:v12.10.2 result file into findings 1`] = `
     "mitigation": "Update the affected package base64url to the fixed version: >=3.0.0 or remove the package from the image.",
     "name": "Out-of-bounds Read",
     "osi_layer": "NOT_APPLICABLE",
-    "reference": {
-      "id": "NSWG-ECO-428",
-      "source": "https://github.com/nodejs/security-wg/tree/master/vuln",
-    },
+    "references": [
+      {
+        "type": "NSWG",
+        "value": "NSWG-ECO-428",
+      },
+      {
+        "type": "url",
+        "value": "https://github.com/nodejs/security-wg/tree/master/vuln",
+      },
+      {
+        "type": "url",
+        "value": "https://github.com/brianloveswords/base64url/pull/25",
+      },
+      {
+        "type": "url",
+        "value": "https://hackerone.com/reports/321687",
+      },
+    ],
     "severity": "HIGH",
   },
   {
@@ -3085,7 +7222,16 @@ Update to version 3.0.0 or later.",
     "mitigation": "Update the affected package base64url to the fixed version: 3.0.0 or remove the package from the image.",
     "name": "Out-of-bounds Read in base64url",
     "osi_layer": "NOT_APPLICABLE",
-    "reference": null,
+    "references": [
+      {
+        "type": "url",
+        "value": "https://github.com/advisories/GHSA-rvg8-pwq2-xj7q",
+      },
+      {
+        "type": "url",
+        "value": "https://github.com/brianloveswords/base64url/pull/25",
+      },
+    ],
     "severity": "MEDIUM",
   },
   {
@@ -3106,7 +7252,16 @@ Update to version 3.0.0 or later.",
     "mitigation": "Update the affected package diff to the fixed version: 3.5.0 or remove the package from the image.",
     "name": "Regular Expression Denial of Service (ReDoS)",
     "osi_layer": "NOT_APPLICABLE",
-    "reference": null,
+    "references": [
+      {
+        "type": "url",
+        "value": "https://github.com/advisories/GHSA-h6ch-v84p-w6p9",
+      },
+      {
+        "type": "url",
+        "value": "https://github.com/kpdecker/jsdiff/commit/2aec4298639bf30fb88a00b356bf404d3551b8c0",
+      },
+    ],
     "severity": "HIGH",
   },
   {
@@ -3129,10 +7284,32 @@ Update to version 3.0.0 or later.",
     "mitigation": "Update the affected package express-jwt to the fixed version: 6.0.0 or remove the package from the image.",
     "name": "Authorization bypass in express-jwt",
     "osi_layer": "NOT_APPLICABLE",
-    "reference": {
-      "id": "CVE-2020-15084",
-      "source": "https://nvd.nist.gov/vuln/detail/CVE-2020-15084",
-    },
+    "references": [
+      {
+        "type": "CVE",
+        "value": "CVE-2020-15084",
+      },
+      {
+        "type": "url",
+        "value": "https://nvd.nist.gov/vuln/detail/CVE-2020-15084",
+      },
+      {
+        "type": "url",
+        "value": "https://github.com/advisories/GHSA-6g6m-m6h5-w9gf",
+      },
+      {
+        "type": "url",
+        "value": "https://github.com/auth0/express-jwt/commit/7ecab5f8f0cab5297c2b863596566eb0c019cdef",
+      },
+      {
+        "type": "url",
+        "value": "https://github.com/auth0/express-jwt/security/advisories/GHSA-6g6m-m6h5-w9gf",
+      },
+      {
+        "type": "url",
+        "value": "https://nvd.nist.gov/vuln/detail/CVE-2020-15084",
+      },
+    ],
     "severity": "HIGH",
   },
   {
@@ -3157,10 +7334,40 @@ Update to version 3.0.0 or later.",
     "mitigation": "Update the affected package growl to the fixed version: 1.10.0 or remove the package from the image.",
     "name": "nodejs-growl: Does not properly sanitize input before passing it to exec",
     "osi_layer": "NOT_APPLICABLE",
-    "reference": {
-      "id": "CVE-2017-16042",
-      "source": "https://nvd.nist.gov/vuln/detail/CVE-2017-16042",
-    },
+    "references": [
+      {
+        "type": "CVE",
+        "value": "CVE-2017-16042",
+      },
+      {
+        "type": "url",
+        "value": "https://nvd.nist.gov/vuln/detail/CVE-2017-16042",
+      },
+      {
+        "type": "url",
+        "value": "https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2017-16042",
+      },
+      {
+        "type": "url",
+        "value": "https://github.com/advisories/GHSA-qh2h-chj9-jffq",
+      },
+      {
+        "type": "url",
+        "value": "https://github.com/tj/node-growl/issues/60",
+      },
+      {
+        "type": "url",
+        "value": "https://github.com/tj/node-growl/pull/61",
+      },
+      {
+        "type": "url",
+        "value": "https://nodesecurity.io/advisories/146",
+      },
+      {
+        "type": "url",
+        "value": "https://nvd.nist.gov/vuln/detail/CVE-2017-16042",
+      },
+    ],
     "severity": "HIGH",
   },
   {
@@ -3182,10 +7389,28 @@ Update to version 3.0.0 or later.",
     "mitigation": "Update the affected package hbs to the fixed version: undefined or remove the package from the image.",
     "name": "Insertion of Sensitive Information into Externally-Accessible File or Directory and Exposure of Sensitive Information to an Unauthorized Actor in hbs",
     "osi_layer": "NOT_APPLICABLE",
-    "reference": {
-      "id": "CVE-2021-32822",
-      "source": "https://nvd.nist.gov/vuln/detail/CVE-2021-32822",
-    },
+    "references": [
+      {
+        "type": "CVE",
+        "value": "CVE-2021-32822",
+      },
+      {
+        "type": "url",
+        "value": "https://nvd.nist.gov/vuln/detail/CVE-2021-32822",
+      },
+      {
+        "type": "url",
+        "value": "https://github.com/advisories/GHSA-7f5c-rpf4-86p8",
+      },
+      {
+        "type": "url",
+        "value": "https://nvd.nist.gov/vuln/detail/CVE-2021-32822",
+      },
+      {
+        "type": "url",
+        "value": "https://securitylab.github.com/advisories/GHSL-2021-020-pillarjs-hbs/",
+      },
+    ],
     "severity": "MEDIUM",
   },
   {
@@ -3210,10 +7435,40 @@ Update to version 3.0.0 or later.",
     "mitigation": "Update the affected package jsonwebtoken to the fixed version: 4.2.2 or remove the package from the image.",
     "name": "nodejs-jsonwebtoken: verification step bypass with an altered token",
     "osi_layer": "NOT_APPLICABLE",
-    "reference": {
-      "id": "CVE-2015-9235",
-      "source": "https://nvd.nist.gov/vuln/detail/CVE-2015-9235",
-    },
+    "references": [
+      {
+        "type": "CVE",
+        "value": "CVE-2015-9235",
+      },
+      {
+        "type": "url",
+        "value": "https://nvd.nist.gov/vuln/detail/CVE-2015-9235",
+      },
+      {
+        "type": "url",
+        "value": "https://auth0.com/blog/2015/03/31/critical-vulnerabilities-in-json-web-token-libraries/",
+      },
+      {
+        "type": "url",
+        "value": "https://github.com/advisories/GHSA-c7hr-j4mj-j2w6",
+      },
+      {
+        "type": "url",
+        "value": "https://github.com/auth0/node-jsonwebtoken/commit/1bb584bc382295eeb7ee8c4452a673a77a68b687",
+      },
+      {
+        "type": "url",
+        "value": "https://nodesecurity.io/advisories/17",
+      },
+      {
+        "type": "url",
+        "value": "https://nvd.nist.gov/vuln/detail/CVE-2015-9235",
+      },
+      {
+        "type": "url",
+        "value": "https://www.timmclean.net/2015/02/25/jwt-alg-none.html",
+      },
+    ],
     "severity": "HIGH",
   },
   {
@@ -3235,10 +7490,28 @@ Update to version 3.0.0 or later.",
     "mitigation": "Update the affected package jsonwebtoken to the fixed version: >=4.2.2 or remove the package from the image.",
     "name": "Verification Bypass",
     "osi_layer": "NOT_APPLICABLE",
-    "reference": {
-      "id": "NSWG-ECO-17",
-      "source": "https://github.com/nodejs/security-wg/tree/master/vuln",
-    },
+    "references": [
+      {
+        "type": "NSWG",
+        "value": "NSWG-ECO-17",
+      },
+      {
+        "type": "url",
+        "value": "https://github.com/nodejs/security-wg/tree/master/vuln",
+      },
+      {
+        "type": "url",
+        "value": "https://auth0.com/blog/2015/03/31/critical-vulnerabilities-in-json-web-token-libraries/",
+      },
+      {
+        "type": "url",
+        "value": "https://github.com/auth0/node-jsonwebtoken/commit/1bb584bc382295eeb7ee8c4452a673a77a68b687",
+      },
+      {
+        "type": "url",
+        "value": "https://www.timmclean.net/2015/02/25/jwt-alg-none.html",
+      },
+    ],
     "severity": "HIGH",
   },
   {
@@ -3263,10 +7536,40 @@ Update to version 3.0.0 or later.",
     "mitigation": "Update the affected package jsonwebtoken to the fixed version: 4.2.2 or remove the package from the image.",
     "name": "nodejs-jsonwebtoken: verification step bypass with an altered token",
     "osi_layer": "NOT_APPLICABLE",
-    "reference": {
-      "id": "CVE-2015-9235",
-      "source": "https://nvd.nist.gov/vuln/detail/CVE-2015-9235",
-    },
+    "references": [
+      {
+        "type": "CVE",
+        "value": "CVE-2015-9235",
+      },
+      {
+        "type": "url",
+        "value": "https://nvd.nist.gov/vuln/detail/CVE-2015-9235",
+      },
+      {
+        "type": "url",
+        "value": "https://auth0.com/blog/2015/03/31/critical-vulnerabilities-in-json-web-token-libraries/",
+      },
+      {
+        "type": "url",
+        "value": "https://github.com/advisories/GHSA-c7hr-j4mj-j2w6",
+      },
+      {
+        "type": "url",
+        "value": "https://github.com/auth0/node-jsonwebtoken/commit/1bb584bc382295eeb7ee8c4452a673a77a68b687",
+      },
+      {
+        "type": "url",
+        "value": "https://nodesecurity.io/advisories/17",
+      },
+      {
+        "type": "url",
+        "value": "https://nvd.nist.gov/vuln/detail/CVE-2015-9235",
+      },
+      {
+        "type": "url",
+        "value": "https://www.timmclean.net/2015/02/25/jwt-alg-none.html",
+      },
+    ],
     "severity": "HIGH",
   },
   {
@@ -3288,10 +7591,28 @@ Update to version 3.0.0 or later.",
     "mitigation": "Update the affected package jsonwebtoken to the fixed version: >=4.2.2 or remove the package from the image.",
     "name": "Verification Bypass",
     "osi_layer": "NOT_APPLICABLE",
-    "reference": {
-      "id": "NSWG-ECO-17",
-      "source": "https://github.com/nodejs/security-wg/tree/master/vuln",
-    },
+    "references": [
+      {
+        "type": "NSWG",
+        "value": "NSWG-ECO-17",
+      },
+      {
+        "type": "url",
+        "value": "https://github.com/nodejs/security-wg/tree/master/vuln",
+      },
+      {
+        "type": "url",
+        "value": "https://auth0.com/blog/2015/03/31/critical-vulnerabilities-in-json-web-token-libraries/",
+      },
+      {
+        "type": "url",
+        "value": "https://github.com/auth0/node-jsonwebtoken/commit/1bb584bc382295eeb7ee8c4452a673a77a68b687",
+      },
+      {
+        "type": "url",
+        "value": "https://www.timmclean.net/2015/02/25/jwt-alg-none.html",
+      },
+    ],
     "severity": "HIGH",
   },
   {
@@ -3318,10 +7639,32 @@ In addition, there is the \`none\` algorithm to be concerned about.  In versions
     "mitigation": "Update the affected package jws to the fixed version: 3.0.0 or remove the package from the image.",
     "name": "Forgeable Public/Private Tokens",
     "osi_layer": "NOT_APPLICABLE",
-    "reference": {
-      "id": "CVE-2016-1000223",
-      "source": "https://nvd.nist.gov/vuln/detail/CVE-2016-1000223",
-    },
+    "references": [
+      {
+        "type": "CVE",
+        "value": "CVE-2016-1000223",
+      },
+      {
+        "type": "url",
+        "value": "https://nvd.nist.gov/vuln/detail/CVE-2016-1000223",
+      },
+      {
+        "type": "url",
+        "value": "https://auth0.com/blog/2015/03/31/critical-vulnerabilities-in-json-web-token-libraries/",
+      },
+      {
+        "type": "url",
+        "value": "https://github.com/advisories/GHSA-gjcw-v447-2w7q",
+      },
+      {
+        "type": "url",
+        "value": "https://github.com/brianloveswords/node-jws/commit/585d0e1e97b6747c10cf5b7689ccc5618a89b299#diff-4ac32a78649ca5bdd8e0ba38b7006a1e",
+      },
+      {
+        "type": "url",
+        "value": "https://nvd.nist.gov/vuln/detail/CVE-2016-1000223",
+      },
+    ],
     "severity": "HIGH",
   },
   {
@@ -3348,10 +7691,48 @@ In addition, there is the \`none\` algorithm to be concerned about.  In versions
     "mitigation": "Update the affected package lodash to the fixed version: 4.17.12 or remove the package from the image.",
     "name": "nodejs-lodash: prototype pollution in defaultsDeep function leading to modifying properties",
     "osi_layer": "NOT_APPLICABLE",
-    "reference": {
-      "id": "CVE-2019-10744",
-      "source": "https://nvd.nist.gov/vuln/detail/CVE-2019-10744",
-    },
+    "references": [
+      {
+        "type": "CVE",
+        "value": "CVE-2019-10744",
+      },
+      {
+        "type": "url",
+        "value": "https://nvd.nist.gov/vuln/detail/CVE-2019-10744",
+      },
+      {
+        "type": "url",
+        "value": "https://access.redhat.com/errata/RHSA-2019:3024",
+      },
+      {
+        "type": "url",
+        "value": "https://github.com/advisories/GHSA-jf85-cpcp-j695",
+      },
+      {
+        "type": "url",
+        "value": "https://nvd.nist.gov/vuln/detail/CVE-2019-10744",
+      },
+      {
+        "type": "url",
+        "value": "https://security.netapp.com/advisory/ntap-20191004-0005/",
+      },
+      {
+        "type": "url",
+        "value": "https://snyk.io/vuln/SNYK-JS-LODASH-450202",
+      },
+      {
+        "type": "url",
+        "value": "https://support.f5.com/csp/article/K47105354?utm_source=f5support&amp;utm_medium=RSS",
+      },
+      {
+        "type": "url",
+        "value": "https://www.oracle.com/security-alerts/cpujan2021.html",
+      },
+      {
+        "type": "url",
+        "value": "https://www.oracle.com/security-alerts/cpuoct2020.html",
+      },
+    ],
     "severity": "HIGH",
   },
   {
@@ -3379,10 +7760,52 @@ In addition, there is the \`none\` algorithm to be concerned about.  In versions
     "mitigation": "Update the affected package lodash to the fixed version: 4.17.19 or remove the package from the image.",
     "name": "nodejs-lodash: prototype pollution in zipObjectDeep function",
     "osi_layer": "NOT_APPLICABLE",
-    "reference": {
-      "id": "CVE-2020-8203",
-      "source": "https://nvd.nist.gov/vuln/detail/CVE-2020-8203",
-    },
+    "references": [
+      {
+        "type": "CVE",
+        "value": "CVE-2020-8203",
+      },
+      {
+        "type": "url",
+        "value": "https://nvd.nist.gov/vuln/detail/CVE-2020-8203",
+      },
+      {
+        "type": "url",
+        "value": "https://github.com/advisories/GHSA-p6mc-m468-83gw",
+      },
+      {
+        "type": "url",
+        "value": "https://github.com/lodash/lodash/issues/4874",
+      },
+      {
+        "type": "url",
+        "value": "https://hackerone.com/reports/712065",
+      },
+      {
+        "type": "url",
+        "value": "https://nvd.nist.gov/vuln/detail/CVE-2020-8203",
+      },
+      {
+        "type": "url",
+        "value": "https://security.netapp.com/advisory/ntap-20200724-0006/",
+      },
+      {
+        "type": "url",
+        "value": "https://www.npmjs.com/advisories/1523",
+      },
+      {
+        "type": "url",
+        "value": "https://www.oracle.com//security-alerts/cpujul2021.html",
+      },
+      {
+        "type": "url",
+        "value": "https://www.oracle.com/security-alerts/cpuApr2021.html",
+      },
+      {
+        "type": "url",
+        "value": "https://www.oracle.com/security-alerts/cpuoct2021.html",
+      },
+    ],
     "severity": "HIGH",
   },
   {
@@ -3414,10 +7837,68 @@ In addition, there is the \`none\` algorithm to be concerned about.  In versions
     "mitigation": "Update the affected package lodash to the fixed version: 4.17.21 or remove the package from the image.",
     "name": "nodejs-lodash: command injection via template",
     "osi_layer": "NOT_APPLICABLE",
-    "reference": {
-      "id": "CVE-2021-23337",
-      "source": "https://nvd.nist.gov/vuln/detail/CVE-2021-23337",
-    },
+    "references": [
+      {
+        "type": "CVE",
+        "value": "CVE-2021-23337",
+      },
+      {
+        "type": "url",
+        "value": "https://nvd.nist.gov/vuln/detail/CVE-2021-23337",
+      },
+      {
+        "type": "url",
+        "value": "https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2021-23337",
+      },
+      {
+        "type": "url",
+        "value": "https://github.com/advisories/GHSA-35jh-r3h4-6jhm",
+      },
+      {
+        "type": "url",
+        "value": "https://github.com/lodash/lodash/blob/ddfd9b11a0126db2302cb70ec9973b66baec0975/lodash.js%23L14851",
+      },
+      {
+        "type": "url",
+        "value": "https://nvd.nist.gov/vuln/detail/CVE-2021-23337",
+      },
+      {
+        "type": "url",
+        "value": "https://security.netapp.com/advisory/ntap-20210312-0006/",
+      },
+      {
+        "type": "url",
+        "value": "https://snyk.io/vuln/SNYK-JAVA-ORGFUJIONWEBJARS-1074932",
+      },
+      {
+        "type": "url",
+        "value": "https://snyk.io/vuln/SNYK-JAVA-ORGWEBJARS-1074930",
+      },
+      {
+        "type": "url",
+        "value": "https://snyk.io/vuln/SNYK-JAVA-ORGWEBJARSBOWER-1074928",
+      },
+      {
+        "type": "url",
+        "value": "https://snyk.io/vuln/SNYK-JAVA-ORGWEBJARSBOWERGITHUBLODASH-1074931",
+      },
+      {
+        "type": "url",
+        "value": "https://snyk.io/vuln/SNYK-JAVA-ORGWEBJARSNPM-1074929",
+      },
+      {
+        "type": "url",
+        "value": "https://snyk.io/vuln/SNYK-JS-LODASH-1040724",
+      },
+      {
+        "type": "url",
+        "value": "https://www.oracle.com//security-alerts/cpujul2021.html",
+      },
+      {
+        "type": "url",
+        "value": "https://www.oracle.com/security-alerts/cpuoct2021.html",
+      },
+    ],
     "severity": "HIGH",
   },
   {
@@ -3441,10 +7922,36 @@ In addition, there is the \`none\` algorithm to be concerned about.  In versions
     "mitigation": "Update the affected package lodash to the fixed version: 4.17.11 or remove the package from the image.",
     "name": "lodash: Prototype pollution in utilities function",
     "osi_layer": "NOT_APPLICABLE",
-    "reference": {
-      "id": "CVE-2018-16487",
-      "source": "https://nvd.nist.gov/vuln/detail/CVE-2018-16487",
-    },
+    "references": [
+      {
+        "type": "CVE",
+        "value": "CVE-2018-16487",
+      },
+      {
+        "type": "url",
+        "value": "https://nvd.nist.gov/vuln/detail/CVE-2018-16487",
+      },
+      {
+        "type": "url",
+        "value": "https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2018-16487",
+      },
+      {
+        "type": "url",
+        "value": "https://github.com/advisories/GHSA-4xc9-xhrj-v574",
+      },
+      {
+        "type": "url",
+        "value": "https://hackerone.com/reports/380873",
+      },
+      {
+        "type": "url",
+        "value": "https://nvd.nist.gov/vuln/detail/CVE-2018-16487",
+      },
+      {
+        "type": "url",
+        "value": "https://security.netapp.com/advisory/ntap-20190919-0004/",
+      },
+    ],
     "severity": "MEDIUM",
   },
   {
@@ -3471,10 +7978,48 @@ In addition, there is the \`none\` algorithm to be concerned about.  In versions
     "mitigation": "Update the affected package lodash to the fixed version: 4.17.5 or remove the package from the image.",
     "name": "lodash: Prototype pollution in utilities function",
     "osi_layer": "NOT_APPLICABLE",
-    "reference": {
-      "id": "CVE-2018-3721",
-      "source": "https://nvd.nist.gov/vuln/detail/CVE-2018-3721",
-    },
+    "references": [
+      {
+        "type": "CVE",
+        "value": "CVE-2018-3721",
+      },
+      {
+        "type": "url",
+        "value": "https://nvd.nist.gov/vuln/detail/CVE-2018-3721",
+      },
+      {
+        "type": "url",
+        "value": "https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2018-3721",
+      },
+      {
+        "type": "url",
+        "value": "https://github.com/advisories/GHSA-fvqr-27wr-82fm",
+      },
+      {
+        "type": "url",
+        "value": "https://github.com/lodash/lodash/commit/d8e069cc3410082e44eb18fcf8e7f3d08ebe1d4a",
+      },
+      {
+        "type": "url",
+        "value": "https://hackerone.com/reports/310443",
+      },
+      {
+        "type": "url",
+        "value": "https://nvd.nist.gov/vuln/detail/CVE-2018-3721",
+      },
+      {
+        "type": "url",
+        "value": "https://security.netapp.com/advisory/ntap-20190919-0004/",
+      },
+      {
+        "type": "url",
+        "value": "https://snyk.io/vuln/npm:lodash:20180130",
+      },
+      {
+        "type": "url",
+        "value": "https://www.npmjs.com/advisories/577",
+      },
+    ],
     "severity": "MEDIUM",
   },
   {
@@ -3500,10 +8045,44 @@ In addition, there is the \`none\` algorithm to be concerned about.  In versions
     "mitigation": "Update the affected package lodash to the fixed version: 4.17.11 or remove the package from the image.",
     "name": "lodash: uncontrolled resource consumption in Data handler causing denial of service",
     "osi_layer": "NOT_APPLICABLE",
-    "reference": {
-      "id": "CVE-2019-1010266",
-      "source": "https://nvd.nist.gov/vuln/detail/CVE-2019-1010266",
-    },
+    "references": [
+      {
+        "type": "CVE",
+        "value": "CVE-2019-1010266",
+      },
+      {
+        "type": "url",
+        "value": "https://nvd.nist.gov/vuln/detail/CVE-2019-1010266",
+      },
+      {
+        "type": "url",
+        "value": "https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2019-1010266",
+      },
+      {
+        "type": "url",
+        "value": "https://github.com/advisories/GHSA-x5rq-j2xg-h7qm",
+      },
+      {
+        "type": "url",
+        "value": "https://github.com/lodash/lodash/issues/3359",
+      },
+      {
+        "type": "url",
+        "value": "https://github.com/lodash/lodash/wiki/Changelog",
+      },
+      {
+        "type": "url",
+        "value": "https://nvd.nist.gov/vuln/detail/CVE-2019-1010266",
+      },
+      {
+        "type": "url",
+        "value": "https://security.netapp.com/advisory/ntap-20190919-0004/",
+      },
+      {
+        "type": "url",
+        "value": "https://snyk.io/vuln/SNYK-JS-LODASH-73639",
+      },
+    ],
     "severity": "MEDIUM",
   },
   {
@@ -3530,10 +8109,48 @@ In addition, there is the \`none\` algorithm to be concerned about.  In versions
     "mitigation": "Update the affected package lodash to the fixed version: 4.17.12 or remove the package from the image.",
     "name": "nodejs-lodash: prototype pollution in defaultsDeep function leading to modifying properties",
     "osi_layer": "NOT_APPLICABLE",
-    "reference": {
-      "id": "CVE-2019-10744",
-      "source": "https://nvd.nist.gov/vuln/detail/CVE-2019-10744",
-    },
+    "references": [
+      {
+        "type": "CVE",
+        "value": "CVE-2019-10744",
+      },
+      {
+        "type": "url",
+        "value": "https://nvd.nist.gov/vuln/detail/CVE-2019-10744",
+      },
+      {
+        "type": "url",
+        "value": "https://access.redhat.com/errata/RHSA-2019:3024",
+      },
+      {
+        "type": "url",
+        "value": "https://github.com/advisories/GHSA-jf85-cpcp-j695",
+      },
+      {
+        "type": "url",
+        "value": "https://nvd.nist.gov/vuln/detail/CVE-2019-10744",
+      },
+      {
+        "type": "url",
+        "value": "https://security.netapp.com/advisory/ntap-20191004-0005/",
+      },
+      {
+        "type": "url",
+        "value": "https://snyk.io/vuln/SNYK-JS-LODASH-450202",
+      },
+      {
+        "type": "url",
+        "value": "https://support.f5.com/csp/article/K47105354?utm_source=f5support&amp;utm_medium=RSS",
+      },
+      {
+        "type": "url",
+        "value": "https://www.oracle.com/security-alerts/cpujan2021.html",
+      },
+      {
+        "type": "url",
+        "value": "https://www.oracle.com/security-alerts/cpuoct2020.html",
+      },
+    ],
     "severity": "HIGH",
   },
   {
@@ -3561,10 +8178,52 @@ In addition, there is the \`none\` algorithm to be concerned about.  In versions
     "mitigation": "Update the affected package lodash to the fixed version: 4.17.19 or remove the package from the image.",
     "name": "nodejs-lodash: prototype pollution in zipObjectDeep function",
     "osi_layer": "NOT_APPLICABLE",
-    "reference": {
-      "id": "CVE-2020-8203",
-      "source": "https://nvd.nist.gov/vuln/detail/CVE-2020-8203",
-    },
+    "references": [
+      {
+        "type": "CVE",
+        "value": "CVE-2020-8203",
+      },
+      {
+        "type": "url",
+        "value": "https://nvd.nist.gov/vuln/detail/CVE-2020-8203",
+      },
+      {
+        "type": "url",
+        "value": "https://github.com/advisories/GHSA-p6mc-m468-83gw",
+      },
+      {
+        "type": "url",
+        "value": "https://github.com/lodash/lodash/issues/4874",
+      },
+      {
+        "type": "url",
+        "value": "https://hackerone.com/reports/712065",
+      },
+      {
+        "type": "url",
+        "value": "https://nvd.nist.gov/vuln/detail/CVE-2020-8203",
+      },
+      {
+        "type": "url",
+        "value": "https://security.netapp.com/advisory/ntap-20200724-0006/",
+      },
+      {
+        "type": "url",
+        "value": "https://www.npmjs.com/advisories/1523",
+      },
+      {
+        "type": "url",
+        "value": "https://www.oracle.com//security-alerts/cpujul2021.html",
+      },
+      {
+        "type": "url",
+        "value": "https://www.oracle.com/security-alerts/cpuApr2021.html",
+      },
+      {
+        "type": "url",
+        "value": "https://www.oracle.com/security-alerts/cpuoct2021.html",
+      },
+    ],
     "severity": "HIGH",
   },
   {
@@ -3596,10 +8255,68 @@ In addition, there is the \`none\` algorithm to be concerned about.  In versions
     "mitigation": "Update the affected package lodash to the fixed version: 4.17.21 or remove the package from the image.",
     "name": "nodejs-lodash: command injection via template",
     "osi_layer": "NOT_APPLICABLE",
-    "reference": {
-      "id": "CVE-2021-23337",
-      "source": "https://nvd.nist.gov/vuln/detail/CVE-2021-23337",
-    },
+    "references": [
+      {
+        "type": "CVE",
+        "value": "CVE-2021-23337",
+      },
+      {
+        "type": "url",
+        "value": "https://nvd.nist.gov/vuln/detail/CVE-2021-23337",
+      },
+      {
+        "type": "url",
+        "value": "https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2021-23337",
+      },
+      {
+        "type": "url",
+        "value": "https://github.com/advisories/GHSA-35jh-r3h4-6jhm",
+      },
+      {
+        "type": "url",
+        "value": "https://github.com/lodash/lodash/blob/ddfd9b11a0126db2302cb70ec9973b66baec0975/lodash.js%23L14851",
+      },
+      {
+        "type": "url",
+        "value": "https://nvd.nist.gov/vuln/detail/CVE-2021-23337",
+      },
+      {
+        "type": "url",
+        "value": "https://security.netapp.com/advisory/ntap-20210312-0006/",
+      },
+      {
+        "type": "url",
+        "value": "https://snyk.io/vuln/SNYK-JAVA-ORGFUJIONWEBJARS-1074932",
+      },
+      {
+        "type": "url",
+        "value": "https://snyk.io/vuln/SNYK-JAVA-ORGWEBJARS-1074930",
+      },
+      {
+        "type": "url",
+        "value": "https://snyk.io/vuln/SNYK-JAVA-ORGWEBJARSBOWER-1074928",
+      },
+      {
+        "type": "url",
+        "value": "https://snyk.io/vuln/SNYK-JAVA-ORGWEBJARSBOWERGITHUBLODASH-1074931",
+      },
+      {
+        "type": "url",
+        "value": "https://snyk.io/vuln/SNYK-JAVA-ORGWEBJARSNPM-1074929",
+      },
+      {
+        "type": "url",
+        "value": "https://snyk.io/vuln/SNYK-JS-LODASH-1040724",
+      },
+      {
+        "type": "url",
+        "value": "https://www.oracle.com//security-alerts/cpujul2021.html",
+      },
+      {
+        "type": "url",
+        "value": "https://www.oracle.com/security-alerts/cpuoct2021.html",
+      },
+    ],
     "severity": "HIGH",
   },
   {
@@ -3625,7 +8342,16 @@ No fix is currently available. Consider using an alternative package until a fix
     "mitigation": "Update the affected package marsdb to the fixed version: undefined or remove the package from the image.",
     "name": "Command Injection in marsdb",
     "osi_layer": "NOT_APPLICABLE",
-    "reference": null,
+    "references": [
+      {
+        "type": "url",
+        "value": "https://github.com/advisories/GHSA-5mrr-rgp6-x4gr",
+      },
+      {
+        "type": "url",
+        "value": "https://github.com/bkimminich/juice-shop/issues/1173",
+      },
+    ],
     "severity": "HIGH",
   },
   {
@@ -3649,10 +8375,36 @@ No fix is currently available. Consider using an alternative package until a fix
     "mitigation": "Update the affected package moment to the fixed version: 2.19.3 or remove the package from the image.",
     "name": "nodejs-moment: Regular expression denial of service",
     "osi_layer": "NOT_APPLICABLE",
-    "reference": {
-      "id": "CVE-2017-18214",
-      "source": "https://nvd.nist.gov/vuln/detail/CVE-2017-18214",
-    },
+    "references": [
+      {
+        "type": "CVE",
+        "value": "CVE-2017-18214",
+      },
+      {
+        "type": "url",
+        "value": "https://nvd.nist.gov/vuln/detail/CVE-2017-18214",
+      },
+      {
+        "type": "url",
+        "value": "https://github.com/advisories/GHSA-446m-mv8f-q348",
+      },
+      {
+        "type": "url",
+        "value": "https://github.com/moment/moment/issues/4163",
+      },
+      {
+        "type": "url",
+        "value": "https://nodesecurity.io/advisories/532",
+      },
+      {
+        "type": "url",
+        "value": "https://nvd.nist.gov/vuln/detail/CVE-2017-18214",
+      },
+      {
+        "type": "url",
+        "value": "https://www.tenable.com/security/tns-2019-02",
+      },
+    ],
     "severity": "HIGH",
   },
   {
@@ -3683,10 +8435,64 @@ No fix is currently available. Consider using an alternative package until a fix
     "mitigation": "Update the affected package moment to the fixed version: 2.11.2 or remove the package from the image.",
     "name": "moment.js: regular expression denial of service",
     "osi_layer": "NOT_APPLICABLE",
-    "reference": {
-      "id": "CVE-2016-4055",
-      "source": "https://nvd.nist.gov/vuln/detail/CVE-2016-4055",
-    },
+    "references": [
+      {
+        "type": "CVE",
+        "value": "CVE-2016-4055",
+      },
+      {
+        "type": "url",
+        "value": "https://nvd.nist.gov/vuln/detail/CVE-2016-4055",
+      },
+      {
+        "type": "url",
+        "value": "http://www.openwall.com/lists/oss-security/2016/04/20/11",
+      },
+      {
+        "type": "url",
+        "value": "http://www.oracle.com/technetwork/security-advisory/cpujul2018-4258247.html",
+      },
+      {
+        "type": "url",
+        "value": "http://www.securityfocus.com/bid/95849",
+      },
+      {
+        "type": "url",
+        "value": "https://github.com/advisories/GHSA-87vv-r9j6-g5qv",
+      },
+      {
+        "type": "url",
+        "value": "https://lists.apache.org/thread.html/10f0f3aefd51444d1198c65f44ffdf2d78ca3359423dbc1c168c9731@%3Cdev.flink.apache.org%3E",
+      },
+      {
+        "type": "url",
+        "value": "https://lists.apache.org/thread.html/17ff53f7999e74fbe3cc0ceb4e1c3b00b180b7c5afec8e978837bc49@%3Cuser.flink.apache.org%3E",
+      },
+      {
+        "type": "url",
+        "value": "https://lists.apache.org/thread.html/52bafac05ad174000ea465fe275fd3cc7bd5c25535a7631c0bc9bfb2@%3Cuser.flink.apache.org%3E",
+      },
+      {
+        "type": "url",
+        "value": "https://lists.apache.org/thread.html/54df3aeb4239b64b50b356f0ca6f986e3c4ca5b84c515dce077c7854@%3Cuser.flink.apache.org%3E",
+      },
+      {
+        "type": "url",
+        "value": "https://nodesecurity.io/advisories/55",
+      },
+      {
+        "type": "url",
+        "value": "https://nvd.nist.gov/vuln/detail/CVE-2016-4055",
+      },
+      {
+        "type": "url",
+        "value": "https://www.owasp.org/index.php/Regular_expression_Denial_of_Service_-_ReDoS",
+      },
+      {
+        "type": "url",
+        "value": "https://www.tenable.com/security/tns-2019-02",
+      },
+    ],
     "severity": "MEDIUM",
   },
   {
@@ -3710,10 +8516,36 @@ No fix is currently available. Consider using an alternative package until a fix
     "mitigation": "Update the affected package sanitize-html to the fixed version: 1.4.3 or remove the package from the image.",
     "name": "XSS - Sanitization not applied recursively",
     "osi_layer": "NOT_APPLICABLE",
-    "reference": {
-      "id": "CVE-2016-1000237",
-      "source": "https://nvd.nist.gov/vuln/detail/CVE-2016-1000237",
-    },
+    "references": [
+      {
+        "type": "CVE",
+        "value": "CVE-2016-1000237",
+      },
+      {
+        "type": "url",
+        "value": "https://nvd.nist.gov/vuln/detail/CVE-2016-1000237",
+      },
+      {
+        "type": "url",
+        "value": "https://github.com/advisories/GHSA-3j7m-hmh3-9jmp",
+      },
+      {
+        "type": "url",
+        "value": "https://github.com/punkave/sanitize-html/issues/29",
+      },
+      {
+        "type": "url",
+        "value": "https://nodesecurity.io/advisories/135",
+      },
+      {
+        "type": "url",
+        "value": "https://nvd.nist.gov/vuln/detail/CVE-2016-1000237",
+      },
+      {
+        "type": "url",
+        "value": "https://raw.githubusercontent.com/distributedweaknessfiling/cvelist/master/2016/1000xxx/CVE-2016-1000237.json",
+      },
+    ],
     "severity": "MEDIUM",
   },
   {
@@ -3737,10 +8569,36 @@ No fix is currently available. Consider using an alternative package until a fix
     "mitigation": "Update the affected package sanitize-html to the fixed version: 1.11.4 or remove the package from the image.",
     "name": "Cross-Site Scripting in sanitize-html",
     "osi_layer": "NOT_APPLICABLE",
-    "reference": {
-      "id": "CVE-2017-16016",
-      "source": "https://nvd.nist.gov/vuln/detail/CVE-2017-16016",
-    },
+    "references": [
+      {
+        "type": "CVE",
+        "value": "CVE-2017-16016",
+      },
+      {
+        "type": "url",
+        "value": "https://nvd.nist.gov/vuln/detail/CVE-2017-16016",
+      },
+      {
+        "type": "url",
+        "value": "https://github.com/advisories/GHSA-xc6g-ggrc-qq4r",
+      },
+      {
+        "type": "url",
+        "value": "https://github.com/punkave/sanitize-html/commit/5d205a1005ba0df80e21d8c64a15bb3accdb2403",
+      },
+      {
+        "type": "url",
+        "value": "https://github.com/punkave/sanitize-html/issues/100",
+      },
+      {
+        "type": "url",
+        "value": "https://nodesecurity.io/advisories/154",
+      },
+      {
+        "type": "url",
+        "value": "https://nvd.nist.gov/vuln/detail/CVE-2017-16016",
+      },
+    ],
     "severity": "MEDIUM",
   },
   {
@@ -3764,10 +8622,36 @@ No fix is currently available. Consider using an alternative package until a fix
     "mitigation": "Update the affected package sanitize-html to the fixed version: 2.3.1 or remove the package from the image.",
     "name": "sanitize-html: improper handling of internationalized domain name (IDN) can lead to bypass hostname whitelist validation",
     "osi_layer": "NOT_APPLICABLE",
-    "reference": {
-      "id": "CVE-2021-26539",
-      "source": "https://nvd.nist.gov/vuln/detail/CVE-2021-26539",
-    },
+    "references": [
+      {
+        "type": "CVE",
+        "value": "CVE-2021-26539",
+      },
+      {
+        "type": "url",
+        "value": "https://nvd.nist.gov/vuln/detail/CVE-2021-26539",
+      },
+      {
+        "type": "url",
+        "value": "https://advisory.checkmarx.net/advisory/CX-2021-4308",
+      },
+      {
+        "type": "url",
+        "value": "https://github.com/advisories/GHSA-rjqq-98f6-6j3r",
+      },
+      {
+        "type": "url",
+        "value": "https://github.com/apostrophecms/sanitize-html/blob/main/CHANGELOG.md#231-2021-01-22",
+      },
+      {
+        "type": "url",
+        "value": "https://github.com/apostrophecms/sanitize-html/pull/458",
+      },
+      {
+        "type": "url",
+        "value": "https://nvd.nist.gov/vuln/detail/CVE-2021-26539",
+      },
+    ],
     "severity": "MEDIUM",
   },
   {
@@ -3791,10 +8675,36 @@ No fix is currently available. Consider using an alternative package until a fix
     "mitigation": "Update the affected package sanitize-html to the fixed version: 2.3.2 or remove the package from the image.",
     "name": "sanitize-html: improper validation of hostnames set by the "allowedIframeHostnames" option can lead to bypass hostname whitelist for iframe element",
     "osi_layer": "NOT_APPLICABLE",
-    "reference": {
-      "id": "CVE-2021-26540",
-      "source": "https://nvd.nist.gov/vuln/detail/CVE-2021-26540",
-    },
+    "references": [
+      {
+        "type": "CVE",
+        "value": "CVE-2021-26540",
+      },
+      {
+        "type": "url",
+        "value": "https://nvd.nist.gov/vuln/detail/CVE-2021-26540",
+      },
+      {
+        "type": "url",
+        "value": "https://advisory.checkmarx.net/advisory/CX-2021-4309",
+      },
+      {
+        "type": "url",
+        "value": "https://github.com/advisories/GHSA-mjxr-4v3x-q3m4",
+      },
+      {
+        "type": "url",
+        "value": "https://github.com/apostrophecms/sanitize-html/blob/main/CHANGELOG.md#232-2021-01-26",
+      },
+      {
+        "type": "url",
+        "value": "https://github.com/apostrophecms/sanitize-html/pull/460",
+      },
+      {
+        "type": "url",
+        "value": "https://nvd.nist.gov/vuln/detail/CVE-2021-26540",
+      },
+    ],
     "severity": "MEDIUM",
   },
   {
@@ -3833,10 +8743,24 @@ console.log(clean);
     "mitigation": "Update the affected package sanitize-html to the fixed version: >=1.11.4 or remove the package from the image.",
     "name": "Cross Site Scripting",
     "osi_layer": "NOT_APPLICABLE",
-    "reference": {
-      "id": "NSWG-ECO-154",
-      "source": "https://github.com/nodejs/security-wg/tree/master/vuln",
-    },
+    "references": [
+      {
+        "type": "NSWG",
+        "value": "NSWG-ECO-154",
+      },
+      {
+        "type": "url",
+        "value": "https://github.com/nodejs/security-wg/tree/master/vuln",
+      },
+      {
+        "type": "url",
+        "value": "https://github.com/punkave/sanitize-html/commit/5d205a1005ba0df80e21d8c64a15bb3accdb2403",
+      },
+      {
+        "type": "url",
+        "value": "https://github.com/punkave/sanitize-html/issues/100",
+      },
+    ],
     "severity": "MEDIUM",
   },
   {
@@ -3862,10 +8786,44 @@ console.log(clean);
     "mitigation": "Update the affected package set-value to the fixed version: 4.0.1 or remove the package from the image.",
     "name": "nodejs-set-value: type confusion allows bypass of CVE-2019-10747",
     "osi_layer": "NOT_APPLICABLE",
-    "reference": {
-      "id": "CVE-2021-23440",
-      "source": "https://nvd.nist.gov/vuln/detail/CVE-2021-23440",
-    },
+    "references": [
+      {
+        "type": "CVE",
+        "value": "CVE-2021-23440",
+      },
+      {
+        "type": "url",
+        "value": "https://nvd.nist.gov/vuln/detail/CVE-2021-23440",
+      },
+      {
+        "type": "url",
+        "value": "https://github.com/advisories/GHSA-4jqc-8m5r-9rpr",
+      },
+      {
+        "type": "url",
+        "value": "https://github.com/jonschlinkert/set-value/commit/7cf8073bb06bf0c15e08475f9f952823b4576452",
+      },
+      {
+        "type": "url",
+        "value": "https://github.com/jonschlinkert/set-value/pull/33",
+      },
+      {
+        "type": "url",
+        "value": "https://nvd.nist.gov/vuln/detail/CVE-2021-23440",
+      },
+      {
+        "type": "url",
+        "value": "https://snyk.io/vuln/SNYK-JAVA-ORGWEBJARSNPM-1584212",
+      },
+      {
+        "type": "url",
+        "value": "https://snyk.io/vuln/SNYK-JS-SETVALUE-1540541",
+      },
+      {
+        "type": "url",
+        "value": "https://www.huntr.dev/bounties/2eae1159-01de-4f82-a177-7478a408c4a2/",
+      },
+    ],
     "severity": "HIGH",
   },
   {
@@ -3893,10 +8851,52 @@ console.log(clean);
     "mitigation": "Update the affected package tar to the fixed version: 6.1.2, 5.0.7, 4.4.15, 3.2.3 or remove the package from the image.",
     "name": "nodejs-tar: Insufficient symlink protection allowing arbitrary file creation and overwrite",
     "osi_layer": "NOT_APPLICABLE",
-    "reference": {
-      "id": "CVE-2021-32803",
-      "source": "https://nvd.nist.gov/vuln/detail/CVE-2021-32803",
-    },
+    "references": [
+      {
+        "type": "CVE",
+        "value": "CVE-2021-32803",
+      },
+      {
+        "type": "url",
+        "value": "https://nvd.nist.gov/vuln/detail/CVE-2021-32803",
+      },
+      {
+        "type": "url",
+        "value": "https://github.com/advisories/GHSA-r628-mhmh-qjhw",
+      },
+      {
+        "type": "url",
+        "value": "https://github.com/npm/node-tar/commit/9dbdeb6df8e9dbd96fa9e84341b9d74734be6c20",
+      },
+      {
+        "type": "url",
+        "value": "https://github.com/npm/node-tar/security/advisories/GHSA-r628-mhmh-qjhw",
+      },
+      {
+        "type": "url",
+        "value": "https://linux.oracle.com/cve/CVE-2021-32803.html",
+      },
+      {
+        "type": "url",
+        "value": "https://linux.oracle.com/errata/ELSA-2021-3666.html",
+      },
+      {
+        "type": "url",
+        "value": "https://nvd.nist.gov/vuln/detail/CVE-2021-32803",
+      },
+      {
+        "type": "url",
+        "value": "https://www.npmjs.com/advisories/1771",
+      },
+      {
+        "type": "url",
+        "value": "https://www.npmjs.com/package/tar",
+      },
+      {
+        "type": "url",
+        "value": "https://www.oracle.com/security-alerts/cpuoct2021.html",
+      },
+    ],
     "severity": "HIGH",
   },
   {
@@ -3924,10 +8924,52 @@ console.log(clean);
     "mitigation": "Update the affected package tar to the fixed version: 6.1.1, 5.0.6, 4.4.14, 3.2.2 or remove the package from the image.",
     "name": "nodejs-tar: Insufficient absolute path sanitization allowing arbitrary file creation and overwrite",
     "osi_layer": "NOT_APPLICABLE",
-    "reference": {
-      "id": "CVE-2021-32804",
-      "source": "https://nvd.nist.gov/vuln/detail/CVE-2021-32804",
-    },
+    "references": [
+      {
+        "type": "CVE",
+        "value": "CVE-2021-32804",
+      },
+      {
+        "type": "url",
+        "value": "https://nvd.nist.gov/vuln/detail/CVE-2021-32804",
+      },
+      {
+        "type": "url",
+        "value": "https://github.com/advisories/GHSA-3jfq-g458-7qm9",
+      },
+      {
+        "type": "url",
+        "value": "https://github.com/npm/node-tar/commit/1f036ca23f64a547bdd6c79c1a44bc62e8115da4",
+      },
+      {
+        "type": "url",
+        "value": "https://github.com/npm/node-tar/security/advisories/GHSA-3jfq-g458-7qm9",
+      },
+      {
+        "type": "url",
+        "value": "https://linux.oracle.com/cve/CVE-2021-32804.html",
+      },
+      {
+        "type": "url",
+        "value": "https://linux.oracle.com/errata/ELSA-2021-3666.html",
+      },
+      {
+        "type": "url",
+        "value": "https://nvd.nist.gov/vuln/detail/CVE-2021-32804",
+      },
+      {
+        "type": "url",
+        "value": "https://www.npmjs.com/advisories/1770",
+      },
+      {
+        "type": "url",
+        "value": "https://www.npmjs.com/package/tar",
+      },
+      {
+        "type": "url",
+        "value": "https://www.oracle.com/security-alerts/cpuoct2021.html",
+      },
+    ],
     "severity": "HIGH",
   },
   {
@@ -3952,10 +8994,40 @@ console.log(clean);
     "mitigation": "Update the affected package tar to the fixed version: 6.1.7, 5.0.8, 4.4.16 or remove the package from the image.",
     "name": "nodejs-tar: insufficient symlink protection due to directory cache poisoning using symbolic links allowing arbitrary file creation and overwrite",
     "osi_layer": "NOT_APPLICABLE",
-    "reference": {
-      "id": "CVE-2021-37701",
-      "source": "https://nvd.nist.gov/vuln/detail/CVE-2021-37701",
-    },
+    "references": [
+      {
+        "type": "CVE",
+        "value": "CVE-2021-37701",
+      },
+      {
+        "type": "url",
+        "value": "https://nvd.nist.gov/vuln/detail/CVE-2021-37701",
+      },
+      {
+        "type": "url",
+        "value": "https://github.com/advisories/GHSA-9r2w-394v-53qc",
+      },
+      {
+        "type": "url",
+        "value": "https://github.com/npm/node-tar/security/advisories/GHSA-9r2w-394v-53qc",
+      },
+      {
+        "type": "url",
+        "value": "https://nvd.nist.gov/vuln/detail/CVE-2021-37701",
+      },
+      {
+        "type": "url",
+        "value": "https://www.npmjs.com/advisories/1779",
+      },
+      {
+        "type": "url",
+        "value": "https://www.npmjs.com/package/tar",
+      },
+      {
+        "type": "url",
+        "value": "https://www.oracle.com/security-alerts/cpuoct2021.html",
+      },
+    ],
     "severity": "HIGH",
   },
   {
@@ -3980,10 +9052,40 @@ console.log(clean);
     "mitigation": "Update the affected package tar to the fixed version: 6.1.9, 5.0.10, 4.4.18 or remove the package from the image.",
     "name": "nodejs-tar: insufficient symlink protection due to directory cache poisoning using symbolic links allowing arbitrary file creation and overwrite",
     "osi_layer": "NOT_APPLICABLE",
-    "reference": {
-      "id": "CVE-2021-37712",
-      "source": "https://nvd.nist.gov/vuln/detail/CVE-2021-37712",
-    },
+    "references": [
+      {
+        "type": "CVE",
+        "value": "CVE-2021-37712",
+      },
+      {
+        "type": "url",
+        "value": "https://nvd.nist.gov/vuln/detail/CVE-2021-37712",
+      },
+      {
+        "type": "url",
+        "value": "https://github.com/advisories/GHSA-qq89-hq3f-393p",
+      },
+      {
+        "type": "url",
+        "value": "https://github.com/npm/node-tar/security/advisories/GHSA-qq89-hq3f-393p",
+      },
+      {
+        "type": "url",
+        "value": "https://nvd.nist.gov/vuln/detail/CVE-2021-37712",
+      },
+      {
+        "type": "url",
+        "value": "https://www.npmjs.com/advisories/1780",
+      },
+      {
+        "type": "url",
+        "value": "https://www.npmjs.com/package/tar",
+      },
+      {
+        "type": "url",
+        "value": "https://www.oracle.com/security-alerts/cpuoct2021.html",
+      },
+    ],
     "severity": "HIGH",
   },
   {
@@ -4007,10 +9109,36 @@ console.log(clean);
     "mitigation": "Update the affected package tar to the fixed version: 6.1.9, 5.0.10, 4.4.18 or remove the package from the image.",
     "name": "Arbitrary File Creation/Overwrite on Windows via insufficient relative path sanitization",
     "osi_layer": "NOT_APPLICABLE",
-    "reference": {
-      "id": "CVE-2021-37713",
-      "source": "https://nvd.nist.gov/vuln/detail/CVE-2021-37713",
-    },
+    "references": [
+      {
+        "type": "CVE",
+        "value": "CVE-2021-37713",
+      },
+      {
+        "type": "url",
+        "value": "https://nvd.nist.gov/vuln/detail/CVE-2021-37713",
+      },
+      {
+        "type": "url",
+        "value": "https://github.com/advisories/GHSA-5955-9wpr-37jh",
+      },
+      {
+        "type": "url",
+        "value": "https://github.com/npm/node-tar/security/advisories/GHSA-5955-9wpr-37jh",
+      },
+      {
+        "type": "url",
+        "value": "https://nvd.nist.gov/vuln/detail/CVE-2021-37713",
+      },
+      {
+        "type": "url",
+        "value": "https://www.npmjs.com/package/tar",
+      },
+      {
+        "type": "url",
+        "value": "https://www.oracle.com/security-alerts/cpuoct2021.html",
+      },
+    ],
     "severity": "HIGH",
   },
   {
@@ -4033,10 +9161,32 @@ console.log(clean);
     "mitigation": "Update the affected package validator to the fixed version: 13.7.0 or remove the package from the image.",
     "name": "Inefficient Regular Expression Complexity in validator.js",
     "osi_layer": "NOT_APPLICABLE",
-    "reference": {
-      "id": "CVE-2021-3765",
-      "source": "https://nvd.nist.gov/vuln/detail/CVE-2021-3765",
-    },
+    "references": [
+      {
+        "type": "CVE",
+        "value": "CVE-2021-3765",
+      },
+      {
+        "type": "url",
+        "value": "https://nvd.nist.gov/vuln/detail/CVE-2021-3765",
+      },
+      {
+        "type": "url",
+        "value": "https://github.com/advisories/GHSA-qgmg-gppg-76g5",
+      },
+      {
+        "type": "url",
+        "value": "https://github.com/validatorjs/validator.js/commit/496fc8b2a7f5997acaaec33cc44d0b8dba5fb5e1",
+      },
+      {
+        "type": "url",
+        "value": "https://huntr.dev/bounties/c37e975c-21a3-4c5f-9b57-04d63b28cfc9",
+      },
+      {
+        "type": "url",
+        "value": "https://nvd.nist.gov/vuln/detail/CVE-2021-3765",
+      },
+    ],
     "severity": "MEDIUM",
   },
   {
@@ -4062,10 +9212,44 @@ console.log(clean);
     "mitigation": "Update the affected package vm2 to the fixed version: 3.9.4 or remove the package from the image.",
     "name": "Prototype Pollution in vm2",
     "osi_layer": "NOT_APPLICABLE",
-    "reference": {
-      "id": "CVE-2021-23449",
-      "source": "https://nvd.nist.gov/vuln/detail/CVE-2021-23449",
-    },
+    "references": [
+      {
+        "type": "CVE",
+        "value": "CVE-2021-23449",
+      },
+      {
+        "type": "url",
+        "value": "https://nvd.nist.gov/vuln/detail/CVE-2021-23449",
+      },
+      {
+        "type": "url",
+        "value": "https://github.com/advisories/GHSA-rjf2-j2r6-q8gr",
+      },
+      {
+        "type": "url",
+        "value": "https://github.com/patriksimek/vm2/commit/b4f6e2bd2c4a1ef52fc4483d8e35f28bc4481886",
+      },
+      {
+        "type": "url",
+        "value": "https://github.com/patriksimek/vm2/issues/363",
+      },
+      {
+        "type": "url",
+        "value": "https://github.com/patriksimek/vm2/releases/tag/3.9.4",
+      },
+      {
+        "type": "url",
+        "value": "https://nvd.nist.gov/vuln/detail/CVE-2021-23449",
+      },
+      {
+        "type": "url",
+        "value": "https://security.netapp.com/advisory/ntap-20211029-0010/",
+      },
+      {
+        "type": "url",
+        "value": "https://snyk.io/vuln/SNYK-JS-VM2-1585918",
+      },
+    ],
     "severity": "HIGH",
   },
 ]
@@ -4092,10 +9276,28 @@ exports[`parses securecodebox:master result file into findings 1`] = `
     "mitigation": "Update the affected package github.com/dgrijalva/jwt-go to the fixed version: undefined or remove the package from the image.",
     "name": "jwt-go: access restriction bypass vulnerability",
     "osi_layer": "NOT_APPLICABLE",
-    "reference": {
-      "id": "CVE-2020-26160",
-      "source": "https://nvd.nist.gov/vuln/detail/CVE-2020-26160",
-    },
+    "references": [
+      {
+        "type": "CVE",
+        "value": "CVE-2020-26160",
+      },
+      {
+        "type": "url",
+        "value": "https://nvd.nist.gov/vuln/detail/CVE-2020-26160",
+      },
+      {
+        "type": "url",
+        "value": "https://github.com/dgrijalva/jwt-go/pull/426",
+      },
+      {
+        "type": "url",
+        "value": "https://nvd.nist.gov/vuln/detail/CVE-2020-26160",
+      },
+      {
+        "type": "url",
+        "value": "https://snyk.io/vuln/SNYK-GOLANG-GITHUBCOMDGRIJALVAJWTGO-596515",
+      },
+    ],
     "severity": "HIGH",
   },
   {
@@ -4123,10 +9325,52 @@ exports[`parses securecodebox:master result file into findings 1`] = `
     "mitigation": "Update the affected package github.com/gogo/protobuf to the fixed version: v1.3.2 or remove the package from the image.",
     "name": "gogo/protobuf: plugin/unmarshal/unmarshal.go lacks certain index validation",
     "osi_layer": "NOT_APPLICABLE",
-    "reference": {
-      "id": "CVE-2021-3121",
-      "source": "https://nvd.nist.gov/vuln/detail/CVE-2021-3121",
-    },
+    "references": [
+      {
+        "type": "CVE",
+        "value": "CVE-2021-3121",
+      },
+      {
+        "type": "url",
+        "value": "https://nvd.nist.gov/vuln/detail/CVE-2021-3121",
+      },
+      {
+        "type": "url",
+        "value": "https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2021-3121",
+      },
+      {
+        "type": "url",
+        "value": "https://discuss.hashicorp.com/t/hcsec-2021-23-consul-exposed-to-denial-of-service-in-gogo-protobuf-dependency/29025",
+      },
+      {
+        "type": "url",
+        "value": "https://github.com/gogo/protobuf/commit/b03c65ea87cdc3521ede29f62fe3ce239267c1bc",
+      },
+      {
+        "type": "url",
+        "value": "https://github.com/gogo/protobuf/compare/v1.3.1...v1.3.2",
+      },
+      {
+        "type": "url",
+        "value": "https://lists.apache.org/thread.html/r68032132c0399c29d6cdc7bd44918535da54060a10a12b1591328bff@%3Cnotifications.skywalking.apache.org%3E",
+      },
+      {
+        "type": "url",
+        "value": "https://lists.apache.org/thread.html/r88d69555cb74a129a7bf84838073b61259b4a3830190e05a3b87994e@%3Ccommits.pulsar.apache.org%3E",
+      },
+      {
+        "type": "url",
+        "value": "https://lists.apache.org/thread.html/rc1e9ff22c5641d73701ba56362fb867d40ed287cca000b131dcf4a44@%3Ccommits.pulsar.apache.org%3E",
+      },
+      {
+        "type": "url",
+        "value": "https://nvd.nist.gov/vuln/detail/CVE-2021-3121",
+      },
+      {
+        "type": "url",
+        "value": "https://security.netapp.com/advisory/ntap-20210219-0006/",
+      },
+    ],
     "severity": "HIGH",
   },
   {
@@ -4150,10 +9394,36 @@ exports[`parses securecodebox:master result file into findings 1`] = `
     "mitigation": "Update the affected package github.com/miekg/dns to the fixed version: v1.1.25-0.20191211073109-8ebf2e419df7 or remove the package from the image.",
     "name": "golang-github-miekg-dns: predictable TXID can lead to response forgeries",
     "osi_layer": "NOT_APPLICABLE",
-    "reference": {
-      "id": "CVE-2019-19794",
-      "source": "https://nvd.nist.gov/vuln/detail/CVE-2019-19794",
-    },
+    "references": [
+      {
+        "type": "CVE",
+        "value": "CVE-2019-19794",
+      },
+      {
+        "type": "url",
+        "value": "https://nvd.nist.gov/vuln/detail/CVE-2019-19794",
+      },
+      {
+        "type": "url",
+        "value": "https://github.com/coredns/coredns/issues/3519",
+      },
+      {
+        "type": "url",
+        "value": "https://github.com/coredns/coredns/issues/3547",
+      },
+      {
+        "type": "url",
+        "value": "https://github.com/miekg/dns/compare/v1.1.24...v1.1.25",
+      },
+      {
+        "type": "url",
+        "value": "https://github.com/miekg/dns/issues/1043",
+      },
+      {
+        "type": "url",
+        "value": "https://github.com/miekg/dns/pull/1044",
+      },
+    ],
     "severity": "MEDIUM",
   },
   {
@@ -4177,10 +9447,36 @@ exports[`parses securecodebox:master result file into findings 1`] = `
     "mitigation": "Update the affected package golang.org/x/crypto to the fixed version: v0.0.0-20201216223049-8b5274cf687f or remove the package from the image.",
     "name": "golang: crypto/ssh: crafted authentication request can lead to nil pointer dereference",
     "osi_layer": "NOT_APPLICABLE",
-    "reference": {
-      "id": "CVE-2020-29652",
-      "source": "https://nvd.nist.gov/vuln/detail/CVE-2020-29652",
-    },
+    "references": [
+      {
+        "type": "CVE",
+        "value": "CVE-2020-29652",
+      },
+      {
+        "type": "url",
+        "value": "https://nvd.nist.gov/vuln/detail/CVE-2020-29652",
+      },
+      {
+        "type": "url",
+        "value": "https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2020-29652",
+      },
+      {
+        "type": "url",
+        "value": "https://go-review.googlesource.com/c/crypto/+/278852",
+      },
+      {
+        "type": "url",
+        "value": "https://groups.google.com/g/golang-announce/c/ouZIlBimOsE?pli=1",
+      },
+      {
+        "type": "url",
+        "value": "https://lists.apache.org/thread.html/r68032132c0399c29d6cdc7bd44918535da54060a10a12b1591328bff@%3Cnotifications.skywalking.apache.org%3E",
+      },
+      {
+        "type": "url",
+        "value": "https://nvd.nist.gov/vuln/detail/CVE-2020-29652",
+      },
+    ],
     "severity": "HIGH",
   },
   {
@@ -4202,10 +9498,28 @@ exports[`parses securecodebox:master result file into findings 1`] = `
     "mitigation": "Update the affected package github.com/dgrijalva/jwt-go to the fixed version: undefined or remove the package from the image.",
     "name": "jwt-go: access restriction bypass vulnerability",
     "osi_layer": "NOT_APPLICABLE",
-    "reference": {
-      "id": "CVE-2020-26160",
-      "source": "https://nvd.nist.gov/vuln/detail/CVE-2020-26160",
-    },
+    "references": [
+      {
+        "type": "CVE",
+        "value": "CVE-2020-26160",
+      },
+      {
+        "type": "url",
+        "value": "https://nvd.nist.gov/vuln/detail/CVE-2020-26160",
+      },
+      {
+        "type": "url",
+        "value": "https://github.com/dgrijalva/jwt-go/pull/426",
+      },
+      {
+        "type": "url",
+        "value": "https://nvd.nist.gov/vuln/detail/CVE-2020-26160",
+      },
+      {
+        "type": "url",
+        "value": "https://snyk.io/vuln/SNYK-GOLANG-GITHUBCOMDGRIJALVAJWTGO-596515",
+      },
+    ],
     "severity": "HIGH",
   },
   {
@@ -4233,10 +9547,52 @@ exports[`parses securecodebox:master result file into findings 1`] = `
     "mitigation": "Update the affected package github.com/gogo/protobuf to the fixed version: v1.3.2 or remove the package from the image.",
     "name": "gogo/protobuf: plugin/unmarshal/unmarshal.go lacks certain index validation",
     "osi_layer": "NOT_APPLICABLE",
-    "reference": {
-      "id": "CVE-2021-3121",
-      "source": "https://nvd.nist.gov/vuln/detail/CVE-2021-3121",
-    },
+    "references": [
+      {
+        "type": "CVE",
+        "value": "CVE-2021-3121",
+      },
+      {
+        "type": "url",
+        "value": "https://nvd.nist.gov/vuln/detail/CVE-2021-3121",
+      },
+      {
+        "type": "url",
+        "value": "https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2021-3121",
+      },
+      {
+        "type": "url",
+        "value": "https://discuss.hashicorp.com/t/hcsec-2021-23-consul-exposed-to-denial-of-service-in-gogo-protobuf-dependency/29025",
+      },
+      {
+        "type": "url",
+        "value": "https://github.com/gogo/protobuf/commit/b03c65ea87cdc3521ede29f62fe3ce239267c1bc",
+      },
+      {
+        "type": "url",
+        "value": "https://github.com/gogo/protobuf/compare/v1.3.1...v1.3.2",
+      },
+      {
+        "type": "url",
+        "value": "https://lists.apache.org/thread.html/r68032132c0399c29d6cdc7bd44918535da54060a10a12b1591328bff@%3Cnotifications.skywalking.apache.org%3E",
+      },
+      {
+        "type": "url",
+        "value": "https://lists.apache.org/thread.html/r88d69555cb74a129a7bf84838073b61259b4a3830190e05a3b87994e@%3Ccommits.pulsar.apache.org%3E",
+      },
+      {
+        "type": "url",
+        "value": "https://lists.apache.org/thread.html/rc1e9ff22c5641d73701ba56362fb867d40ed287cca000b131dcf4a44@%3Ccommits.pulsar.apache.org%3E",
+      },
+      {
+        "type": "url",
+        "value": "https://nvd.nist.gov/vuln/detail/CVE-2021-3121",
+      },
+      {
+        "type": "url",
+        "value": "https://security.netapp.com/advisory/ntap-20210219-0006/",
+      },
+    ],
     "severity": "HIGH",
   },
   {
@@ -4260,10 +9616,36 @@ exports[`parses securecodebox:master result file into findings 1`] = `
     "mitigation": "Update the affected package golang.org/x/crypto to the fixed version: v0.0.0-20201216223049-8b5274cf687f or remove the package from the image.",
     "name": "golang: crypto/ssh: crafted authentication request can lead to nil pointer dereference",
     "osi_layer": "NOT_APPLICABLE",
-    "reference": {
-      "id": "CVE-2020-29652",
-      "source": "https://nvd.nist.gov/vuln/detail/CVE-2020-29652",
-    },
+    "references": [
+      {
+        "type": "CVE",
+        "value": "CVE-2020-29652",
+      },
+      {
+        "type": "url",
+        "value": "https://nvd.nist.gov/vuln/detail/CVE-2020-29652",
+      },
+      {
+        "type": "url",
+        "value": "https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2020-29652",
+      },
+      {
+        "type": "url",
+        "value": "https://go-review.googlesource.com/c/crypto/+/278852",
+      },
+      {
+        "type": "url",
+        "value": "https://groups.google.com/g/golang-announce/c/ouZIlBimOsE?pli=1",
+      },
+      {
+        "type": "url",
+        "value": "https://lists.apache.org/thread.html/r68032132c0399c29d6cdc7bd44918535da54060a10a12b1591328bff@%3Cnotifications.skywalking.apache.org%3E",
+      },
+      {
+        "type": "url",
+        "value": "https://nvd.nist.gov/vuln/detail/CVE-2020-29652",
+      },
+    ],
     "severity": "HIGH",
   },
   {
@@ -4289,10 +9671,44 @@ exports[`parses securecodebox:master result file into findings 1`] = `
     "mitigation": "Update the affected package golang.org/x/crypto to the fixed version: v0.0.0-20200220183623-bac4c82f6975 or remove the package from the image.",
     "name": "golang.org/x/crypto: Processing of crafted ssh-ed25519 public keys allows for panic",
     "osi_layer": "NOT_APPLICABLE",
-    "reference": {
-      "id": "CVE-2020-9283",
-      "source": "https://nvd.nist.gov/vuln/detail/CVE-2020-9283",
-    },
+    "references": [
+      {
+        "type": "CVE",
+        "value": "CVE-2020-9283",
+      },
+      {
+        "type": "url",
+        "value": "https://nvd.nist.gov/vuln/detail/CVE-2020-9283",
+      },
+      {
+        "type": "url",
+        "value": "http://packetstormsecurity.com/files/156480/Go-SSH-0.0.2-Denial-Of-Service.html",
+      },
+      {
+        "type": "url",
+        "value": "https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2020-9283",
+      },
+      {
+        "type": "url",
+        "value": "https://groups.google.com/forum/#!topic/golang-announce/3L45YRc91SY",
+      },
+      {
+        "type": "url",
+        "value": "https://lists.debian.org/debian-lts-announce/2020/10/msg00014.html",
+      },
+      {
+        "type": "url",
+        "value": "https://lists.debian.org/debian-lts-announce/2020/11/msg00027.html",
+      },
+      {
+        "type": "url",
+        "value": "https://lists.debian.org/debian-lts-announce/2020/11/msg00031.html",
+      },
+      {
+        "type": "url",
+        "value": "https://nvd.nist.gov/vuln/detail/CVE-2020-9283",
+      },
+    ],
     "severity": "HIGH",
   },
   {
@@ -4317,10 +9733,40 @@ exports[`parses securecodebox:master result file into findings 1`] = `
     "mitigation": "Update the affected package gopkg.in/yaml.v2 to the fixed version: v2.2.8 or remove the package from the image.",
     "name": "kubernetes: Denial of service in API server via crafted YAML payloads by authorized users",
     "osi_layer": "NOT_APPLICABLE",
-    "reference": {
-      "id": "CVE-2019-11254",
-      "source": "https://nvd.nist.gov/vuln/detail/CVE-2019-11254",
-    },
+    "references": [
+      {
+        "type": "CVE",
+        "value": "CVE-2019-11254",
+      },
+      {
+        "type": "url",
+        "value": "https://nvd.nist.gov/vuln/detail/CVE-2019-11254",
+      },
+      {
+        "type": "url",
+        "value": "https://github.com/kubernetes/kubernetes/issues/89535",
+      },
+      {
+        "type": "url",
+        "value": "https://groups.google.com/d/msg/kubernetes-announce/ALL9s73E5ck/4yHe8J-PBAAJ",
+      },
+      {
+        "type": "url",
+        "value": "https://groups.google.com/forum/#!topic/kubernetes-security-announce/wuwEwZigXBc",
+      },
+      {
+        "type": "url",
+        "value": "https://linux.oracle.com/cve/CVE-2019-11254.html",
+      },
+      {
+        "type": "url",
+        "value": "https://linux.oracle.com/errata/ELSA-2020-5653.html",
+      },
+      {
+        "type": "url",
+        "value": "https://security.netapp.com/advisory/ntap-20200413-0003/",
+      },
+    ],
     "severity": "MEDIUM",
   },
   {
@@ -4345,10 +9791,40 @@ exports[`parses securecodebox:master result file into findings 1`] = `
     "mitigation": "Update the affected package k8s.io/client-go to the fixed version: v0.17.0 or remove the package from the image.",
     "name": "kubernetes: Bearer tokens written to logs at high verbosity levels (>= 7)",
     "osi_layer": "NOT_APPLICABLE",
-    "reference": {
-      "id": "CVE-2019-11250",
-      "source": "https://nvd.nist.gov/vuln/detail/CVE-2019-11250",
-    },
+    "references": [
+      {
+        "type": "CVE",
+        "value": "CVE-2019-11250",
+      },
+      {
+        "type": "url",
+        "value": "https://nvd.nist.gov/vuln/detail/CVE-2019-11250",
+      },
+      {
+        "type": "url",
+        "value": "http://www.openwall.com/lists/oss-security/2020/10/16/2",
+      },
+      {
+        "type": "url",
+        "value": "https://access.redhat.com/errata/RHSA-2019:4052",
+      },
+      {
+        "type": "url",
+        "value": "https://access.redhat.com/errata/RHSA-2019:4087",
+      },
+      {
+        "type": "url",
+        "value": "https://github.com/kubernetes/kubernetes/issues/81114",
+      },
+      {
+        "type": "url",
+        "value": "https://nvd.nist.gov/vuln/detail/CVE-2019-11250",
+      },
+      {
+        "type": "url",
+        "value": "https://security.netapp.com/advisory/ntap-20190919-0003/",
+      },
+    ],
     "severity": "MEDIUM",
   },
   {
@@ -4371,10 +9847,32 @@ exports[`parses securecodebox:master result file into findings 1`] = `
     "mitigation": "Update the affected package k8s.io/client-go to the fixed version: v0.20.0-alpha.2 or remove the package from the image.",
     "name": "kubernetes: Incomplete fix for CVE-2019-11250 allows for token leak in logs when logLevel >= 9",
     "osi_layer": "NOT_APPLICABLE",
-    "reference": {
-      "id": "CVE-2020-8565",
-      "source": "https://nvd.nist.gov/vuln/detail/CVE-2020-8565",
-    },
+    "references": [
+      {
+        "type": "CVE",
+        "value": "CVE-2020-8565",
+      },
+      {
+        "type": "url",
+        "value": "https://nvd.nist.gov/vuln/detail/CVE-2020-8565",
+      },
+      {
+        "type": "url",
+        "value": "https://github.com/kubernetes/kubernetes/issues/95623",
+      },
+      {
+        "type": "url",
+        "value": "https://groups.google.com/g/kubernetes-announce/c/ScdmyORnPDk",
+      },
+      {
+        "type": "url",
+        "value": "https://groups.google.com/g/kubernetes-security-discuss/c/vm-HcrFUOCs/m/36utxAM5CwAJ",
+      },
+      {
+        "type": "url",
+        "value": "https://nvd.nist.gov/vuln/detail/CVE-2020-8565",
+      },
+    ],
     "severity": "MEDIUM",
   },
   {
@@ -4396,10 +9894,28 @@ exports[`parses securecodebox:master result file into findings 1`] = `
     "mitigation": "Update the affected package github.com/dgrijalva/jwt-go to the fixed version: undefined or remove the package from the image.",
     "name": "jwt-go: access restriction bypass vulnerability",
     "osi_layer": "NOT_APPLICABLE",
-    "reference": {
-      "id": "CVE-2020-26160",
-      "source": "https://nvd.nist.gov/vuln/detail/CVE-2020-26160",
-    },
+    "references": [
+      {
+        "type": "CVE",
+        "value": "CVE-2020-26160",
+      },
+      {
+        "type": "url",
+        "value": "https://nvd.nist.gov/vuln/detail/CVE-2020-26160",
+      },
+      {
+        "type": "url",
+        "value": "https://github.com/dgrijalva/jwt-go/pull/426",
+      },
+      {
+        "type": "url",
+        "value": "https://nvd.nist.gov/vuln/detail/CVE-2020-26160",
+      },
+      {
+        "type": "url",
+        "value": "https://snyk.io/vuln/SNYK-GOLANG-GITHUBCOMDGRIJALVAJWTGO-596515",
+      },
+    ],
     "severity": "HIGH",
   },
   {
@@ -4427,10 +9943,52 @@ exports[`parses securecodebox:master result file into findings 1`] = `
     "mitigation": "Update the affected package github.com/gogo/protobuf to the fixed version: v1.3.2 or remove the package from the image.",
     "name": "gogo/protobuf: plugin/unmarshal/unmarshal.go lacks certain index validation",
     "osi_layer": "NOT_APPLICABLE",
-    "reference": {
-      "id": "CVE-2021-3121",
-      "source": "https://nvd.nist.gov/vuln/detail/CVE-2021-3121",
-    },
+    "references": [
+      {
+        "type": "CVE",
+        "value": "CVE-2021-3121",
+      },
+      {
+        "type": "url",
+        "value": "https://nvd.nist.gov/vuln/detail/CVE-2021-3121",
+      },
+      {
+        "type": "url",
+        "value": "https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2021-3121",
+      },
+      {
+        "type": "url",
+        "value": "https://discuss.hashicorp.com/t/hcsec-2021-23-consul-exposed-to-denial-of-service-in-gogo-protobuf-dependency/29025",
+      },
+      {
+        "type": "url",
+        "value": "https://github.com/gogo/protobuf/commit/b03c65ea87cdc3521ede29f62fe3ce239267c1bc",
+      },
+      {
+        "type": "url",
+        "value": "https://github.com/gogo/protobuf/compare/v1.3.1...v1.3.2",
+      },
+      {
+        "type": "url",
+        "value": "https://lists.apache.org/thread.html/r68032132c0399c29d6cdc7bd44918535da54060a10a12b1591328bff@%3Cnotifications.skywalking.apache.org%3E",
+      },
+      {
+        "type": "url",
+        "value": "https://lists.apache.org/thread.html/r88d69555cb74a129a7bf84838073b61259b4a3830190e05a3b87994e@%3Ccommits.pulsar.apache.org%3E",
+      },
+      {
+        "type": "url",
+        "value": "https://lists.apache.org/thread.html/rc1e9ff22c5641d73701ba56362fb867d40ed287cca000b131dcf4a44@%3Ccommits.pulsar.apache.org%3E",
+      },
+      {
+        "type": "url",
+        "value": "https://nvd.nist.gov/vuln/detail/CVE-2021-3121",
+      },
+      {
+        "type": "url",
+        "value": "https://security.netapp.com/advisory/ntap-20210219-0006/",
+      },
+    ],
     "severity": "HIGH",
   },
   {
@@ -4454,10 +10012,36 @@ exports[`parses securecodebox:master result file into findings 1`] = `
     "mitigation": "Update the affected package github.com/miekg/dns to the fixed version: v1.1.25-0.20191211073109-8ebf2e419df7 or remove the package from the image.",
     "name": "golang-github-miekg-dns: predictable TXID can lead to response forgeries",
     "osi_layer": "NOT_APPLICABLE",
-    "reference": {
-      "id": "CVE-2019-19794",
-      "source": "https://nvd.nist.gov/vuln/detail/CVE-2019-19794",
-    },
+    "references": [
+      {
+        "type": "CVE",
+        "value": "CVE-2019-19794",
+      },
+      {
+        "type": "url",
+        "value": "https://nvd.nist.gov/vuln/detail/CVE-2019-19794",
+      },
+      {
+        "type": "url",
+        "value": "https://github.com/coredns/coredns/issues/3519",
+      },
+      {
+        "type": "url",
+        "value": "https://github.com/coredns/coredns/issues/3547",
+      },
+      {
+        "type": "url",
+        "value": "https://github.com/miekg/dns/compare/v1.1.24...v1.1.25",
+      },
+      {
+        "type": "url",
+        "value": "https://github.com/miekg/dns/issues/1043",
+      },
+      {
+        "type": "url",
+        "value": "https://github.com/miekg/dns/pull/1044",
+      },
+    ],
     "severity": "MEDIUM",
   },
   {
@@ -4481,10 +10065,36 @@ exports[`parses securecodebox:master result file into findings 1`] = `
     "mitigation": "Update the affected package golang.org/x/crypto to the fixed version: v0.0.0-20201216223049-8b5274cf687f or remove the package from the image.",
     "name": "golang: crypto/ssh: crafted authentication request can lead to nil pointer dereference",
     "osi_layer": "NOT_APPLICABLE",
-    "reference": {
-      "id": "CVE-2020-29652",
-      "source": "https://nvd.nist.gov/vuln/detail/CVE-2020-29652",
-    },
+    "references": [
+      {
+        "type": "CVE",
+        "value": "CVE-2020-29652",
+      },
+      {
+        "type": "url",
+        "value": "https://nvd.nist.gov/vuln/detail/CVE-2020-29652",
+      },
+      {
+        "type": "url",
+        "value": "https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2020-29652",
+      },
+      {
+        "type": "url",
+        "value": "https://go-review.googlesource.com/c/crypto/+/278852",
+      },
+      {
+        "type": "url",
+        "value": "https://groups.google.com/g/golang-announce/c/ouZIlBimOsE?pli=1",
+      },
+      {
+        "type": "url",
+        "value": "https://lists.apache.org/thread.html/r68032132c0399c29d6cdc7bd44918535da54060a10a12b1591328bff@%3Cnotifications.skywalking.apache.org%3E",
+      },
+      {
+        "type": "url",
+        "value": "https://nvd.nist.gov/vuln/detail/CVE-2020-29652",
+      },
+    ],
     "severity": "HIGH",
   },
 ]

--- a/scanners/trivy/parser/parser.js
+++ b/scanners/trivy/parser/parser.js
@@ -31,7 +31,7 @@ async function parse(scanResults) {
           "value": vulnerability.VulnerabilityID
         },
         {
-          "type": "url",
+          "type": "URL",
           "value": `https://nvd.nist.gov/vuln/detail/${vulnerability.VulnerabilityID}`
         }
       ];
@@ -42,7 +42,7 @@ async function parse(scanResults) {
           "value": vulnerability.VulnerabilityID
         },
         {
-          "type": "url",
+          "type": "URL",
           "value": `https://github.com/nodejs/security-wg/tree/master/vuln`
         }
       ];
@@ -55,7 +55,7 @@ async function parse(scanResults) {
             references = [];
           }
           references.push({
-            "type": "url",
+            "type": "URL",
             "value": reference
           });
         }

--- a/scanners/wpscan/parser/parser.js
+++ b/scanners/wpscan/parser/parser.js
@@ -17,100 +17,94 @@ async function parse(scanResults) {
   // convert unix timestamp to ISO date string, multiply by 1000 because JS uses milliseconds
   const identified_at = new Date(scanResults.stop_time * 1000).toISOString();
 
-  const findings = [];
+  // Add a general INFORMATIONAL summary finding
+const summaryFinding = {
+  name: "WordPress Service",
+  description: "WordPress Service Information",
+  identified_at: identified_at,
+  category: "WordPress Service",
+  location: targetUrl,
+  osi_layer: "APPLICATION",
+  severity: "INFORMATIONAL",
+  references: null,
+  confidence: scanResults.version?.confidence,
+  attributes: {
+    hostname: targetUrl,
+    ip_address: targetIp,
+    wpscan_version: wpscanVersion,
+    wpscan_requests: wpscanRequestsDone,
+    wp_version: scanResults.version?.number,
+    wp_release_date: scanResults.version?.release_date,
+    wp_release_status: scanResults.version?.status,
+    wp_interesting_entries: scanResults.version?.interesting_entries,
+    wp_found_by: scanResults.version?.found_by,
+    wp_confirmed_by: scanResults.version?.confirmed_by,
+    wp_vulnerabilities: scanResults.version?.vulnerabilities,
+  },
+};
 
-  // add a general INFORMATIONAL summary finding
-  findings.push({
-    name: "WordPress Service",
-    description: "WordPress Service Information",
-    identified_at: identified_at,
-    category: "WordPress Service",
-    location: targetUrl,
+// Add all interesting findings as INFORMATIONAL
+const interestingFindings = scanResults.interesting_findings.map(interestingFinding => {
+  // Create a flattened array of references with their types
+  const references = Object.entries(interestingFinding.references)
+    .flatMap(([key, elements]) =>
+      elements.map(element => ({
+        type: key.toUpperCase(),
+        value: element,
+      }))
+    );
+
+ // Return the interesting findings object for the current entry
+  return {
+    name: `WordPress finding '${interestingFinding.type}'`,
+    description: interestingFinding.to_s,
+    category: `WordPress ${interestingFinding.type}`,
+    location: interestingFinding.url,
     osi_layer: "APPLICATION",
     severity: "INFORMATIONAL",
-    references: null,
-    confidence: scanResults.version?.confidence,
+    confidence: interestingFinding.confidence,
+    references: references.length > 0 ? references : null,
     attributes: {
       hostname: targetUrl,
-      ip_address: targetIp,
-      wpscan_version: wpscanVersion,
-      wpscan_requests: wpscanRequestsDone,
-      wp_version: scanResults.version?.number,
-      wp_release_date: scanResults.version?.release_date,
-      wp_release_status: scanResults.version?.status,
-      wp_interesting_entries: scanResults.version?.interesting_entries,
-      wp_found_by: scanResults.version?.found_by,
-      wp_confirmed_by: scanResults.version?.confirmed_by,
-      wp_vulnerabilities: scanResults.version?.vulnerabilities,
+      wp_interesting_entries: interestingFinding.interesting_entries,
+      wp_found_by: interestingFinding.found_by,
+      wp_confirmed_by: interestingFinding.confirmed_by,
     },
-  });
+  };
+});
 
-  // add all interesting findings as INFORMATIONAL
-  for (const interestingFinding of scanResults.interesting_findings) {
-    let references = [];
-    if (Object.keys(interestingFinding.references).length > 0) {
-      for (const key in interestingFinding.references) {
-        for (const element of interestingFinding.references[key]) {
-          references.push({
-            "type": key.toUpperCase(),
-            "value": element
-          });
-        }
-      }
-    }
-    findings.push({
-      name: "WordPress finding '" + interestingFinding.type + "'",
-      description: interestingFinding.to_s,
-      category: "WordPress " + interestingFinding.type,
-      location: interestingFinding.url,
+// Add plugin vulnerabilities as HIGH
+const pluginVulnerabilities = Object.values(scanResults.plugins).flatMap(plugin =>
+  plugin.vulnerabilities.map(vulnerability => {
+    // Create a flattened array of references with their types
+    const references = Object.entries(vulnerability.references)
+      .flatMap(([key, elements]) =>
+        elements.map(element => ({
+          type: key.toUpperCase(),
+          value: element,
+        }))
+      );
+    // Return the plugin vulnerabilities object for the current plugin and vulnerability
+    return {
+      name: `WordPress finding: vulnerability in '${plugin['slug']}'`,
+      description: vulnerability['title'],
+      category: "WordPress Plugin",
+      location: plugin['location'],
       osi_layer: "APPLICATION",
-      severity: "INFORMATIONAL",
-      confidence: interestingFinding.confidence,
+      severity: "HIGH",
       references: references.length > 0 ? references : null,
       attributes: {
         hostname: targetUrl,
-        wp_interesting_entries: interestingFinding.interesting_entries,
-        wp_found_by: interestingFinding.found_by,
-        wp_confirmed_by: interestingFinding.confirmed_by,
+        confidence: plugin['confidence'],
+        wp_interesting_entries: plugin['interesting_entries'],
+        wp_found_by: plugin['found_by'],
+        wp_confirmed_by: plugin['confirmed_by'],
       },
-    });
-  }
+    };
+  })
+);
 
-  // add plugin vulnerabilities as HIGH
-  Object.values(scanResults.plugins).forEach(plugin => {
-    plugin.vulnerabilities.forEach(vulnerability => {
-      let references = [];
-      // check if references are available
-      if (Object.keys(vulnerability.references).length > 0){
-        for (const key in vulnerability.references) {
-          for (const element of vulnerability.references[key]) {
-            references.push({
-              "type": key.toUpperCase(),
-              "value": element
-            });
-          }
-        }
-      }
-      findings.push({
-        name: "WordPress finding: vulnerability in '" + plugin['slug'] + "'",
-        description: vulnerability['title'],
-        category: "WordPress Plugin",
-        location: plugin['location'],
-        osi_layer: "APPLICATION",
-        severity: "HIGH",
-        references: references.length > 0 ? references : null,
-        attributes: {
-          hostname: targetUrl,
-          confidence: plugin['confidence'],
-          wp_interesting_entries: plugin['interesting_entries'],
-          wp_found_by: plugin['found_by'],
-          wp_confirmed_by: plugin['confirmed_by'],
-        },
-      });
-    })
-  });
-
-  return findings;
+// Combine all findings and return
+return [summaryFinding, ...interestingFindings, ...pluginVulnerabilities];
 }
-
 module.exports.parse = parse;

--- a/scanners/wpscan/parser/parser.test.js
+++ b/scanners/wpscan/parser/parser.test.js
@@ -48,7 +48,7 @@ test("WPScan parser parses a successfully scan result with at least one informat
         "location": "https://www.example.com/",
         "name": "WordPress Service",
         "osi_layer": "APPLICATION",
-        "reference": {},
+        "references": null,
         "severity": "INFORMATIONAL",
       },
       {
@@ -66,7 +66,7 @@ test("WPScan parser parses a successfully scan result with at least one informat
         "location": "https://www.example.com/",
         "name": "WordPress finding 'headers'",
         "osi_layer": "APPLICATION",
-        "reference": {},
+        "references": null,
         "severity": "INFORMATIONAL",
       },
       {
@@ -85,7 +85,7 @@ test("WPScan parser parses a successfully scan result with at least one informat
         "location": "https://www.example.com/robots.txt",
         "name": "WordPress finding 'robots_txt'",
         "osi_layer": "APPLICATION",
-        "reference": {},
+        "references": null,
         "severity": "INFORMATIONAL",
       },
       {
@@ -101,7 +101,7 @@ test("WPScan parser parses a successfully scan result with at least one informat
         "location": "https://www.example.com/readme.html",
         "name": "WordPress finding 'readme'",
         "osi_layer": "APPLICATION",
-        "reference": {},
+        "references": null,
         "severity": "INFORMATIONAL",
       },
       {
@@ -117,7 +117,12 @@ test("WPScan parser parses a successfully scan result with at least one informat
         "location": "https://www.example.com/wp-content/mu-plugins/",
         "name": "WordPress finding 'mu_plugins'",
         "osi_layer": "APPLICATION",
-        "reference": {},
+        "references": [
+          {
+            "type": "URL",
+            "value": "http://codex.wordpress.org/Must_Use_Plugins",
+          },
+        ],
         "severity": "INFORMATIONAL",
       },
       {
@@ -133,8 +138,52 @@ test("WPScan parser parses a successfully scan result with at least one informat
         "location": "https://www.example.com/wp-cron.php",
         "name": "WordPress finding 'wp_cron'",
         "osi_layer": "APPLICATION",
-        "reference": {},
+        "references": [
+          {
+            "type": "URL",
+            "value": "https://www.iplocation.net/defend-wordpress-from-ddos",
+          },
+          {
+            "type": "URL",
+            "value": "https://github.com/wpscanteam/wpscan/issues/1299",
+          },
+        ],
         "severity": "INFORMATIONAL",
+      },
+      {
+        "attributes": {
+          "confidence": 80,
+          "hostname": "https://www.example.com/",
+          "wp_confirmed_by": {},
+          "wp_found_by": "Known Locations (Aggressive Detection)",
+          "wp_interesting_entries": [
+            "https://www.example.com/wp-content/plugins/akismet/, status: 403",
+          ],
+        },
+        "category": "WordPress Plugin",
+        "description": "Akismet 2.5.0-3.1.4 - Unauthenticated Stored Cross-Site Scripting (XSS)",
+        "location": "https://www.example.com/wp-content/plugins/akismet/",
+        "name": "WordPress finding: vulnerability in 'akismet'",
+        "osi_layer": "APPLICATION",
+        "references": [
+          {
+            "type": "CVE",
+            "value": "2015-9357",
+          },
+          {
+            "type": "URL",
+            "value": "http://blog.akismet.com/2015/10/13/akismet-3-1-5-wordpress/",
+          },
+          {
+            "type": "URL",
+            "value": "https://blog.sucuri.net/2015/10/security-advisory-stored-xss-in-akismet-wordpress-plugin.html",
+          },
+          {
+            "type": "WPVULNDB",
+            "value": "8215",
+          },
+        ],
+        "severity": "HIGH",
       },
     ]
   `);
@@ -172,7 +221,7 @@ test("WPScan parser parses a scan result file without a detected wp version corr
         "location": "https://wp.example.com/",
         "name": "WordPress Service",
         "osi_layer": "APPLICATION",
-        "reference": {},
+        "references": null,
         "severity": "INFORMATIONAL",
       },
       {
@@ -191,7 +240,7 @@ test("WPScan parser parses a scan result file without a detected wp version corr
         "location": "https://wp.example.com/",
         "name": "WordPress finding 'headers'",
         "osi_layer": "APPLICATION",
-        "reference": {},
+        "references": null,
         "severity": "INFORMATIONAL",
       },
       {
@@ -210,7 +259,7 @@ test("WPScan parser parses a scan result file without a detected wp version corr
         "location": "https://wp.example.com/robots.txt",
         "name": "WordPress finding 'robots_txt'",
         "osi_layer": "APPLICATION",
-        "reference": {},
+        "references": null,
         "severity": "INFORMATIONAL",
       },
       {
@@ -226,7 +275,7 @@ test("WPScan parser parses a scan result file without a detected wp version corr
         "location": "https://wp.example.com/readme.html",
         "name": "WordPress finding 'readme'",
         "osi_layer": "APPLICATION",
-        "reference": {},
+        "references": null,
         "severity": "INFORMATIONAL",
       },
       {
@@ -242,7 +291,12 @@ test("WPScan parser parses a scan result file without a detected wp version corr
         "location": "https://wp.example.com/wp-content/mu-plugins/",
         "name": "WordPress finding 'mu_plugins'",
         "osi_layer": "APPLICATION",
-        "reference": {},
+        "references": [
+          {
+            "type": "URL",
+            "value": "http://codex.wordpress.org/Must_Use_Plugins",
+          },
+        ],
         "severity": "INFORMATIONAL",
       },
       {
@@ -258,7 +312,16 @@ test("WPScan parser parses a scan result file without a detected wp version corr
         "location": "https://wp.example.com/wp-cron.php",
         "name": "WordPress finding 'wp_cron'",
         "osi_layer": "APPLICATION",
-        "reference": {},
+        "references": [
+          {
+            "type": "URL",
+            "value": "https://www.iplocation.net/defend-wordpress-from-ddos",
+          },
+          {
+            "type": "URL",
+            "value": "https://github.com/wpscanteam/wpscan/issues/1299",
+          },
+        ],
         "severity": "INFORMATIONAL",
       },
     ]

--- a/scanners/zap/parser/__snapshots__/parser.test.js.snap
+++ b/scanners/zap/parser/__snapshots__/parser.test.js.snap
@@ -34,11 +34,12 @@ exports[`Parsing a bodgeit result. 1`] = `
     },
     "category": "Unexpected Content-Type was returned",
     "description": "A Content-Type of text/html was returned by the server.This is not one of the types expected to be returned by an API.Raised by the 'Alert on Unexpected Content Types' script",
-    "hint": undefined,
+    "hint": null,
     "location": "https://cwiki.apache.org",
     "mitigation": null,
     "name": "Unexpected Content-Type was returned",
     "osi_layer": "APPLICATION",
+    "references": null,
     "severity": "LOW",
   },
   {
@@ -66,11 +67,12 @@ exports[`Parsing a bodgeit result. 1`] = `
     },
     "category": "Unexpected Content-Type was returned",
     "description": "A Content-Type of text/html was returned by the server.This is not one of the types expected to be returned by an API.Raised by the 'Alert on Unexpected Content Types' script",
-    "hint": undefined,
+    "hint": null,
     "location": "http://wiki.apache.org",
     "mitigation": null,
     "name": "Unexpected Content-Type was returned",
     "osi_layer": "APPLICATION",
+    "references": null,
     "severity": "LOW",
   },
   {
@@ -98,11 +100,12 @@ exports[`Parsing a bodgeit result. 1`] = `
     },
     "category": "Unexpected Content-Type was returned",
     "description": "A Content-Type of binary/octet-stream was returned by the server.This is not one of the types expected to be returned by an API.Raised by the 'Alert on Unexpected Content Types' script",
-    "hint": undefined,
+    "hint": null,
     "location": "https://content-signature-2.cdn.mozilla.net",
     "mitigation": null,
     "name": "Unexpected Content-Type was returned",
     "osi_layer": "APPLICATION",
+    "references": null,
     "severity": "LOW",
   },
   {
@@ -151,11 +154,49 @@ exports[`Parsing a bodgeit result. 1`] = `
     },
     "category": "Content Security Policy (CSP) Header Not Set",
     "description": "Content Security Policy (CSP) is an added layer of security that helps to detect and mitigate certain types of attacks, including Cross Site Scripting (XSS) and data injection attacks. These attacks are used for everything from data theft to site defacement or distribution of malware. CSP provides a set of standard HTTP headers that allow website owners to declare approved sources of content that browsers should be allowed to load on that page — covered types are JavaScript, CSS, HTML frames, fonts, images and embeddable objects such as Java applets, ActiveX, audio and video files.",
-    "hint": undefined,
+    "hint": null,
     "location": "http://bodgeit.securecodebox-demo.svc:8080",
     "mitigation": "Ensure that your web server, application server, load balancer, etc. is configured to set the Content-Security-Policy header, to achieve optimal browser support: "Content-Security-Policy" for Chrome 25+, Firefox 23+ and Safari 7+, "X-Content-Security-Policy" for Firefox 4.0+ and Internet Explorer 10+, and "X-WebKit-CSP" for Chrome 14+ and Safari 6+.",
     "name": "Content Security Policy (CSP) Header Not Set",
     "osi_layer": "APPLICATION",
+    "references": [
+      {
+        "type": "URL",
+        "value": "https://developer.mozilla.org/en-US/docs/Web/Security/CSP/Introducing_Content_Security_Policy",
+      },
+      {
+        "type": "URL",
+        "value": "https://cheatsheetseries.owasp.org/cheatsheets/Content_Security_Policy_Cheat_Sheet.html",
+      },
+      {
+        "type": "URL",
+        "value": "http://www.w3.org/TR/CSP/",
+      },
+      {
+        "type": "URL",
+        "value": "http://w3c.github.io/webappsec/specs/content-security-policy/csp-specification.dev.html",
+      },
+      {
+        "type": "URL",
+        "value": "http://www.html5rocks.com/en/tutorials/security/content-security-policy/",
+      },
+      {
+        "type": "URL",
+        "value": "http://caniuse.com/#feat=contentsecuritypolicy",
+      },
+      {
+        "type": "URL",
+        "value": "http://content-security-policy.com/",
+      },
+      {
+        "type": "CWE",
+        "value": "CWE-693",
+      },
+      {
+        "type": "URL",
+        "value": "https://cwe.mitre.org/data/definitions/693.html",
+      },
+    ],
     "severity": "MEDIUM",
   },
   {
@@ -204,11 +245,29 @@ exports[`Parsing a bodgeit result. 1`] = `
     },
     "category": "Insecure HTTP Method - PUT",
     "description": "This method was originally intended for file managemant operations. It is now most commonly used in REST services, PUT is most-often utilized for **update** capabilities, PUT-ing to a known resource URI with the request body containing the newly-updated representation of the original resource..",
-    "hint": undefined,
+    "hint": null,
     "location": "http://bodgeit.securecodebox-demo.svc:8080",
     "mitigation": "TBA",
     "name": "Insecure HTTP Method - PUT",
     "osi_layer": "APPLICATION",
+    "references": [
+      {
+        "type": "URL",
+        "value": "http://projects.webappsec.org/Fingerprinting",
+      },
+      {
+        "type": "URL",
+        "value": "",
+      },
+      {
+        "type": "CWE",
+        "value": "CWE-200",
+      },
+      {
+        "type": "URL",
+        "value": "https://cwe.mitre.org/data/definitions/200.html",
+      },
+    ],
     "severity": "MEDIUM",
   },
   {
@@ -236,11 +295,25 @@ exports[`Parsing a bodgeit result. 1`] = `
     },
     "category": "Missing Anti-clickjacking Header",
     "description": "The response does not include either Content-Security-Policy with 'frame-ancestors' directive or X-Frame-Options to protect against 'ClickJacking' attacks.",
-    "hint": undefined,
+    "hint": null,
     "location": "http://bodgeit.securecodebox-demo.svc:8080",
     "mitigation": "Modern Web browsers support the Content-Security-Policy and X-Frame-Options HTTP headers. Ensure one of them is set on all web pages returned by your site/app.If you expect the page to be framed only by pages on your server (e.g. it's part of a FRAMESET) then you'll want to use SAMEORIGIN, otherwise if you never expect the page to be framed, you should use DENY. Alternatively consider implementing Content Security Policy's "frame-ancestors" directive.",
     "name": "Missing Anti-clickjacking Header",
     "osi_layer": "APPLICATION",
+    "references": [
+      {
+        "type": "URL",
+        "value": "https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/X-Frame-Options",
+      },
+      {
+        "type": "CWE",
+        "value": "CWE-1021",
+      },
+      {
+        "type": "URL",
+        "value": "https://cwe.mitre.org/data/definitions/1021.html",
+      },
+    ],
     "severity": "MEDIUM",
   },
   {
@@ -296,11 +369,21 @@ exports[`Parsing a bodgeit result. 1`] = `
     },
     "category": "A Server Error response code was returned by the server",
     "description": "A response code of 501 was returned by the server.This may indicate that the application is failing to handle unexpected input correctly.Raised by the 'Alert on HTTP Response Code Error' script",
-    "hint": undefined,
+    "hint": null,
     "location": "http://bodgeit.securecodebox-demo.svc:8080",
     "mitigation": null,
     "name": "A Server Error response code was returned by the server",
     "osi_layer": "APPLICATION",
+    "references": [
+      {
+        "type": "CWE",
+        "value": "CWE-388",
+      },
+      {
+        "type": "URL",
+        "value": "https://cwe.mitre.org/data/definitions/388.html",
+      },
+    ],
     "severity": "LOW",
   },
   {
@@ -349,11 +432,37 @@ exports[`Parsing a bodgeit result. 1`] = `
     },
     "category": "Server Leaks Version Information via "Server" HTTP Response Header Field",
     "description": "The web/application server is leaking version information via the "Server" HTTP response header. Access to such information may facilitate attackers identifying other vulnerabilities your web/application server is subject to.",
-    "hint": undefined,
+    "hint": null,
     "location": "http://bodgeit.securecodebox-demo.svc:8080",
     "mitigation": "Ensure that your web server, application server, load balancer, etc. is configured to suppress the "Server" header or provide generic details.",
     "name": "Server Leaks Version Information via "Server" HTTP Response Header Field",
     "osi_layer": "APPLICATION",
+    "references": [
+      {
+        "type": "URL",
+        "value": "http://httpd.apache.org/docs/current/mod/core.html#servertokens",
+      },
+      {
+        "type": "URL",
+        "value": "http://msdn.microsoft.com/en-us/library/ff648552.aspx#ht_urlscan_007",
+      },
+      {
+        "type": "URL",
+        "value": "http://blogs.msdn.com/b/varunm/archive/2013/04/23/remove-unwanted-http-response-headers.aspx",
+      },
+      {
+        "type": "URL",
+        "value": "http://www.troyhunt.com/2012/02/shhh-dont-let-your-response-headers.html",
+      },
+      {
+        "type": "CWE",
+        "value": "CWE-200",
+      },
+      {
+        "type": "URL",
+        "value": "https://cwe.mitre.org/data/definitions/200.html",
+      },
+    ],
     "severity": "LOW",
   },
   {
@@ -1109,11 +1218,12 @@ exports[`Parsing a bodgeit result. 1`] = `
     },
     "category": "Unexpected Content-Type was returned",
     "description": "A Content-Type of text/html was returned by the server.This is not one of the types expected to be returned by an API.Raised by the 'Alert on Unexpected Content Types' script",
-    "hint": undefined,
+    "hint": null,
     "location": "http://bodgeit.securecodebox-demo.svc:8080",
     "mitigation": null,
     "name": "Unexpected Content-Type was returned",
     "osi_layer": "APPLICATION",
+    "references": null,
     "severity": "LOW",
   },
   {
@@ -1141,11 +1251,29 @@ exports[`Parsing a bodgeit result. 1`] = `
     },
     "category": "X-Content-Type-Options Header Missing",
     "description": "The Anti-MIME-Sniffing header X-Content-Type-Options was not set to 'nosniff'. This allows older versions of Internet Explorer and Chrome to perform MIME-sniffing on the response body, potentially causing the response body to be interpreted and displayed as a content type other than the declared content type. Current (early 2014) and legacy versions of Firefox will use the declared content type (if one is set), rather than performing MIME-sniffing.",
-    "hint": undefined,
+    "hint": null,
     "location": "http://bodgeit.securecodebox-demo.svc:8080",
     "mitigation": "Ensure that the application/web server sets the Content-Type header appropriately, and that it sets the X-Content-Type-Options header to 'nosniff' for all web pages.If possible, ensure that the end user uses a standards-compliant and modern web browser that does not perform MIME-sniffing at all, or that can be directed by the web application/web server to not perform MIME-sniffing.",
     "name": "X-Content-Type-Options Header Missing",
     "osi_layer": "APPLICATION",
+    "references": [
+      {
+        "type": "URL",
+        "value": "http://msdn.microsoft.com/en-us/library/ie/gg622941%28v=vs.85%29.aspx",
+      },
+      {
+        "type": "URL",
+        "value": "https://owasp.org/www-community/Security_Headers",
+      },
+      {
+        "type": "CWE",
+        "value": "CWE-693",
+      },
+      {
+        "type": "URL",
+        "value": "https://cwe.mitre.org/data/definitions/693.html",
+      },
+    ],
     "severity": "LOW",
   },
   {
@@ -1733,11 +1861,21 @@ exports[`Parsing a bodgeit result. 1`] = `
     },
     "category": "A Client Error response code was returned by the server",
     "description": "A response code of 404 was returned by the server.This may indicate that the application is failing to handle unexpected input correctly.Raised by the 'Alert on HTTP Response Code Error' script",
-    "hint": undefined,
+    "hint": null,
     "location": "http://bodgeit.securecodebox-demo.svc:8080",
     "mitigation": null,
     "name": "A Client Error response code was returned by the server",
     "osi_layer": "APPLICATION",
+    "references": [
+      {
+        "type": "CWE",
+        "value": "CWE-388",
+      },
+      {
+        "type": "URL",
+        "value": "https://cwe.mitre.org/data/definitions/388.html",
+      },
+    ],
     "severity": "INFORMATIONAL",
   },
   {
@@ -1757,11 +1895,29 @@ exports[`Parsing a bodgeit result. 1`] = `
     },
     "category": "HTTP Only Site",
     "description": "The site is only served under HTTP and not HTTPS.",
-    "hint": undefined,
+    "hint": null,
     "location": "http://bodgeit.securecodebox-demo.svc:8080",
     "mitigation": "Configure your web or application server to use SSL (https).",
     "name": "HTTP Only Site",
     "osi_layer": "APPLICATION",
+    "references": [
+      {
+        "type": "URL",
+        "value": "https://cheatsheetseries.owasp.org/cheatsheets/Transport_Layer_Protection_Cheat_Sheet.html",
+      },
+      {
+        "type": "URL",
+        "value": "https://letsencrypt.org/",
+      },
+      {
+        "type": "CWE",
+        "value": "CWE-311",
+      },
+      {
+        "type": "URL",
+        "value": "https://cwe.mitre.org/data/definitions/311.html",
+      },
+    ],
     "severity": "MEDIUM",
   },
 ]
@@ -1797,11 +1953,25 @@ exports[`Parsing a nginx result. 1`] = `
     },
     "category": "X-Frame-Options Header Not Set",
     "description": "X-Frame-Options header is not included in the HTTP response to protect against 'ClickJacking' attacks.",
-    "hint": undefined,
+    "hint": null,
     "location": "http://nginx.demo-targets.svc",
     "mitigation": "Most modern Web browsers support the X-Frame-Options HTTP header. Ensure it's set on all web pages returned by your site (if you expect the page to be framed only by pages on your server (e.g. it's part of a FRAMESET) then you'll want to use SAMEORIGIN, otherwise if you never expect the page to be framed, you should use DENY. ALLOW-FROM allows specific websites to frame the web page in supported web browsers).",
     "name": "X-Frame-Options Header Not Set",
     "osi_layer": "APPLICATION",
+    "references": [
+      {
+        "type": "URL",
+        "value": "https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/X-Frame-Options",
+      },
+      {
+        "type": "CWE",
+        "value": "CWE-16",
+      },
+      {
+        "type": "URL",
+        "value": "https://cwe.mitre.org/data/definitions/16.html",
+      },
+    ],
     "severity": "MEDIUM",
   },
   {
@@ -1842,11 +2012,37 @@ exports[`Parsing a nginx result. 1`] = `
     },
     "category": "Server Leaks Version Information via "Server" HTTP Response Header Field",
     "description": "The web/application server is leaking version information via the "Server" HTTP response header. Access to such information may facilitate attackers identifying other vulnerabilities your web/application server is subject to.",
-    "hint": undefined,
+    "hint": null,
     "location": "http://nginx.demo-targets.svc",
     "mitigation": "Ensure that your web server, application server, load balancer, etc. is configured to suppress the "Server" header or provide generic details.",
     "name": "Server Leaks Version Information via "Server" HTTP Response Header Field",
     "osi_layer": "APPLICATION",
+    "references": [
+      {
+        "type": "URL",
+        "value": "http://httpd.apache.org/docs/current/mod/core.html#servertokens",
+      },
+      {
+        "type": "URL",
+        "value": "http://msdn.microsoft.com/en-us/library/ff648552.aspx#ht_urlscan_007",
+      },
+      {
+        "type": "URL",
+        "value": "http://blogs.msdn.com/b/varunm/archive/2013/04/23/remove-unwanted-http-response-headers.aspx",
+      },
+      {
+        "type": "URL",
+        "value": "http://www.troyhunt.com/2012/02/shhh-dont-let-your-response-headers.html",
+      },
+      {
+        "type": "CWE",
+        "value": "CWE-200",
+      },
+      {
+        "type": "URL",
+        "value": "https://cwe.mitre.org/data/definitions/200.html",
+      },
+    ],
     "severity": "LOW",
   },
   {
@@ -1877,11 +2073,29 @@ exports[`Parsing a nginx result. 1`] = `
     },
     "category": "X-Content-Type-Options Header Missing",
     "description": "The Anti-MIME-Sniffing header X-Content-Type-Options was not set to 'nosniff'. This allows older versions of Internet Explorer and Chrome to perform MIME-sniffing on the response body, potentially causing the response body to be interpreted and displayed as a content type other than the declared content type. Current (early 2014) and legacy versions of Firefox will use the declared content type (if one is set), rather than performing MIME-sniffing.",
-    "hint": undefined,
+    "hint": null,
     "location": "http://nginx.demo-targets.svc",
     "mitigation": "Ensure that the application/web server sets the Content-Type header appropriately, and that it sets the X-Content-Type-Options header to 'nosniff' for all web pages.If possible, ensure that the end user uses a standards-compliant and modern web browser that does not perform MIME-sniffing at all, or that can be directed by the web application/web server to not perform MIME-sniffing.",
     "name": "X-Content-Type-Options Header Missing",
     "osi_layer": "APPLICATION",
+    "references": [
+      {
+        "type": "URL",
+        "value": "http://msdn.microsoft.com/en-us/library/ie/gg622941%28v=vs.85%29.aspx",
+      },
+      {
+        "type": "URL",
+        "value": "https://owasp.org/www-community/Security_Headers",
+      },
+      {
+        "type": "CWE",
+        "value": "CWE-16",
+      },
+      {
+        "type": "URL",
+        "value": "https://cwe.mitre.org/data/definitions/16.html",
+      },
+    ],
     "severity": "LOW",
   },
   {
@@ -1918,11 +2132,49 @@ exports[`Parsing a nginx result. 1`] = `
     },
     "category": "Content Security Policy (CSP) Header Not Set",
     "description": "Content Security Policy (CSP) is an added layer of security that helps to detect and mitigate certain types of attacks, including Cross Site Scripting (XSS) and data injection attacks. These attacks are used for everything from data theft to site defacement or distribution of malware. CSP provides a set of standard HTTP headers that allow website owners to declare approved sources of content that browsers should be allowed to load on that page — covered types are JavaScript, CSS, HTML frames, fonts, images and embeddable objects such as Java applets, ActiveX, audio and video files.",
-    "hint": undefined,
+    "hint": null,
     "location": "http://nginx.demo-targets.svc",
     "mitigation": "Ensure that your web server, application server, load balancer, etc. is configured to set the Content-Security-Policy header, to achieve optimal browser support: "Content-Security-Policy" for Chrome 25+, Firefox 23+ and Safari 7+, "X-Content-Security-Policy" for Firefox 4.0+ and Internet Explorer 10+, and "X-WebKit-CSP" for Chrome 14+ and Safari 6+.",
     "name": "Content Security Policy (CSP) Header Not Set",
     "osi_layer": "APPLICATION",
+    "references": [
+      {
+        "type": "URL",
+        "value": "https://developer.mozilla.org/en-US/docs/Web/Security/CSP/Introducing_Content_Security_Policy",
+      },
+      {
+        "type": "URL",
+        "value": "https://cheatsheetseries.owasp.org/cheatsheets/Content_Security_Policy_Cheat_Sheet.html",
+      },
+      {
+        "type": "URL",
+        "value": "http://www.w3.org/TR/CSP/",
+      },
+      {
+        "type": "URL",
+        "value": "http://w3c.github.io/webappsec/specs/content-security-policy/csp-specification.dev.html",
+      },
+      {
+        "type": "URL",
+        "value": "http://www.html5rocks.com/en/tutorials/security/content-security-policy/",
+      },
+      {
+        "type": "URL",
+        "value": "http://caniuse.com/#feat=contentsecuritypolicy",
+      },
+      {
+        "type": "URL",
+        "value": "http://content-security-policy.com/",
+      },
+      {
+        "type": "CWE",
+        "value": "CWE-16",
+      },
+      {
+        "type": "URL",
+        "value": "https://cwe.mitre.org/data/definitions/16.html",
+      },
+    ],
     "severity": "LOW",
   },
 ]
@@ -2048,11 +2300,25 @@ exports[`Parsing the docs.securecodebox.io results. 1`] = `
     },
     "category": "Timestamp Disclosure - Unix",
     "description": "A timestamp was disclosed by the application/web server - Unix",
-    "hint": undefined,
+    "hint": null,
     "location": "https://docs.securecodebox.io",
     "mitigation": "Manually confirm that the timestamp data is not sensitive, and that the data cannot be aggregated to disclose exploitable patterns.",
     "name": "Timestamp Disclosure - Unix",
     "osi_layer": "APPLICATION",
+    "references": [
+      {
+        "type": "URL",
+        "value": "http://projects.webappsec.org/w/page/13246936/Information%20Leakage",
+      },
+      {
+        "type": "CWE",
+        "value": "CWE-200",
+      },
+      {
+        "type": "URL",
+        "value": "https://cwe.mitre.org/data/definitions/200.html",
+      },
+    ],
     "severity": "INFORMATIONAL",
   },
   {
@@ -2173,11 +2439,29 @@ exports[`Parsing the docs.securecodebox.io results. 1`] = `
     },
     "category": "X-Content-Type-Options Header Missing",
     "description": "The Anti-MIME-Sniffing header X-Content-Type-Options was not set to 'nosniff'. This allows older versions of Internet Explorer and Chrome to perform MIME-sniffing on the response body, potentially causing the response body to be interpreted and displayed as a content type other than the declared content type. Current (early 2014) and legacy versions of Firefox will use the declared content type (if one is set), rather than performing MIME-sniffing.",
-    "hint": undefined,
+    "hint": null,
     "location": "https://docs.securecodebox.io",
     "mitigation": "Ensure that the application/web server sets the Content-Type header appropriately, and that it sets the X-Content-Type-Options header to 'nosniff' for all web pages.If possible, ensure that the end user uses a standards-compliant and modern web browser that does not perform MIME-sniffing at all, or that can be directed by the web application/web server to not perform MIME-sniffing.",
     "name": "X-Content-Type-Options Header Missing",
     "osi_layer": "APPLICATION",
+    "references": [
+      {
+        "type": "URL",
+        "value": "http://msdn.microsoft.com/en-us/library/ie/gg622941%28v=vs.85%29.aspx",
+      },
+      {
+        "type": "URL",
+        "value": "https://owasp.org/www-community/Security_Headers",
+      },
+      {
+        "type": "CWE",
+        "value": "CWE-16",
+      },
+      {
+        "type": "URL",
+        "value": "https://cwe.mitre.org/data/definitions/16.html",
+      },
+    ],
     "severity": "LOW",
   },
   {
@@ -2278,11 +2562,49 @@ exports[`Parsing the docs.securecodebox.io results. 1`] = `
     },
     "category": "Content Security Policy (CSP) Header Not Set",
     "description": "Content Security Policy (CSP) is an added layer of security that helps to detect and mitigate certain types of attacks, including Cross Site Scripting (XSS) and data injection attacks. These attacks are used for everything from data theft to site defacement or distribution of malware. CSP provides a set of standard HTTP headers that allow website owners to declare approved sources of content that browsers should be allowed to load on that page — covered types are JavaScript, CSS, HTML frames, fonts, images and embeddable objects such as Java applets, ActiveX, audio and video files.",
-    "hint": undefined,
+    "hint": null,
     "location": "https://docs.securecodebox.io",
     "mitigation": "Ensure that your web server, application server, load balancer, etc. is configured to set the Content-Security-Policy header, to achieve optimal browser support: "Content-Security-Policy" for Chrome 25+, Firefox 23+ and Safari 7+, "X-Content-Security-Policy" for Firefox 4.0+ and Internet Explorer 10+, and "X-WebKit-CSP" for Chrome 14+ and Safari 6+.",
     "name": "Content Security Policy (CSP) Header Not Set",
     "osi_layer": "APPLICATION",
+    "references": [
+      {
+        "type": "URL",
+        "value": "https://developer.mozilla.org/en-US/docs/Web/Security/CSP/Introducing_Content_Security_Policy",
+      },
+      {
+        "type": "URL",
+        "value": "https://cheatsheetseries.owasp.org/cheatsheets/Content_Security_Policy_Cheat_Sheet.html",
+      },
+      {
+        "type": "URL",
+        "value": "http://www.w3.org/TR/CSP/",
+      },
+      {
+        "type": "URL",
+        "value": "http://w3c.github.io/webappsec/specs/content-security-policy/csp-specification.dev.html",
+      },
+      {
+        "type": "URL",
+        "value": "http://www.html5rocks.com/en/tutorials/security/content-security-policy/",
+      },
+      {
+        "type": "URL",
+        "value": "http://caniuse.com/#feat=contentsecuritypolicy",
+      },
+      {
+        "type": "URL",
+        "value": "http://content-security-policy.com/",
+      },
+      {
+        "type": "CWE",
+        "value": "CWE-16",
+      },
+      {
+        "type": "URL",
+        "value": "https://cwe.mitre.org/data/definitions/16.html",
+      },
+    ],
     "severity": "LOW",
   },
   {
@@ -2403,11 +2725,25 @@ exports[`Parsing the docs.securecodebox.io results. 1`] = `
     },
     "category": "Retrieved from Cache",
     "description": "The content was retrieved from a shared cache. If the response data is sensitive, personal or user-specific, this may result in sensitive information being leaked. In some cases, this may even result in a user gaining complete control of the session of another user, depending on the configuration of the caching components in use in their environment. This is primarily an issue where caching servers such as "proxy" caches are configured on the local network. This configuration is typically found in corporate or educational environments, for instance. ",
-    "hint": undefined,
+    "hint": null,
     "location": "https://docs.securecodebox.io",
     "mitigation": "Validate that the response does not contain sensitive, personal or user-specific information.  If it does, consider the use of the following HTTP response headers, to limit, or prevent the content being stored and retrieved from the cache by another user:Cache-Control: no-cache, no-store, must-revalidate, privatePragma: no-cacheExpires: 0This configuration directs both HTTP 1.0 and HTTP 1.1 compliant caching servers to not store the response, and to not retrieve the response (without validation) from the cache, in response to a similar request.",
     "name": "Retrieved from Cache",
     "osi_layer": "APPLICATION",
+    "references": [
+      {
+        "type": "URL",
+        "value": "https://tools.ietf.org/html/rfc7234",
+      },
+      {
+        "type": "URL",
+        "value": "https://tools.ietf.org/html/rfc7231",
+      },
+      {
+        "type": "URL",
+        "value": "http://www.w3.org/Protocols/rfc2616/rfc2616-sec13.html (obsoleted by rfc7234)",
+      },
+    ],
     "severity": "INFORMATIONAL",
   },
   {
@@ -2548,11 +2884,25 @@ exports[`Parsing the docs.securecodebox.io results. 1`] = `
     },
     "category": "Incomplete or No Cache-control and Pragma HTTP Header Set",
     "description": "The cache-control and pragma HTTP header have not been set properly or are missing allowing the browser and proxies to cache content.",
-    "hint": undefined,
+    "hint": null,
     "location": "https://docs.securecodebox.io",
     "mitigation": "Whenever possible ensure the cache-control HTTP header is set with no-cache, no-store, must-revalidate; and that the pragma HTTP header is set with no-cache.",
     "name": "Incomplete or No Cache-control and Pragma HTTP Header Set",
     "osi_layer": "APPLICATION",
+    "references": [
+      {
+        "type": "URL",
+        "value": "https://cheatsheetseries.owasp.org/cheatsheets/Session_Management_Cheat_Sheet.html#web-content-caching",
+      },
+      {
+        "type": "CWE",
+        "value": "CWE-525",
+      },
+      {
+        "type": "URL",
+        "value": "https://cwe.mitre.org/data/definitions/525.html",
+      },
+    ],
     "severity": "LOW",
   },
   {
@@ -2668,11 +3018,25 @@ exports[`Parsing the docs.securecodebox.io results. 1`] = `
     },
     "category": "Private IP Disclosure",
     "description": "A private IP (such as 10.x.x.x, 172.x.x.x, 192.168.x.x) or an Amazon EC2 private hostname (for example, ip-10-0-56-78) has been found in the HTTP response body. This information might be helpful for further attacks targeting internal systems.",
-    "hint": undefined,
+    "hint": null,
     "location": "https://docs.securecodebox.io",
     "mitigation": "Remove the private IP address from the HTTP response body.  For comments, use JSP/ASP/PHP comment instead of HTML/JavaScript comment which can be seen by client browsers.",
     "name": "Private IP Disclosure",
     "osi_layer": "APPLICATION",
+    "references": [
+      {
+        "type": "URL",
+        "value": "https://tools.ietf.org/html/rfc1918",
+      },
+      {
+        "type": "CWE",
+        "value": "CWE-200",
+      },
+      {
+        "type": "URL",
+        "value": "https://cwe.mitre.org/data/definitions/200.html",
+      },
+    ],
     "severity": "LOW",
   },
   {
@@ -2793,11 +3157,17 @@ exports[`Parsing the docs.securecodebox.io results. 1`] = `
     },
     "category": "Modern Web Application",
     "description": "The application appears to be a modern web application. If you need to explore it automatically then the Ajax Spider may well be more effective than the standard one.",
-    "hint": undefined,
+    "hint": null,
     "location": "https://docs.securecodebox.io",
     "mitigation": "This is an informational alert and so no changes are required.",
     "name": "Modern Web Application",
     "osi_layer": "APPLICATION",
+    "references": [
+      {
+        "type": "URL",
+        "value": "",
+      },
+    ],
     "severity": "INFORMATIONAL",
   },
   {
@@ -2898,11 +3268,25 @@ exports[`Parsing the docs.securecodebox.io results. 1`] = `
     },
     "category": "Big Redirect Detected (Potential Sensitive Information Leak)",
     "description": "The server has responded with a redirect that seems to provide a large response. This may indicate that although the server sent a redirect it also responded with body content (which may include sensitive details, PII, etc.).",
-    "hint": undefined,
+    "hint": null,
     "location": "https://docs.securecodebox.io",
     "mitigation": "Ensure that no sensitive information is leaked via redirect responses. Redirect responses should have almost no content.",
     "name": "Big Redirect Detected (Potential Sensitive Information Leak)",
     "osi_layer": "APPLICATION",
+    "references": [
+      {
+        "type": "URL",
+        "value": "",
+      },
+      {
+        "type": "CWE",
+        "value": "CWE-201",
+      },
+      {
+        "type": "URL",
+        "value": "https://cwe.mitre.org/data/definitions/201.html",
+      },
+    ],
     "severity": "LOW",
   },
   {
@@ -3003,11 +3387,25 @@ exports[`Parsing the docs.securecodebox.io results. 1`] = `
     },
     "category": "Information Disclosure - Suspicious Comments",
     "description": "The response appears to contain suspicious comments which may help an attacker. Note: Matches made within script blocks or files are against the entire content not only comments.",
-    "hint": undefined,
+    "hint": null,
     "location": "https://docs.securecodebox.io",
     "mitigation": "Remove all comments that return information that may help an attacker and fix any underlying problems they refer to.",
     "name": "Information Disclosure - Suspicious Comments",
     "osi_layer": "APPLICATION",
+    "references": [
+      {
+        "type": "URL",
+        "value": "",
+      },
+      {
+        "type": "CWE",
+        "value": "CWE-200",
+      },
+      {
+        "type": "URL",
+        "value": "https://cwe.mitre.org/data/definitions/200.html",
+      },
+    ],
     "severity": "INFORMATIONAL",
   },
   {
@@ -3128,11 +3526,25 @@ exports[`Parsing the docs.securecodebox.io results. 1`] = `
     },
     "category": "X-Frame-Options Header Not Set",
     "description": "X-Frame-Options header is not included in the HTTP response to protect against 'ClickJacking' attacks.",
-    "hint": undefined,
+    "hint": null,
     "location": "https://docs.securecodebox.io",
     "mitigation": "Most modern Web browsers support the X-Frame-Options HTTP header. Ensure it's set on all web pages returned by your site (if you expect the page to be framed only by pages on your server (e.g. it's part of a FRAMESET) then you'll want to use SAMEORIGIN, otherwise if you never expect the page to be framed, you should use DENY. ALLOW-FROM allows specific websites to frame the web page in supported web browsers).",
     "name": "X-Frame-Options Header Not Set",
     "osi_layer": "APPLICATION",
+    "references": [
+      {
+        "type": "URL",
+        "value": "https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/X-Frame-Options",
+      },
+      {
+        "type": "CWE",
+        "value": "CWE-16",
+      },
+      {
+        "type": "URL",
+        "value": "https://cwe.mitre.org/data/definitions/16.html",
+      },
+    ],
     "severity": "MEDIUM",
   },
   {
@@ -3163,11 +3575,25 @@ exports[`Parsing the docs.securecodebox.io results. 1`] = `
     },
     "category": "Application Error Disclosure",
     "description": "This page contains an error/warning message that may disclose sensitive information like the location of the file that produced the unhandled exception. This information can be used to launch further attacks against the web application. The alert could be a false positive if the error message is found inside a documentation page.",
-    "hint": undefined,
+    "hint": null,
     "location": "https://docs.securecodebox.io",
     "mitigation": "Review the source code of this page. Implement custom error pages. Consider implementing a mechanism to provide a unique error reference/identifier to the client (browser) while logging the details on the server side and not exposing them to the user.",
     "name": "Application Error Disclosure",
     "osi_layer": "APPLICATION",
+    "references": [
+      {
+        "type": "URL",
+        "value": "",
+      },
+      {
+        "type": "CWE",
+        "value": "CWE-200",
+      },
+      {
+        "type": "URL",
+        "value": "https://cwe.mitre.org/data/definitions/200.html",
+      },
+    ],
     "severity": "MEDIUM",
   },
   {
@@ -3212,11 +3638,41 @@ exports[`Parsing the docs.securecodebox.io results. 1`] = `
     },
     "category": "Strict-Transport-Security Header Not Set",
     "description": "HTTP Strict Transport Security (HSTS) is a web security policy mechanism whereby a web server declares that complying user agents (such as a web browser) are to interact with it using only secure HTTPS connections (i.e. HTTP layered over TLS/SSL). HSTS is an IETF standards track protocol and is specified in RFC 6797.",
-    "hint": undefined,
+    "hint": null,
     "location": "https://docs.securecodebox.io",
     "mitigation": "Ensure that your web server, application server, load balancer, etc. is configured to enforce Strict-Transport-Security.",
     "name": "Strict-Transport-Security Header Not Set",
     "osi_layer": "APPLICATION",
+    "references": [
+      {
+        "type": "URL",
+        "value": "https://cheatsheetseries.owasp.org/cheatsheets/HTTP_Strict_Transport_Security_Cheat_Sheet.html",
+      },
+      {
+        "type": "URL",
+        "value": "https://owasp.org/www-community/Security_Headers",
+      },
+      {
+        "type": "URL",
+        "value": "http://en.wikipedia.org/wiki/HTTP_Strict_Transport_Security",
+      },
+      {
+        "type": "URL",
+        "value": "http://caniuse.com/stricttransportsecurity",
+      },
+      {
+        "type": "URL",
+        "value": "http://tools.ietf.org/html/rfc6797",
+      },
+      {
+        "type": "CWE",
+        "value": "CWE-16",
+      },
+      {
+        "type": "URL",
+        "value": "https://cwe.mitre.org/data/definitions/16.html",
+      },
+    ],
     "severity": "LOW",
   },
 ]
@@ -3262,11 +3718,37 @@ exports[`Parsing the example.com results. 1`] = `
     },
     "category": "Server Leaks Version Information via "Server" HTTP Response Header Field",
     "description": "The web/application server is leaking version information via the "Server" HTTP response header. Access to such information may facilitate attackers identifying other vulnerabilities your web/application server is subject to.",
-    "hint": undefined,
+    "hint": null,
     "location": "http://example.com",
     "mitigation": "Ensure that your web server, application server, load balancer, etc. is configured to suppress the "Server" header or provide generic details.",
     "name": "Server Leaks Version Information via "Server" HTTP Response Header Field",
     "osi_layer": "APPLICATION",
+    "references": [
+      {
+        "type": "URL",
+        "value": "http://httpd.apache.org/docs/current/mod/core.html#servertokens",
+      },
+      {
+        "type": "URL",
+        "value": "http://msdn.microsoft.com/en-us/library/ff648552.aspx#ht_urlscan_007",
+      },
+      {
+        "type": "URL",
+        "value": "http://blogs.msdn.com/b/varunm/archive/2013/04/23/remove-unwanted-http-response-headers.aspx",
+      },
+      {
+        "type": "URL",
+        "value": "http://www.troyhunt.com/2012/02/shhh-dont-let-your-response-headers.html",
+      },
+      {
+        "type": "CWE",
+        "value": "CWE-200",
+      },
+      {
+        "type": "URL",
+        "value": "https://cwe.mitre.org/data/definitions/200.html",
+      },
+    ],
     "severity": "LOW",
   },
   {
@@ -3307,11 +3789,25 @@ exports[`Parsing the example.com results. 1`] = `
     },
     "category": "Retrieved from Cache",
     "description": "The content was retrieved from a shared cache. If the response data is sensitive, personal or user-specific, this may result in sensitive information being leaked. In some cases, this may even result in a user gaining complete control of the session of another user, depending on the configuration of the caching components in use in their environment. This is primarily an issue where caching servers such as "proxy" caches are configured on the local network. This configuration is typically found in corporate or educational environments, for instance. ",
-    "hint": undefined,
+    "hint": null,
     "location": "http://example.com",
     "mitigation": "Validate that the response does not contain sensitive, personal or user-specific information.  If it does, consider the use of the following HTTP response headers, to limit, or prevent the content being stored and retrieved from the cache by another user:Cache-Control: no-cache, no-store, must-revalidate, privatePragma: no-cacheExpires: 0This configuration directs both HTTP 1.0 and HTTP 1.1 compliant caching servers to not store the response, and to not retrieve the response (without validation) from the cache, in response to a similar request.",
     "name": "Retrieved from Cache",
     "osi_layer": "APPLICATION",
+    "references": [
+      {
+        "type": "URL",
+        "value": "https://tools.ietf.org/html/rfc7234",
+      },
+      {
+        "type": "URL",
+        "value": "https://tools.ietf.org/html/rfc7231",
+      },
+      {
+        "type": "URL",
+        "value": "http://www.w3.org/Protocols/rfc2616/rfc2616-sec13.html (obsoleted by rfc7234)",
+      },
+    ],
     "severity": "INFORMATIONAL",
   },
   {
@@ -3348,11 +3844,49 @@ exports[`Parsing the example.com results. 1`] = `
     },
     "category": "Content Security Policy (CSP) Header Not Set",
     "description": "Content Security Policy (CSP) is an added layer of security that helps to detect and mitigate certain types of attacks, including Cross Site Scripting (XSS) and data injection attacks. These attacks are used for everything from data theft to site defacement or distribution of malware. CSP provides a set of standard HTTP headers that allow website owners to declare approved sources of content that browsers should be allowed to load on that page — covered types are JavaScript, CSS, HTML frames, fonts, images and embeddable objects such as Java applets, ActiveX, audio and video files.",
-    "hint": undefined,
+    "hint": null,
     "location": "http://example.com",
     "mitigation": "Ensure that your web server, application server, load balancer, etc. is configured to set the Content-Security-Policy header, to achieve optimal browser support: "Content-Security-Policy" for Chrome 25+, Firefox 23+ and Safari 7+, "X-Content-Security-Policy" for Firefox 4.0+ and Internet Explorer 10+, and "X-WebKit-CSP" for Chrome 14+ and Safari 6+.",
     "name": "Content Security Policy (CSP) Header Not Set",
     "osi_layer": "APPLICATION",
+    "references": [
+      {
+        "type": "URL",
+        "value": "https://developer.mozilla.org/en-US/docs/Web/Security/CSP/Introducing_Content_Security_Policy",
+      },
+      {
+        "type": "URL",
+        "value": "https://cheatsheetseries.owasp.org/cheatsheets/Content_Security_Policy_Cheat_Sheet.html",
+      },
+      {
+        "type": "URL",
+        "value": "http://www.w3.org/TR/CSP/",
+      },
+      {
+        "type": "URL",
+        "value": "http://w3c.github.io/webappsec/specs/content-security-policy/csp-specification.dev.html",
+      },
+      {
+        "type": "URL",
+        "value": "http://www.html5rocks.com/en/tutorials/security/content-security-policy/",
+      },
+      {
+        "type": "URL",
+        "value": "http://caniuse.com/#feat=contentsecuritypolicy",
+      },
+      {
+        "type": "URL",
+        "value": "http://content-security-policy.com/",
+      },
+      {
+        "type": "CWE",
+        "value": "CWE-16",
+      },
+      {
+        "type": "URL",
+        "value": "https://cwe.mitre.org/data/definitions/16.html",
+      },
+    ],
     "severity": "LOW",
   },
   {
@@ -3383,11 +3917,29 @@ exports[`Parsing the example.com results. 1`] = `
     },
     "category": "X-Content-Type-Options Header Missing",
     "description": "The Anti-MIME-Sniffing header X-Content-Type-Options was not set to 'nosniff'. This allows older versions of Internet Explorer and Chrome to perform MIME-sniffing on the response body, potentially causing the response body to be interpreted and displayed as a content type other than the declared content type. Current (early 2014) and legacy versions of Firefox will use the declared content type (if one is set), rather than performing MIME-sniffing.",
-    "hint": undefined,
+    "hint": null,
     "location": "http://example.com",
     "mitigation": "Ensure that the application/web server sets the Content-Type header appropriately, and that it sets the X-Content-Type-Options header to 'nosniff' for all web pages.If possible, ensure that the end user uses a standards-compliant and modern web browser that does not perform MIME-sniffing at all, or that can be directed by the web application/web server to not perform MIME-sniffing.",
     "name": "X-Content-Type-Options Header Missing",
     "osi_layer": "APPLICATION",
+    "references": [
+      {
+        "type": "URL",
+        "value": "http://msdn.microsoft.com/en-us/library/ie/gg622941%28v=vs.85%29.aspx",
+      },
+      {
+        "type": "URL",
+        "value": "https://owasp.org/www-community/Security_Headers",
+      },
+      {
+        "type": "CWE",
+        "value": "CWE-16",
+      },
+      {
+        "type": "URL",
+        "value": "https://cwe.mitre.org/data/definitions/16.html",
+      },
+    ],
     "severity": "LOW",
   },
   {
@@ -3418,11 +3970,25 @@ exports[`Parsing the example.com results. 1`] = `
     },
     "category": "X-Frame-Options Header Not Set",
     "description": "X-Frame-Options header is not included in the HTTP response to protect against 'ClickJacking' attacks.",
-    "hint": undefined,
+    "hint": null,
     "location": "http://example.com",
     "mitigation": "Most modern Web browsers support the X-Frame-Options HTTP header. Ensure it's set on all web pages returned by your site (if you expect the page to be framed only by pages on your server (e.g. it's part of a FRAMESET) then you'll want to use SAMEORIGIN, otherwise if you never expect the page to be framed, you should use DENY. ALLOW-FROM allows specific websites to frame the web page in supported web browsers).",
     "name": "X-Frame-Options Header Not Set",
     "osi_layer": "APPLICATION",
+    "references": [
+      {
+        "type": "URL",
+        "value": "https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/X-Frame-Options",
+      },
+      {
+        "type": "CWE",
+        "value": "CWE-16",
+      },
+      {
+        "type": "URL",
+        "value": "https://cwe.mitre.org/data/definitions/16.html",
+      },
+    ],
     "severity": "MEDIUM",
   },
 ]
@@ -3548,11 +4114,25 @@ exports[`Parsing the juice-shop results. 1`] = `
     },
     "category": "Cross-Domain Misconfiguration",
     "description": "Web browser data loading may be possible, due to a Cross Origin Resource Sharing (CORS) misconfiguration on the web server",
-    "hint": undefined,
+    "hint": null,
     "location": "http://juice-shop:3000",
     "mitigation": "Ensure that sensitive data is not available in an unauthenticated manner (using IP address white-listing, for instance).Configure the "Access-Control-Allow-Origin" HTTP header to a more restrictive set of domains, or remove all CORS headers entirely, to allow the web browser to enforce the Same Origin Policy (SOP) in a more restrictive manner.",
     "name": "Cross-Domain Misconfiguration",
     "osi_layer": "APPLICATION",
+    "references": [
+      {
+        "type": "URL",
+        "value": "http://www.hpenterprisesecurity.com/vulncat/en/vulncat/vb/html5_overly_permissive_cors_policy.html",
+      },
+      {
+        "type": "CWE",
+        "value": "CWE-264",
+      },
+      {
+        "type": "URL",
+        "value": "https://cwe.mitre.org/data/definitions/264.html",
+      },
+    ],
     "severity": "MEDIUM",
   },
   {
@@ -3668,11 +4248,25 @@ exports[`Parsing the juice-shop results. 1`] = `
     },
     "category": "Cookie Poisoning",
     "description": "This check looks at user-supplied input in query string parameters and POST data to identify where cookie parameters might be controlled. This is called a cookie poisoning attack, and becomes exploitable when an attacker can manipulate the cookie in various ways. In some cases this will not be exploitable, however, allowing URL parameters to set cookie values is generally considered a bug.",
-    "hint": undefined,
+    "hint": null,
     "location": "http://juice-shop:3000",
     "mitigation": "Do not allow user input to control cookie names and values. If some query string parameters must be set in cookie values, be sure to filter out semicolon's that can serve as name/value pair delimiters.",
     "name": "Cookie Poisoning",
     "osi_layer": "APPLICATION",
+    "references": [
+      {
+        "type": "URL",
+        "value": "http://websecuritytool.codeplex.com/wikipage?title=Checks#user-controlled-cookie",
+      },
+      {
+        "type": "CWE",
+        "value": "CWE-20",
+      },
+      {
+        "type": "URL",
+        "value": "https://cwe.mitre.org/data/definitions/20.html",
+      },
+    ],
     "severity": "INFORMATIONAL",
   },
   {
@@ -3793,11 +4387,25 @@ exports[`Parsing the juice-shop results. 1`] = `
     },
     "category": "Timestamp Disclosure - Unix",
     "description": "A timestamp was disclosed by the application/web server - Unix",
-    "hint": undefined,
+    "hint": null,
     "location": "http://juice-shop:3000",
     "mitigation": "Manually confirm that the timestamp data is not sensitive, and that the data cannot be aggregated to disclose exploitable patterns.",
     "name": "Timestamp Disclosure - Unix",
     "osi_layer": "APPLICATION",
+    "references": [
+      {
+        "type": "URL",
+        "value": "http://projects.webappsec.org/w/page/13246936/Information%20Leakage",
+      },
+      {
+        "type": "CWE",
+        "value": "CWE-200",
+      },
+      {
+        "type": "URL",
+        "value": "https://cwe.mitre.org/data/definitions/200.html",
+      },
+    ],
     "severity": "INFORMATIONAL",
   },
   {
@@ -3938,11 +4546,25 @@ exports[`Parsing the juice-shop results. 1`] = `
     },
     "category": "Session ID in URL Rewrite",
     "description": "URL rewrite is used to track user session ID. The session ID may be disclosed via cross-site referer header. In addition, the session ID might be stored in browser history or server logs.",
-    "hint": undefined,
+    "hint": null,
     "location": "http://juice-shop:3000",
     "mitigation": "For secure content, put session ID in a cookie. To be even more secure consider using a combination of cookie and URL rewrite.",
     "name": "Session ID in URL Rewrite",
     "osi_layer": "APPLICATION",
+    "references": [
+      {
+        "type": "URL",
+        "value": "http://seclists.org/lists/webappsec/2002/Oct-Dec/0111.html",
+      },
+      {
+        "type": "CWE",
+        "value": "CWE-200",
+      },
+      {
+        "type": "URL",
+        "value": "https://cwe.mitre.org/data/definitions/200.html",
+      },
+    ],
     "severity": "MEDIUM",
   },
   {
@@ -3998,11 +4620,17 @@ exports[`Parsing the juice-shop results. 1`] = `
     },
     "category": "Modern Web Application",
     "description": "The application appears to be a modern web application. If you need to explore it automatically then the Ajax Spider may well be more effective than the standard one.",
-    "hint": undefined,
+    "hint": null,
     "location": "http://juice-shop:3000",
     "mitigation": "This is an informational alert and so no changes are required.",
     "name": "Modern Web Application",
     "osi_layer": "APPLICATION",
+    "references": [
+      {
+        "type": "URL",
+        "value": "",
+      },
+    ],
     "severity": "INFORMATIONAL",
   },
   {
@@ -4103,11 +4731,33 @@ exports[`Parsing the juice-shop results. 1`] = `
     },
     "category": "Loosely Scoped Cookie",
     "description": "Cookies can be scoped by domain or path. This check is only concerned with domain scope.The domain scope applied to a cookie determines which domains can access it. For example, a cookie can be scoped strictly to a subdomain e.g. www.nottrusted.com, or loosely scoped to a parent domain e.g. nottrusted.com. In the latter case, any subdomain of nottrusted.com can access the cookie. Loosely scoped cookies are common in mega-applications like google.com and live.com. Cookies set from a subdomain like app.foo.bar are transmitted only to that domain by the browser. However, cookies scoped to a parent-level domain may be transmitted to the parent, or any subdomain of the parent.",
-    "hint": undefined,
+    "hint": null,
     "location": "http://juice-shop:3000",
     "mitigation": "Always scope cookies to a FQDN (Fully Qualified Domain Name).",
     "name": "Loosely Scoped Cookie",
     "osi_layer": "APPLICATION",
+    "references": [
+      {
+        "type": "URL",
+        "value": "https://tools.ietf.org/html/rfc6265#section-4.1",
+      },
+      {
+        "type": "URL",
+        "value": "https://owasp.org/www-project-web-security-testing-guide/v41/4-Web_Application_Security_Testing/06-Session_Management_Testing/02-Testing_for_Cookies_Attributes.html",
+      },
+      {
+        "type": "URL",
+        "value": "http://code.google.com/p/browsersec/wiki/Part2#Same-origin_policy_for_cookies",
+      },
+      {
+        "type": "CWE",
+        "value": "CWE-565",
+      },
+      {
+        "type": "URL",
+        "value": "https://cwe.mitre.org/data/definitions/565.html",
+      },
+    ],
     "severity": "INFORMATIONAL",
   },
   {
@@ -4228,11 +4878,29 @@ exports[`Parsing the juice-shop results. 1`] = `
     },
     "category": "X-Content-Type-Options Header Missing",
     "description": "The Anti-MIME-Sniffing header X-Content-Type-Options was not set to 'nosniff'. This allows older versions of Internet Explorer and Chrome to perform MIME-sniffing on the response body, potentially causing the response body to be interpreted and displayed as a content type other than the declared content type. Current (early 2014) and legacy versions of Firefox will use the declared content type (if one is set), rather than performing MIME-sniffing.",
-    "hint": undefined,
+    "hint": null,
     "location": "http://juice-shop:3000",
     "mitigation": "Ensure that the application/web server sets the Content-Type header appropriately, and that it sets the X-Content-Type-Options header to 'nosniff' for all web pages.If possible, ensure that the end user uses a standards-compliant and modern web browser that does not perform MIME-sniffing at all, or that can be directed by the web application/web server to not perform MIME-sniffing.",
     "name": "X-Content-Type-Options Header Missing",
     "osi_layer": "APPLICATION",
+    "references": [
+      {
+        "type": "URL",
+        "value": "http://msdn.microsoft.com/en-us/library/ie/gg622941%28v=vs.85%29.aspx",
+      },
+      {
+        "type": "URL",
+        "value": "https://owasp.org/www-community/Security_Headers",
+      },
+      {
+        "type": "CWE",
+        "value": "CWE-16",
+      },
+      {
+        "type": "URL",
+        "value": "https://cwe.mitre.org/data/definitions/16.html",
+      },
+    ],
     "severity": "LOW",
   },
   {
@@ -4281,11 +4949,25 @@ exports[`Parsing the juice-shop results. 1`] = `
     },
     "category": "Information Disclosure - Suspicious Comments",
     "description": "The response appears to contain suspicious comments which may help an attacker. Note: Matches made within script blocks or files are against the entire content not only comments.",
-    "hint": undefined,
+    "hint": null,
     "location": "http://juice-shop:3000",
     "mitigation": "Remove all comments that return information that may help an attacker and fix any underlying problems they refer to.",
     "name": "Information Disclosure - Suspicious Comments",
     "osi_layer": "APPLICATION",
+    "references": [
+      {
+        "type": "URL",
+        "value": "",
+      },
+      {
+        "type": "CWE",
+        "value": "CWE-200",
+      },
+      {
+        "type": "URL",
+        "value": "https://cwe.mitre.org/data/definitions/200.html",
+      },
+    ],
     "severity": "INFORMATIONAL",
   },
   {
@@ -4358,11 +5040,49 @@ exports[`Parsing the juice-shop results. 1`] = `
     },
     "category": "Content Security Policy (CSP) Header Not Set",
     "description": "Content Security Policy (CSP) is an added layer of security that helps to detect and mitigate certain types of attacks, including Cross Site Scripting (XSS) and data injection attacks. These attacks are used for everything from data theft to site defacement or distribution of malware. CSP provides a set of standard HTTP headers that allow website owners to declare approved sources of content that browsers should be allowed to load on that page — covered types are JavaScript, CSS, HTML frames, fonts, images and embeddable objects such as Java applets, ActiveX, audio and video files.",
-    "hint": undefined,
+    "hint": null,
     "location": "http://juice-shop:3000",
     "mitigation": "Ensure that your web server, application server, load balancer, etc. is configured to set the Content-Security-Policy header, to achieve optimal browser support: "Content-Security-Policy" for Chrome 25+, Firefox 23+ and Safari 7+, "X-Content-Security-Policy" for Firefox 4.0+ and Internet Explorer 10+, and "X-WebKit-CSP" for Chrome 14+ and Safari 6+.",
     "name": "Content Security Policy (CSP) Header Not Set",
     "osi_layer": "APPLICATION",
+    "references": [
+      {
+        "type": "URL",
+        "value": "https://developer.mozilla.org/en-US/docs/Web/Security/CSP/Introducing_Content_Security_Policy",
+      },
+      {
+        "type": "URL",
+        "value": "https://cheatsheetseries.owasp.org/cheatsheets/Content_Security_Policy_Cheat_Sheet.html",
+      },
+      {
+        "type": "URL",
+        "value": "http://www.w3.org/TR/CSP/",
+      },
+      {
+        "type": "URL",
+        "value": "http://w3c.github.io/webappsec/specs/content-security-policy/csp-specification.dev.html",
+      },
+      {
+        "type": "URL",
+        "value": "http://www.html5rocks.com/en/tutorials/security/content-security-policy/",
+      },
+      {
+        "type": "URL",
+        "value": "http://caniuse.com/#feat=contentsecuritypolicy",
+      },
+      {
+        "type": "URL",
+        "value": "http://content-security-policy.com/",
+      },
+      {
+        "type": "CWE",
+        "value": "CWE-16",
+      },
+      {
+        "type": "URL",
+        "value": "https://cwe.mitre.org/data/definitions/16.html",
+      },
+    ],
     "severity": "LOW",
   },
   {
@@ -4419,11 +5139,25 @@ exports[`Parsing the juice-shop results. 1`] = `
     },
     "category": "Cross-Domain JavaScript Source File Inclusion",
     "description": "The page includes one or more script files from a third-party domain.",
-    "hint": undefined,
+    "hint": null,
     "location": "http://juice-shop:3000",
     "mitigation": "Ensure JavaScript source files are loaded from only trusted sources, and the sources can't be controlled by end users of the application.",
     "name": "Cross-Domain JavaScript Source File Inclusion",
     "osi_layer": "APPLICATION",
+    "references": [
+      {
+        "type": "URL",
+        "value": "",
+      },
+      {
+        "type": "CWE",
+        "value": "CWE-829",
+      },
+      {
+        "type": "URL",
+        "value": "https://cwe.mitre.org/data/definitions/829.html",
+      },
+    ],
     "severity": "LOW",
   },
   {
@@ -4454,11 +5188,25 @@ exports[`Parsing the juice-shop results. 1`] = `
     },
     "category": "X-Frame-Options Header Not Set",
     "description": "X-Frame-Options header is not included in the HTTP response to protect against 'ClickJacking' attacks.",
-    "hint": undefined,
+    "hint": null,
     "location": "http://juice-shop:3000",
     "mitigation": "Most modern Web browsers support the X-Frame-Options HTTP header. Ensure it's set on all web pages returned by your site (if you expect the page to be framed only by pages on your server (e.g. it's part of a FRAMESET) then you'll want to use SAMEORIGIN, otherwise if you never expect the page to be framed, you should use DENY. ALLOW-FROM allows specific websites to frame the web page in supported web browsers).",
     "name": "X-Frame-Options Header Not Set",
     "osi_layer": "APPLICATION",
+    "references": [
+      {
+        "type": "URL",
+        "value": "https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/X-Frame-Options",
+      },
+      {
+        "type": "CWE",
+        "value": "CWE-16",
+      },
+      {
+        "type": "URL",
+        "value": "https://cwe.mitre.org/data/definitions/16.html",
+      },
+    ],
     "severity": "MEDIUM",
   },
   {
@@ -4484,11 +5232,25 @@ exports[`Parsing the juice-shop results. 1`] = `
     },
     "category": "Private IP Disclosure",
     "description": "A private IP (such as 10.x.x.x, 172.x.x.x, 192.168.x.x) or an Amazon EC2 private hostname (for example, ip-10-0-56-78) has been found in the HTTP response body. This information might be helpful for further attacks targeting internal systems.",
-    "hint": undefined,
+    "hint": null,
     "location": "http://juice-shop:3000",
     "mitigation": "Remove the private IP address from the HTTP response body.  For comments, use JSP/ASP/PHP comment instead of HTML/JavaScript comment which can be seen by client browsers.",
     "name": "Private IP Disclosure",
     "osi_layer": "APPLICATION",
+    "references": [
+      {
+        "type": "URL",
+        "value": "https://tools.ietf.org/html/rfc1918",
+      },
+      {
+        "type": "CWE",
+        "value": "CWE-200",
+      },
+      {
+        "type": "URL",
+        "value": "https://cwe.mitre.org/data/definitions/200.html",
+      },
+    ],
     "severity": "LOW",
   },
 ]

--- a/scanners/zap/parser/parser.js
+++ b/scanners/zap/parser/parser.js
@@ -57,28 +57,24 @@ function createFindingFromAlert(alert, { location, host, port }) {
   }
 
   const urlList = alert.reference.split('<p>').filter(item => item !== '').map(item => stripHtmlTags(item));
-  let references = []
-  urlList.forEach(element => {
-    references.push(
+  const urlReferences = urlList.map(element => ({
+    type: "URL",
+    value: element,
+  }));
+  
+  const cweReferences = (alert.cweid !== '-1' && alert.cweid !== undefined) ? [
     {
-      "type": "URL",
-      "value": element
-    });
-  });
-
-  if(alert.cweid !== '-1' && alert.cweid !== undefined){
-    references.push(
-      {
-        "type": "CWE",
-        "value": "CWE-" + alert.cweid
-      },
-      {
-        "type": "URL",
-        "value": "https://cwe.mitre.org/data/definitions/" + alert.cweid + ".html"
-      });
-  }
- 
-  console.log(references);
+      type: "CWE",
+      value: "CWE-" + alert.cweid,
+    },
+    {
+      type: "URL",
+      value: "https://cwe.mitre.org/data/definitions/" + alert.cweid + ".html",
+    },
+  ] : [];
+  
+  const references = [...urlReferences, ...cweReferences];
+  
 
   return {
     name: stripHtmlTags(alert.name),


### PR DESCRIPTION
## Description
<!-- Please describe briefly which issue is solved by your PR or which enhancement it brings -->
closes #519 
Adds `references` attribute to finding schema that follows the following format:
```yaml
"references": [
      {
        "type": "URL",
        "value": "https://www.netspi.com/blog/technical/network-penetration-testing/analyzing-dns-txt-records-to-fingerprint-service-providers/",
      },
      {
        "type": "CWE",
        "value": "CWE-200",
      },
      {
        "type": "URL",
        "value": "https://cwe.mitre.org/data/definitions/cwe-200.html",
      },
    ],
```
This was done to the following scanners:

- [X] cmseek
- [X]  trivy
- [X]  wpscan
- [X]  semgrep
- [X]  zap
- [X]  Nikto
- [X]  Nuclei

These were chosen because they mention their CVE/CWE in their findings
### Checklist

* [x] Test your changes as thoroughly as possible before you commit them. Preferably, automate your test by unit/integration tests.
* [x] Make sure that all your commits are signed-off and that you are added to the [Contributors](https://github.com/secureCodeBox/secureCodeBox/blob/main/CONTRIBUTORS.md) file.
* [x] Make sure that all CI finish successfully.
* [x] Optional (but appreciated): Make sure that all commits are [Verified](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits).
