### PR TITLE
Remove 'interval' from required properties as ScheduledScan can be defined by 'schedule' too

### DIFF
--- a/operator/crds/execution.securecodebox.io_scheduledscans.yaml
+++ b/operator/crds/execution.securecodebox.io_scheduledscans.yaml
@@ -4825,7 +4825,6 @@ spec:
                   minimum: 0
                   type: integer
               required:
-                - interval
                 - scanSpec
               type: object
             status:


### PR DESCRIPTION
## Description
Fixes [#1993](https://github.com/secureCodeBox/secureCodeBox/issues/1993)

 A ScheduledScan can be defined by `ìnterval` or `schedule` property. Thus, none of these attributes should be `required`. We already check for the existance of one of the twos in [here](https://github.com/secureCodeBox/secureCodeBox/blob/main/operator/controllers/execution/scheduledscan_controller.go#L224)

### Checklist

* [ ] Test your changes as thoroughly as possible before you commit them. Preferably, automate your test by unit/integration tests.
* [ ] Make sure that all your commits are signed-off and that you are added to the [Contributors](https://github.com/secureCodeBox/secureCodeBox/blob/main/CONTRIBUTORS.md) file.
* [ ] Make sure that all CI finish successfully.
* [ ] Optional (but appreciated): Make sure that all commits are [Verified](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits).
