### PR TITLE
Ignore .license files for hook helm charts

### DIFF
--- a/hooks/cascading-scans/.helmignore
+++ b/hooks/cascading-scans/.helmignore
@@ -39,3 +39,4 @@ integration-tests/*
 examples/*
 coverage/*
 Makefile
+*.license

--- a/hooks/finding-post-processing/.helmignore
+++ b/hooks/finding-post-processing/.helmignore
@@ -38,3 +38,4 @@ integration-tests/*
 examples/*
 coverage/*
 Makefile
+*.license

--- a/hooks/generic-webhook/.helmignore
+++ b/hooks/generic-webhook/.helmignore
@@ -31,9 +31,11 @@ src/*
 config/*
 Dockerfile
 .dockerignore
+docs/*
 *.tar
 hook/*
 integration-tests/*
 examples/*
-docs/*
+coverage/*
 Makefile
+*.license

--- a/hooks/notification/.helmignore
+++ b/hooks/notification/.helmignore
@@ -38,4 +38,5 @@ integration-tests/*
 examples/*
 coverage/*
 Makefile
+*.license
 

--- a/hooks/persistence-azure-monitor/.helmignore
+++ b/hooks/persistence-azure-monitor/.helmignore
@@ -38,3 +38,4 @@ integration-tests/*
 examples/*
 coverage/*
 Makefile
+*.license

--- a/hooks/persistence-defectdojo/.helmignore
+++ b/hooks/persistence-defectdojo/.helmignore
@@ -39,3 +39,4 @@ integration-tests/*
 examples/*
 coverage/*
 Makefile
+*.license

--- a/hooks/update-field-hook/.helmignore
+++ b/hooks/update-field-hook/.helmignore
@@ -31,9 +31,11 @@ src/*
 config/*
 Dockerfile
 .dockerignore
+docs/*
 *.tar
 hook/*
 integration-tests/*
 examples/*
-docs/*
+coverage/*
 Makefile
+*.license


### PR DESCRIPTION
## Description

Ignores .license files for hook charts to prevent error publishing the charts as they .license files cause troubles in the charts/ sub directories.

### Checklist

* [x] Test your changes as thoroughly as possible before you commit them. Preferably, automate your test by unit/integration tests.
* [x] Make sure that all your commits are signed-off and that you are added to the [Contributors](https://github.com/secureCodeBox/secureCodeBox/blob/main/CONTRIBUTORS.md) file.
* [ ] Make sure that all CI finish successfully.
* [x] Optional (but appreciated): Make sure that all commits are [Verified](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits).
