### PR TITLE
Allow to configure env and volumes in hooks

### DIFF
--- a/hooks/cascading-scans/templates/cascading-scans-hook.yaml
+++ b/hooks/cascading-scans/templates/cascading-scans-hook.yaml
@@ -17,6 +17,8 @@ spec:
   type: ReadOnly
   image: "{{ .Values.hook.image.repository }}:{{ .Values.hook.image.tag | default .Chart.Version }}"
   ttlSecondsAfterFinished: {{ .Values.hook.ttlSecondsAfterFinished }}
+  env: 
+    {{- toYaml .Values.hook.env | nindent 4 }}
   serviceAccountName: cascading-scans
   affinity:
     {{- toYaml .Values.hook.affinity | nindent 4 }}
@@ -30,3 +32,7 @@ spec:
   resources:
     {{- toYaml . | nindent 4 }}
   {{- end }}
+  volumes:
+    {{- toYaml .Values.hook.extraVolumes | nindent 4 }}
+  volumeMounts:
+    {{- toYaml .Values.hook.extraVolumeMounts | nindent 4 }}

--- a/hooks/cascading-scans/values.yaml
+++ b/hooks/cascading-scans/values.yaml
@@ -35,3 +35,12 @@ hook:
   # -- Optional resources lets you control resource limits and requests for the hook container. See https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
   # @default -- { requests: { cpu: "200m", memory: "100Mi" }, limits: { cpu: "400m", memory: "200Mi" } }
   resources: {}
+
+  # hook.extraVolumes -- Optional Volumes mapped into the hook (see: https://kubernetes.io/docs/concepts/storage/volumes/)
+  extraVolumes: []
+
+  # hook.extraVolumeMounts -- Optional VolumeMounts mapped into the hook (see: https://kubernetes.io/docs/concepts/storage/volumes/)
+  extraVolumeMounts: []
+
+  # hook.env -- Optional environment variables mapped into the hook (see: https://kubernetes.io/docs/tasks/inject-data-application/define-environment-variable-container/)
+  env: []

--- a/hooks/finding-post-processing/templates/finding-post-processing-hook.yaml
+++ b/hooks/finding-post-processing/templates/finding-post-processing-hook.yaml
@@ -19,6 +19,9 @@ spec:
   env:
     - name: RULES
       value: {{ .Values.rules | toJson | quote }}
+    {{ if .Values.hook.env }}
+    {{- toYaml .Values.hook.env | nindent 4 }}
+    {{ end }}
   affinity:
     {{- toYaml .Values.hook.affinity | nindent 4 }}
   tolerations:
@@ -31,3 +34,7 @@ spec:
   resources:
     {{- toYaml . | nindent 4 }}
   {{- end }}
+  volumes:
+    {{- toYaml .Values.hook.extraVolumes | nindent 4 }}
+  volumeMounts:
+    {{- toYaml .Values.hook.extraVolumeMounts | nindent 4 }}

--- a/hooks/finding-post-processing/values.yaml
+++ b/hooks/finding-post-processing/values.yaml
@@ -51,3 +51,12 @@ hook:
   # -- Optional resources lets you control resource limits and requests for the hook container. See https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
   # @default -- { requests: { cpu: "200m", memory: "100Mi" }, limits: { cpu: "400m", memory: "200Mi" } }
   resources: {}
+
+  # hook.extraVolumes -- Optional Volumes mapped into the hook (see: https://kubernetes.io/docs/concepts/storage/volumes/)
+  extraVolumes: []
+
+  # hook.extraVolumeMounts -- Optional VolumeMounts mapped into the hook (see: https://kubernetes.io/docs/concepts/storage/volumes/)
+  extraVolumeMounts: []
+
+  # hook.env -- Optional environment variables mapped into the hook (see: https://kubernetes.io/docs/tasks/inject-data-application/define-environment-variable-container/)
+  env: []

--- a/hooks/generic-webhook/templates/webhook-hook.yaml
+++ b/hooks/generic-webhook/templates/webhook-hook.yaml
@@ -43,6 +43,9 @@ spec:
           name: {{ .Values.hook.authentication.apikey.userSecret }}
           key: {{ .Values.hook.authentication.apikey.headerValueKey }}
           optional: true
+    {{ if .Values.hook.env }}
+    {{- toYaml .Values.hook.env | nindent 4 }}
+    {{ end }}
   affinity:
     {{- toYaml .Values.hook.affinity | nindent 4 }}
   tolerations:
@@ -55,3 +58,7 @@ spec:
   resources:
     {{- toYaml . | nindent 4 }}
   {{- end }}
+  volumes:
+    {{- toYaml .Values.hook.extraVolumes | nindent 4 }}
+  volumeMounts:
+    {{- toYaml .Values.hook.extraVolumeMounts | nindent 4 }}

--- a/hooks/generic-webhook/values.yaml
+++ b/hooks/generic-webhook/values.yaml
@@ -55,3 +55,12 @@ hook:
   # -- Optional resources lets you control resource limits and requests for the hook container. See https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
   # @default -- { requests: { cpu: "200m", memory: "100Mi" }, limits: { cpu: "400m", memory: "200Mi" } }
   resources: {}
+
+  # hook.extraVolumes -- Optional Volumes mapped into the hook (see: https://kubernetes.io/docs/concepts/storage/volumes/)
+  extraVolumes: []
+
+  # hook.extraVolumeMounts -- Optional VolumeMounts mapped into the hook (see: https://kubernetes.io/docs/concepts/storage/volumes/)
+  extraVolumeMounts: []
+
+  # hook.env -- Optional environment variables mapped into the hook (see: https://kubernetes.io/docs/tasks/inject-data-application/define-environment-variable-container/)
+  env: []

--- a/hooks/notification/.helm-docs.gotmpl
+++ b/hooks/notification/.helm-docs.gotmpl
@@ -35,7 +35,7 @@ You can customise the message templates on your behalf or use the already provid
 Installing the Notification hook will add a ReadOnly Hook to your namespace.
 
 ```bash
-helm upgrade --install nwh ./hooks/notification-hook/ --values /path/to/your/values"
+helm upgrade --install notification ./hooks/notification/ --values /path/to/your/values"
 ```
 
 The `values.yaml` you need depends on the notification type you want to use.

--- a/hooks/notification/templates/notification-hook.yaml
+++ b/hooks/notification/templates/notification-hook.yaml
@@ -26,6 +26,9 @@ spec:
       configMap:
         name: {{ .Values.customTemplateMap.name }} 
     {{ end }}
+    {{ if .Values.hook.extraVolumes }}
+    {{- toYaml .Values.hook.extraVolumes | nindent 4 }}
+    {{ end }}
   volumeMounts:
     - name: {{ .Release.Name }}-config
       mountPath: /home/app/config
@@ -34,8 +37,14 @@ spec:
     - name: {{ .Release.Name }}-custom-templates
       mountPath: /home/app/hook-wrapper/hook/notification-templates 
     {{ end }}
+    {{ if .Values.hook.extraVolumeMounts }}
+    {{- toYaml .Values.hook.extraVolumeMounts | nindent 4 }}
+    {{ end }}
   env:
     {{- toYaml .Values.env | nindent 4}} 
+    {{ if .Values.hook.env }}
+    {{- toYaml .Values.hook.env | nindent 4 }}
+    {{ end }}
   affinity:
     {{- toYaml .Values.hook.affinity | nindent 4 }}
   tolerations:

--- a/hooks/notification/values.yaml
+++ b/hooks/notification/values.yaml
@@ -38,6 +38,15 @@ hook:
   # @default -- { requests: { cpu: "200m", memory: "100Mi" }, limits: { cpu: "400m", memory: "200Mi" } }
   resources: {}
 
+  # hook.extraVolumes -- Optional Volumes mapped into the hook (see: https://kubernetes.io/docs/concepts/storage/volumes/)
+  extraVolumes: []
+
+  # hook.extraVolumeMounts -- Optional VolumeMounts mapped into the hook (see: https://kubernetes.io/docs/concepts/storage/volumes/)
+  extraVolumeMounts: []
+
+  # hook.env -- Optional environment variables mapped into the hook (see: https://kubernetes.io/docs/tasks/inject-data-application/define-environment-variable-container/)
+  env: []
+
 notificationChannels:
   - name: slack
     type: slack

--- a/hooks/persistence-azure-monitor/templates/persistence-provider.yaml
+++ b/hooks/persistence-azure-monitor/templates/persistence-provider.yaml
@@ -30,9 +30,9 @@ spec:
         secretKeyRef:
           name: {{ .Values.monitor.authentication.apiKeySecret }}
           key: sharedkey
-    {{- if .Values.hook.env }}
+    {{ if .Values.hook.env }}
     {{- toYaml .Values.hook.env | nindent 4 }}
-    {{- end -}}
+    {{ end }}
   {{- with .Values.imagePullSecrets }}
   imagePullSecrets:
     {{- toYaml . | nindent 4 }}

--- a/hooks/persistence-azure-monitor/templates/persistence-provider.yaml
+++ b/hooks/persistence-azure-monitor/templates/persistence-provider.yaml
@@ -30,6 +30,9 @@ spec:
         secretKeyRef:
           name: {{ .Values.monitor.authentication.apiKeySecret }}
           key: sharedkey
+    {{- if .Values.hook.env }}
+    {{- toYaml .Values.hook.env | nindent 4 }}
+    {{- end -}}
   {{- with .Values.imagePullSecrets }}
   imagePullSecrets:
     {{- toYaml . | nindent 4 }}
@@ -38,3 +41,7 @@ spec:
   resources:
     {{- toYaml . | nindent 4 }}
   {{- end }}
+  volumes:
+    {{- toYaml .Values.hook.extraVolumes | nindent 4 }}
+  volumeMounts:
+    {{- toYaml .Values.hook.extraVolumeMounts | nindent 4 }}

--- a/hooks/persistence-azure-monitor/values.yaml
+++ b/hooks/persistence-azure-monitor/values.yaml
@@ -38,6 +38,15 @@ hook:
   # @default -- { requests: { cpu: "200m", memory: "100Mi" }, limits: { cpu: "400m", memory: "200Mi" } }
   resources: {}
 
+  # hook.extraVolumes -- Optional Volumes mapped into the hook (see: https://kubernetes.io/docs/concepts/storage/volumes/)
+  extraVolumes: []
+
+  # hook.extraVolumeMounts -- Optional VolumeMounts mapped into the hook (see: https://kubernetes.io/docs/concepts/storage/volumes/)
+  extraVolumeMounts: []
+
+  # hook.env -- Optional environment variables mapped into the hook (see: https://kubernetes.io/docs/tasks/inject-data-application/define-environment-variable-container/)
+  env: []
+
 monitor:
   # monitor.logtype -- Configure the Logtype that the hook should use in Azure Monitor
   logtypePrefix: "SCB"

--- a/hooks/persistence-defectdojo/.helm-docs.gotmpl
+++ b/hooks/persistence-defectdojo/.helm-docs.gotmpl
@@ -115,6 +115,15 @@ If the engagement doesn't exist the hook will create the engagement (CI/CD engag
 (product & product type). The hook will then pull the imported information from DefectDojo and use them to replace the 
 findings inside secureCodeBox.
 
+In case you use a DefectDojo instance with a self-signed root CA, upgrade the hook with:
+```bash
+helm upgrade --install dd secureCodeBox/persistence-defectdojo \
+    --set="defectdojo.url=https://defectdojo-django.default.svc" \
+    --set-json 'hook.extraVolumes=[{"name": "ca-dojo", "configMap": {"name": "ca-dojo"}}]' \
+    --set-json 'hook.extraVolumeMounts=[{"name": "ca-dojo", "mountPath": "/etc/ssl/certs/java/cacerts", "subPath": "cacerts", "readOnly": false}]'
+```
+After, you can update `/etc/ssl/certs/java/cacerts` with your certificate.
+
 You don't need any configuration for that to work, the hook will infer engagement & product names from the scan name.
 If you want more control over the names or add additional meta information like the version of the tested software you
 can add these via annotation to the scan. See examples below.
@@ -215,7 +224,7 @@ The secureCodeBox DefectDojo Hook can be configured to run with such a token of 
 kubectl create secret generic defectdojo-credentials --from-literal="apikey=08b7..."
 
 helm upgrade --install dd secureCodeBox/persistence-defectdojo \
-    --set="defectdojo.url=https://defectdojo-django.default.svc" \
+    --set="defectdojo.url=http://defectdojo-django.default.svc" \
     --set="defectdojo.lowPrivilegedMode=true" \
     --set="defectdojo.authentication.userId=42"
 ```

--- a/hooks/persistence-defectdojo/templates/persistence-provider.yaml
+++ b/hooks/persistence-defectdojo/templates/persistence-provider.yaml
@@ -42,6 +42,9 @@ spec:
           key: {{ .Values.defectdojo.authentication.apiKeyKey }}
     - name: DEFECTDOJO_LOW_PRIVILEGED_MODE
       value: {{ .Values.defectdojo.lowPrivilegedMode | quote }}
+    {{- if .Values.hook.env }}
+    {{- toYaml .Values.hook.env | nindent 4 }}
+    {{- end -}}
   {{- with .Values.imagePullSecrets }}
   imagePullSecrets:
     {{- toYaml . | nindent 4 }}
@@ -50,3 +53,7 @@ spec:
   resources:
     {{- toYaml . | nindent 4 }}
   {{- end }}
+  volumes:
+    {{- toYaml .Values.hook.extraVolumes | nindent 4 }}
+  volumeMounts:
+    {{- toYaml .Values.hook.extraVolumeMounts | nindent 4 }}

--- a/hooks/persistence-defectdojo/templates/persistence-provider.yaml
+++ b/hooks/persistence-defectdojo/templates/persistence-provider.yaml
@@ -42,9 +42,9 @@ spec:
           key: {{ .Values.defectdojo.authentication.apiKeyKey }}
     - name: DEFECTDOJO_LOW_PRIVILEGED_MODE
       value: {{ .Values.defectdojo.lowPrivilegedMode | quote }}
-    {{- if .Values.hook.env }}
+    {{ if .Values.hook.env }}
     {{- toYaml .Values.hook.env | nindent 4 }}
-    {{- end -}}
+    {{ end }}
   {{- with .Values.imagePullSecrets }}
   imagePullSecrets:
     {{- toYaml . | nindent 4 }}

--- a/hooks/persistence-defectdojo/values.yaml
+++ b/hooks/persistence-defectdojo/values.yaml
@@ -38,6 +38,15 @@ hook:
   # @default -- { requests: { cpu: "200m", memory: "100Mi" }, limits: { cpu: "400m", memory: "200Mi" } }
   resources: {}
 
+  # hook.extraVolumes -- Optional Volumes mapped into the hook (see: https://kubernetes.io/docs/concepts/storage/volumes/)
+  extraVolumes: []
+
+  # hook.extraVolumeMounts -- Optional VolumeMounts mapped into the hook (see: https://kubernetes.io/docs/concepts/storage/volumes/)
+  extraVolumeMounts: []
+
+  # hook.env -- Optional environment variables mapped into the hook (see: https://kubernetes.io/docs/tasks/inject-data-application/define-environment-variable-container/)
+  env: []
+
 defectdojo:
   # -- Syncs back (two way sync) all imported findings from DefectDojo to SCB Findings Store. When set to false the hook will only import the findings to DefectDojo (one way sync).
   syncFindingsBack: true

--- a/hooks/persistence-elastic/templates/persistence-provider.yaml
+++ b/hooks/persistence-elastic/templates/persistence-provider.yaml
@@ -54,9 +54,9 @@ spec:
           name: {{ .Values.authentication.apiKeySecret }}
           key: id
 {{- end }}
-    {{- if .Values.hook.env }}
+    {{ if .Values.hook.env }}
     {{- toYaml .Values.hook.env | nindent 4 }}
-    {{- end -}}
+    {{ end }}
   {{- with .Values.imagePullSecrets }}
   imagePullSecrets:
     {{- toYaml . | nindent 4 }}

--- a/hooks/persistence-elastic/templates/persistence-provider.yaml
+++ b/hooks/persistence-elastic/templates/persistence-provider.yaml
@@ -54,6 +54,9 @@ spec:
           name: {{ .Values.authentication.apiKeySecret }}
           key: id
 {{- end }}
+    {{- if .Values.hook.env }}
+    {{- toYaml .Values.hook.env | nindent 4 }}
+    {{- end -}}
   {{- with .Values.imagePullSecrets }}
   imagePullSecrets:
     {{- toYaml . | nindent 4 }}
@@ -62,3 +65,7 @@ spec:
   resources:
     {{- toYaml . | nindent 4 }}
   {{- end }}
+  volumes:
+    {{- toYaml .Values.hook.extraVolumes | nindent 4 }}
+  volumeMounts:
+    {{- toYaml .Values.hook.extraVolumeMounts | nindent 4 }}

--- a/hooks/persistence-elastic/values.yaml
+++ b/hooks/persistence-elastic/values.yaml
@@ -108,3 +108,12 @@ hook:
   # -- Optional resources lets you control resource limits and requests for the hook container. See https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
   # @default -- { requests: { cpu: "200m", memory: "100Mi" }, limits: { cpu: "400m", memory: "200Mi" } }
   resources: {}
+
+  # hook.extraVolumes -- Optional Volumes mapped into the hook (see: https://kubernetes.io/docs/concepts/storage/volumes/)
+  extraVolumes: []
+
+  # hook.extraVolumeMounts -- Optional VolumeMounts mapped into the hook (see: https://kubernetes.io/docs/concepts/storage/volumes/)
+  extraVolumeMounts: []
+
+  # hook.env -- Optional environment variables mapped into the hook (see: https://kubernetes.io/docs/tasks/inject-data-application/define-environment-variable-container/)
+  env: []

--- a/hooks/update-field-hook/templates/update-field-hook.yaml
+++ b/hooks/update-field-hook/templates/update-field-hook.yaml
@@ -21,6 +21,9 @@ spec:
       value: {{ .Values.attribute.name | quote }}
     - name: ATTRIBUTE_VALUE
       value: {{ .Values.attribute.value | quote }}
+    {{- if .Values.hook.env }}
+    {{- toYaml .Values.hook.env | nindent 4 }}
+    {{- end -}}
   affinity:
     {{- toYaml .Values.hook.affinity | nindent 4 }}
   tolerations:
@@ -33,3 +36,7 @@ spec:
   resources:
     {{- toYaml . | nindent 4 }}
   {{- end }}
+  volumes:
+    {{- toYaml .Values.hook.extraVolumes | nindent 4 }}
+  volumeMounts:
+    {{- toYaml .Values.hook.extraVolumeMounts | nindent 4 }}

--- a/hooks/update-field-hook/templates/update-field-hook.yaml
+++ b/hooks/update-field-hook/templates/update-field-hook.yaml
@@ -21,9 +21,9 @@ spec:
       value: {{ .Values.attribute.name | quote }}
     - name: ATTRIBUTE_VALUE
       value: {{ .Values.attribute.value | quote }}
-    {{- if .Values.hook.env }}
+    {{ if .Values.hook.env }}
     {{- toYaml .Values.hook.env | nindent 4 }}
-    {{- end -}}
+    {{ end }}
   affinity:
     {{- toYaml .Values.hook.affinity | nindent 4 }}
   tolerations:

--- a/hooks/update-field-hook/values.yaml
+++ b/hooks/update-field-hook/values.yaml
@@ -41,3 +41,12 @@ hook:
   # -- Optional resources lets you control resource limits and requests for the hook container. See https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
   # @default -- { requests: { cpu: "200m", memory: "100Mi" }, limits: { cpu: "400m", memory: "200Mi" } }
   resources: {}
+
+  # hook.extraVolumes -- Optional Volumes mapped into the hook (see: https://kubernetes.io/docs/concepts/storage/volumes/)
+  extraVolumes: []
+
+  # hook.extraVolumeMounts -- Optional VolumeMounts mapped into the hook (see: https://kubernetes.io/docs/concepts/storage/volumes/)
+  extraVolumeMounts: []
+
+  # hook.env -- Optional environment variables mapped into the hook (see: https://kubernetes.io/docs/tasks/inject-data-application/define-environment-variable-container/)
+  env: []


### PR DESCRIPTION
## Description
Implements [#1763](https://github.com/secureCodeBox/secureCodeBox/issues/1763). Volumes and VolumeMounts ([here](https://kubernetes.io/docs/concepts/storage/volumes/)) are now configurable with `hook.extraVolumes` and `hook.extraVolumeMounts`. Environment variables ([here](https://kubernetes.io/docs/tasks/inject-data-application/define-environment-variable-container/)) can be added in `hook.env`.

Supported hooks:
- cascading-scans
- finding-post-processing
- generic-webhook
- notification
- persistence-azure-monitor
- persistence-defectdojo
- persistence-elastic
- update-field-hook

### Checklist

* [ ] Test your changes as thoroughly as possible before you commit them. Preferably, automate your test by unit/integration tests.
* [ ] Make sure that all your commits are signed-off and that you are added to the [Contributors](https://github.com/secureCodeBox/secureCodeBox/blob/main/CONTRIBUTORS.md) file.
* [ ] Make sure that all CI finish successfully.
* [ ] Optional (but appreciated): Make sure that all commits are [Verified](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits).
