### PR TITLE
Added permission to `manager-role` ClusterRole to update 'roles'

### DIFF
--- a/operator/config/rbac/role.yaml
+++ b/operator/config/rbac/role.yaml
@@ -131,5 +131,6 @@ rules:
   verbs:
   - create
   - get
+  - update
   - list
   - watch


### PR DESCRIPTION
<!-- 
Thank you for your contribution to our Project 🙌 

Before submitting your Pull Request, please take the time to check the points below and provide some descriptive information.
* [ ] If this PR comes from a fork, please [Allow edits from maintainers](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork)
* [ ] Set a meaningful title. Format: {task_name} (closes #{issue_number}). For example: Use logger (closes #41)
* [ ] [Link your Pull Request to an issue](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) (if applicable)
* [ ] Create Draft pull requests if you need clarification or an explicit review before you can continue your work item.
* [ ] Make sure that your PR is not introducing _unnecessary_ reformatting (e.g., introduced by on-save hooks in your IDE)
* [ ] Make sure each new source file you add has a correct license header.

For more information on content related and formal acceptance criteria for PRs, please have a look at our 
[docs](https://www.securecodebox.io/docs/contributing/contribution-criteria). 
-->

## Description
<!-- Please describe briefly which issue is solved by your PR or which enhancement it brings -->

- closes #2003 
- in  #1864 ([Commit](https://github.com/secureCodeBox/secureCodeBox/pull/1864/files#diff-5c2e6520d65f675219f107c7ae56e26d0be0d74725c3614567691b02fe5c6134R103-R107))  we added parsedefinitions `get` access to the parse_reconciler. That means in upgrading the operator. The parser role needed to be updated.  However, The 'manager-role' does not permission to update roles.

Logs of Bug previous to fix:
```
1.6987528214331818e+09    INFO    controllers.execution.Scan    Matching ParseDefinition Found    {"scan_parse": "default/nikto-bodgeit", "ParseDefinition": "nikto-json"}
1.6987528214341886e+09    INFO    controllers.execution.Scan    Role already exists but not in the correct state
1.6987528214381618e+09    ERROR    controllers.execution.Scan    Failed to update Role    {"error": "roles.rbac.authorization.k8s.io \"parser\" is forbidden: User \"system:serviceaccount:securecodebox-system:securecodebox-operator\" cannot update resource \"roles\" in API group \"rbac.authorization.k8s.io\" in the namespace \"default\""}
github.com/secureCodeBox/secureCodeBox/operator/controllers/execution/scans.(*ScanReconciler).startParser
    /workspace/controllers/execution/scans/parse_reconciler.go:109
github.com/secureCodeBox/secureCodeBox/operator/controllers/execution/scans.(*ScanReconciler).Reconcile
    /workspace/controllers/execution/scans/scan_controller.go:102
sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).Reconcile
    /go/pkg/mod/sigs.k8s.io/controller-runtime@v0.12.2/pkg/internal/controller/controller.go:121
sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).reconcileHandler
    /go/pkg/mod/sigs.k8s.io/controller-runtime@v0.12.2/pkg/internal/controller/controller.go:320
sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).processNextWorkItem
    /go/pkg/mod/sigs.k8s.io/controller-runtime@v0.12.2/pkg/internal/controller/controller.go:273
sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).Start.func2.2
    /go/pkg/mod/sigs.k8s.io/controller-runtime@v0.12.2/pkg/internal/controller/controller.go:234
```
@J12934 Adding permission to `manager-role` ClusterRole to update 'roles' fixes the issue. But does that have any unintended consequences ? Like some kind of privilege escalation. AFAIK, it's fine, since you can't give access you don't have.
