### PR TITLE
#1741 decrease number of expected results

### DIFF
--- a/scanners/nuclei/integration-tests/nuclei.test.js
+++ b/scanners/nuclei/integration-tests/nuclei.test.js
@@ -16,9 +16,9 @@ test(
       180
     );
 
-    expect(count).toBeGreaterThanOrEqual(20);
-    expect(severities["informational"]).toBeGreaterThanOrEqual(20);
-    expect(categories["http-missing-security-headers"]).toBeGreaterThanOrEqual(15);
+    expect(count).toBeGreaterThanOrEqual(15);
+    expect(severities["informational"]).toBeGreaterThanOrEqual(15);
+    expect(categories["http-missing-security-headers"]).toBeGreaterThanOrEqual(8);
     expect(categories["tomcat-detect"]).toBe(1);
   },
   3 * 60 * 1000


### PR DESCRIPTION
Apparently some nuclei scan rules have been removed, which causes the expected results to be smaller then the previously expected results.

I've checked locally and especially the `http-missing-security-headers` findings have been reduced (from >15 to 11)