### PR TITLE
Add missing affinity and tolerations properties to hooks

### DIFF
--- a/hooks/persistence-azure-monitor/templates/persistence-provider.yaml
+++ b/hooks/persistence-azure-monitor/templates/persistence-provider.yaml
@@ -33,6 +33,10 @@ spec:
     {{ if .Values.hook.env }}
     {{- toYaml .Values.hook.env | nindent 4 }}
     {{ end }}
+  affinity:
+    {{- toYaml .Values.hook.affinity | nindent 4 }}
+  tolerations:
+    {{- toYaml .Values.hook.tolerations | nindent 4 }}
   {{- with .Values.imagePullSecrets }}
   imagePullSecrets:
     {{- toYaml . | nindent 4 }}

--- a/hooks/persistence-defectdojo/templates/persistence-provider.yaml
+++ b/hooks/persistence-defectdojo/templates/persistence-provider.yaml
@@ -45,6 +45,10 @@ spec:
     {{ if .Values.hook.env }}
     {{- toYaml .Values.hook.env | nindent 4 }}
     {{ end }}
+  affinity:
+    {{- toYaml .Values.hook.affinity | nindent 4 }}
+  tolerations:
+    {{- toYaml .Values.hook.tolerations | nindent 4 }}
   {{- with .Values.imagePullSecrets }}
   imagePullSecrets:
     {{- toYaml . | nindent 4 }}

--- a/hooks/persistence-elastic/templates/persistence-provider.yaml
+++ b/hooks/persistence-elastic/templates/persistence-provider.yaml
@@ -57,6 +57,10 @@ spec:
     {{ if .Values.hook.env }}
     {{- toYaml .Values.hook.env | nindent 4 }}
     {{ end }}
+  affinity:
+    {{- toYaml .Values.hook.affinity | nindent 4 }}
+  tolerations:
+    {{- toYaml .Values.hook.tolerations | nindent 4 }}
   {{- with .Values.imagePullSecrets }}
   imagePullSecrets:
     {{- toYaml . | nindent 4 }}


### PR DESCRIPTION
## Description
Fixes [#1972](https://github.com/secureCodeBox/secureCodeBox/issues/1972)

The `persistence-azure-monitor`, `persistence-elastic`, and `persistence-defectdojo` are missing the `affinity` and `tolerations` property in their provider template. We add them according to the other hooks

### Checklist

* [ ] Test your changes as thoroughly as possible before you commit them. Preferably, automate your test by unit/integration tests.
* [ ] Make sure that all your commits are signed-off and that you are added to the [Contributors](https://github.com/secureCodeBox/secureCodeBox/blob/main/CONTRIBUTORS.md) file.
* [ ] Make sure that all CI finish successfully.
* [ ] Optional (but appreciated): Make sure that all commits are [Verified](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits).
