### PR TITLE
Renames the hook.image.repository of update-field hook

### DIFF
--- a/hooks/update-field-hook/values.yaml
+++ b/hooks/update-field-hook/values.yaml
@@ -18,7 +18,7 @@ attribute:
 hook:
   image:
     # hook.image.repository -- Hook image repository
-    repository: docker.io/securecodebox/hook-update-field
+    repository: docker.io/securecodebox/hook-update-field-hook
     # hook.image.tag -- The image Tag defaults to the charts version if not defined.
     # @default -- defaults to the charts version
     tag: null


### PR DESCRIPTION
## Description
<!-- Please describe briefly which issue is solved by your PR or which enhancement it brings -->
In #1282, to fix the install.sh script, the update-field hook folder and its references were renamed 
Renaming the values.yaml was missed. This fixes that.

### Checklist

* [ ] Test your changes as thoroughly as possible before you commit them. Preferably, automate your test by unit/integration tests.
* [ ] Make sure that all your commits are signed-off and that you are added to the [Contributors](https://github.com/secureCodeBox/secureCodeBox/blob/main/CONTRIBUTORS.md) file.
* [ ] Make sure that all CI finish successfully.
* [ ] Optional (but appreciated): Make sure that all commits are [Verified](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits).
