### PR TITLE
Fix Outdated Slack Link

### DIFF
--- a/.helm-docs/templates.gotmpl
+++ b/.helm-docs/templates.gotmpl
@@ -79,7 +79,7 @@ As for any pre-built image usage, it is the image user's responsibility to ensur
 You are welcome, please join us on... 👋
 
 - [GitHub][scb-github]
-- [Slack][scb-slack]
+- [OWASP Slack (Channel #project-securecodebox)][scb-slack]
 - [Twitter][scb-twitter]
 
 secureCodeBox is an official [OWASP][scb-owasp] project.
@@ -99,6 +99,6 @@ Please have a look at [Contributing](./CONTRIBUTING.md)
 [scb-site]: https://www.securecodebox.io/
 [scb-github]: https://github.com/secureCodeBox/
 [scb-twitter]: https://twitter.com/secureCodeBox
-[scb-slack]: https://join.slack.com/t/securecodebox/shared_invite/enQtNDU3MTUyOTM0NTMwLTBjOWRjNjVkNGEyMjQ0ZGMyNDdlYTQxYWQ4MzNiNGY3MDMxNThkZjJmMzY2NDRhMTk3ZWM3OWFkYmY1YzUxNTU
+[scb-slack]: https://owasp.org/slack/invite
 [scb-license]: https://github.com/secureCodeBox/secureCodeBox/blob/master/LICENSE
 {{- end }}

--- a/.templates/new-scanner/README.md
+++ b/.templates/new-scanner/README.md
@@ -103,6 +103,6 @@ Code of secureCodeBox is licensed under the [Apache License 2.0][scb-license].
 [scb-site]: https://www.securecodebox.io/
 [scb-github]: https://github.com/secureCodeBox/
 [scb-twitter]: https://twitter.com/secureCodeBox
-[scb-slack]: https://join.slack.com/t/securecodebox/shared_invite/enQtNDU3MTUyOTM0NTMwLTBjOWRjNjVkNGEyMjQ0ZGMyNDdlYTQxYWQ4MzNiNGY3MDMxNThkZjJmMzY2NDRhMTk3ZWM3OWFkYmY1YzUxNTU
+[scb-slack]: https://owasp.org/slack/invite
 [scb-license]: https://github.com/secureCodeBox/secureCodeBox/blob/master/LICENSE
 Please include any links that can be used as a reference for the scanner.

--- a/auto-discovery/cloud-aws/README.md
+++ b/auto-discovery/cloud-aws/README.md
@@ -239,7 +239,7 @@ Code of secureCodeBox is licensed under the [Apache License 2.0][scb-license].
 [scb-site]: https://www.securecodebox.io/
 [scb-github]: https://github.com/secureCodeBox/
 [scb-twitter]: https://twitter.com/secureCodeBox
-[scb-slack]: https://join.slack.com/t/securecodebox/shared_invite/enQtNDU3MTUyOTM0NTMwLTBjOWRjNjVkNGEyMjQ0ZGMyNDdlYTQxYWQ4MzNiNGY3MDMxNThkZjJmMzY2NDRhMTk3ZWM3OWFkYmY1YzUxNTU
+[scb-slack]: https://owasp.org/slack/invite
 [scb-license]: https://github.com/secureCodeBox/secureCodeBox/blob/master/LICENSE
 ## Development
 

--- a/auto-discovery/cloud-aws/docs/README.ArtifactHub.md
+++ b/auto-discovery/cloud-aws/docs/README.ArtifactHub.md
@@ -231,7 +231,7 @@ Please have a look at [Contributing](./CONTRIBUTING.md)
 You are welcome, please join us on... 👋
 
 - [GitHub][scb-github]
-- [Slack][scb-slack]
+- [OWASP Slack (Channel #project-securecodebox)][scb-slack]
 - [Twitter][scb-twitter]
 
 secureCodeBox is an official [OWASP][scb-owasp] project.
@@ -246,7 +246,7 @@ Code of secureCodeBox is licensed under the [Apache License 2.0][scb-license].
 [scb-site]: https://www.securecodebox.io/
 [scb-github]: https://github.com/secureCodeBox/
 [scb-twitter]: https://twitter.com/secureCodeBox
-[scb-slack]: https://join.slack.com/t/securecodebox/shared_invite/enQtNDU3MTUyOTM0NTMwLTBjOWRjNjVkNGEyMjQ0ZGMyNDdlYTQxYWQ4MzNiNGY3MDMxNThkZjJmMzY2NDRhMTk3ZWM3OWFkYmY1YzUxNTU
+[scb-slack]: https://owasp.org/slack/invite
 [scb-license]: https://github.com/secureCodeBox/secureCodeBox/blob/master/LICENSE
 ## Development
 

--- a/auto-discovery/cloud-aws/docs/README.DockerHub-Core.md
+++ b/auto-discovery/cloud-aws/docs/README.DockerHub-Core.md
@@ -141,7 +141,7 @@ export SQS_QUEUE_URL="${queue_url}"
 You are welcome, please join us on... 👋
 
 - [GitHub][scb-github]
-- [Slack][scb-slack]
+- [OWASP Slack (Channel #project-securecodebox)][scb-slack]
 - [Twitter][scb-twitter]
 
 secureCodeBox is an official [OWASP][scb-owasp] project.
@@ -158,7 +158,7 @@ As for any pre-built image usage, it is the image user's responsibility to ensur
 [scb-site]: https://www.securecodebox.io/
 [scb-github]: https://github.com/secureCodeBox/
 [scb-twitter]: https://twitter.com/secureCodeBox
-[scb-slack]: https://join.slack.com/t/securecodebox/shared_invite/enQtNDU3MTUyOTM0NTMwLTBjOWRjNjVkNGEyMjQ0ZGMyNDdlYTQxYWQ4MzNiNGY3MDMxNThkZjJmMzY2NDRhMTk3ZWM3OWFkYmY1YzUxNTU
+[scb-slack]: https://owasp.org/slack/invite
 [scb-license]: https://github.com/secureCodeBox/secureCodeBox/blob/master/LICENSE
 ## Development
 

--- a/auto-discovery/kubernetes/README.md
+++ b/auto-discovery/kubernetes/README.md
@@ -188,7 +188,7 @@ Code of secureCodeBox is licensed under the [Apache License 2.0][scb-license].
 [scb-site]: https://www.securecodebox.io/
 [scb-github]: https://github.com/secureCodeBox/
 [scb-twitter]: https://twitter.com/secureCodeBox
-[scb-slack]: https://join.slack.com/t/securecodebox/shared_invite/enQtNDU3MTUyOTM0NTMwLTBjOWRjNjVkNGEyMjQ0ZGMyNDdlYTQxYWQ4MzNiNGY3MDMxNThkZjJmMzY2NDRhMTk3ZWM3OWFkYmY1YzUxNTU
+[scb-slack]: https://owasp.org/slack/invite
 [scb-license]: https://github.com/secureCodeBox/secureCodeBox/blob/master/LICENSE
 ## Development
 

--- a/auto-discovery/kubernetes/docs/README.ArtifactHub.md
+++ b/auto-discovery/kubernetes/docs/README.ArtifactHub.md
@@ -180,7 +180,7 @@ Please have a look at [Contributing](./CONTRIBUTING.md)
 You are welcome, please join us on... 👋
 
 - [GitHub][scb-github]
-- [Slack][scb-slack]
+- [OWASP Slack (Channel #project-securecodebox)][scb-slack]
 - [Twitter][scb-twitter]
 
 secureCodeBox is an official [OWASP][scb-owasp] project.
@@ -195,7 +195,7 @@ Code of secureCodeBox is licensed under the [Apache License 2.0][scb-license].
 [scb-site]: https://www.securecodebox.io/
 [scb-github]: https://github.com/secureCodeBox/
 [scb-twitter]: https://twitter.com/secureCodeBox
-[scb-slack]: https://join.slack.com/t/securecodebox/shared_invite/enQtNDU3MTUyOTM0NTMwLTBjOWRjNjVkNGEyMjQ0ZGMyNDdlYTQxYWQ4MzNiNGY3MDMxNThkZjJmMzY2NDRhMTk3ZWM3OWFkYmY1YzUxNTU
+[scb-slack]: https://owasp.org/slack/invite
 [scb-license]: https://github.com/secureCodeBox/secureCodeBox/blob/master/LICENSE
 ## Development
 

--- a/auto-discovery/kubernetes/docs/README.DockerHub-Core.md
+++ b/auto-discovery/kubernetes/docs/README.DockerHub-Core.md
@@ -66,7 +66,7 @@ When the ContainerAutoDiscovery is enabled, the AutoDiscovery can also create a 
 You are welcome, please join us on... 👋
 
 - [GitHub][scb-github]
-- [Slack][scb-slack]
+- [OWASP Slack (Channel #project-securecodebox)][scb-slack]
 - [Twitter][scb-twitter]
 
 secureCodeBox is an official [OWASP][scb-owasp] project.
@@ -83,7 +83,7 @@ As for any pre-built image usage, it is the image user's responsibility to ensur
 [scb-site]: https://www.securecodebox.io/
 [scb-github]: https://github.com/secureCodeBox/
 [scb-twitter]: https://twitter.com/secureCodeBox
-[scb-slack]: https://join.slack.com/t/securecodebox/shared_invite/enQtNDU3MTUyOTM0NTMwLTBjOWRjNjVkNGEyMjQ0ZGMyNDdlYTQxYWQ4MzNiNGY3MDMxNThkZjJmMzY2NDRhMTk3ZWM3OWFkYmY1YzUxNTU
+[scb-slack]: https://owasp.org/slack/invite
 [scb-license]: https://github.com/secureCodeBox/secureCodeBox/blob/master/LICENSE
 ## Development
 

--- a/demo-targets/bodgeit/README.md
+++ b/demo-targets/bodgeit/README.md
@@ -89,6 +89,6 @@ Code of secureCodeBox is licensed under the [Apache License 2.0][scb-license].
 [scb-site]: https://www.securecodebox.io/
 [scb-github]: https://github.com/secureCodeBox/
 [scb-twitter]: https://twitter.com/secureCodeBox
-[scb-slack]: https://join.slack.com/t/securecodebox/shared_invite/enQtNDU3MTUyOTM0NTMwLTBjOWRjNjVkNGEyMjQ0ZGMyNDdlYTQxYWQ4MzNiNGY3MDMxNThkZjJmMzY2NDRhMTk3ZWM3OWFkYmY1YzUxNTU
+[scb-slack]: https://owasp.org/slack/invite
 [scb-license]: https://github.com/secureCodeBox/secureCodeBox/blob/master/LICENSE
 

--- a/demo-targets/bodgeit/docs/README.ArtifactHub.md
+++ b/demo-targets/bodgeit/docs/README.ArtifactHub.md
@@ -96,7 +96,7 @@ Please have a look at [Contributing](./CONTRIBUTING.md)
 You are welcome, please join us on... 👋
 
 - [GitHub][scb-github]
-- [Slack][scb-slack]
+- [OWASP Slack (Channel #project-securecodebox)][scb-slack]
 - [Twitter][scb-twitter]
 
 secureCodeBox is an official [OWASP][scb-owasp] project.
@@ -111,6 +111,6 @@ Code of secureCodeBox is licensed under the [Apache License 2.0][scb-license].
 [scb-site]: https://www.securecodebox.io/
 [scb-github]: https://github.com/secureCodeBox/
 [scb-twitter]: https://twitter.com/secureCodeBox
-[scb-slack]: https://join.slack.com/t/securecodebox/shared_invite/enQtNDU3MTUyOTM0NTMwLTBjOWRjNjVkNGEyMjQ0ZGMyNDdlYTQxYWQ4MzNiNGY3MDMxNThkZjJmMzY2NDRhMTk3ZWM3OWFkYmY1YzUxNTU
+[scb-slack]: https://owasp.org/slack/invite
 [scb-license]: https://github.com/secureCodeBox/secureCodeBox/blob/master/LICENSE
 

--- a/demo-targets/bodgeit/docs/README.DockerHub-Target.md
+++ b/demo-targets/bodgeit/docs/README.DockerHub-Target.md
@@ -67,7 +67,7 @@ BodgeIt Store is a serverside rendering based html website without any heavy jav
 You are welcome, please join us on... 👋
 
 - [GitHub][scb-github]
-- [Slack][scb-slack]
+- [OWASP Slack (Channel #project-securecodebox)][scb-slack]
 - [Twitter][scb-twitter]
 
 secureCodeBox is an official [OWASP][scb-owasp] project.
@@ -84,6 +84,6 @@ As for any pre-built image usage, it is the image user's responsibility to ensur
 [scb-site]: https://www.securecodebox.io/
 [scb-github]: https://github.com/secureCodeBox/
 [scb-twitter]: https://twitter.com/secureCodeBox
-[scb-slack]: https://join.slack.com/t/securecodebox/shared_invite/enQtNDU3MTUyOTM0NTMwLTBjOWRjNjVkNGEyMjQ0ZGMyNDdlYTQxYWQ4MzNiNGY3MDMxNThkZjJmMzY2NDRhMTk3ZWM3OWFkYmY1YzUxNTU
+[scb-slack]: https://owasp.org/slack/invite
 [scb-license]: https://github.com/secureCodeBox/secureCodeBox/blob/master/LICENSE
 

--- a/demo-targets/dummy-ssh/README.md
+++ b/demo-targets/dummy-ssh/README.md
@@ -87,6 +87,6 @@ Code of secureCodeBox is licensed under the [Apache License 2.0][scb-license].
 [scb-site]: https://www.securecodebox.io/
 [scb-github]: https://github.com/secureCodeBox/
 [scb-twitter]: https://twitter.com/secureCodeBox
-[scb-slack]: https://join.slack.com/t/securecodebox/shared_invite/enQtNDU3MTUyOTM0NTMwLTBjOWRjNjVkNGEyMjQ0ZGMyNDdlYTQxYWQ4MzNiNGY3MDMxNThkZjJmMzY2NDRhMTk3ZWM3OWFkYmY1YzUxNTU
+[scb-slack]: https://owasp.org/slack/invite
 [scb-license]: https://github.com/secureCodeBox/secureCodeBox/blob/master/LICENSE
 

--- a/demo-targets/dummy-ssh/docs/README.ArtifactHub.md
+++ b/demo-targets/dummy-ssh/docs/README.ArtifactHub.md
@@ -94,7 +94,7 @@ Please have a look at [Contributing](./CONTRIBUTING.md)
 You are welcome, please join us on... 👋
 
 - [GitHub][scb-github]
-- [Slack][scb-slack]
+- [OWASP Slack (Channel #project-securecodebox)][scb-slack]
 - [Twitter][scb-twitter]
 
 secureCodeBox is an official [OWASP][scb-owasp] project.
@@ -109,6 +109,6 @@ Code of secureCodeBox is licensed under the [Apache License 2.0][scb-license].
 [scb-site]: https://www.securecodebox.io/
 [scb-github]: https://github.com/secureCodeBox/
 [scb-twitter]: https://twitter.com/secureCodeBox
-[scb-slack]: https://join.slack.com/t/securecodebox/shared_invite/enQtNDU3MTUyOTM0NTMwLTBjOWRjNjVkNGEyMjQ0ZGMyNDdlYTQxYWQ4MzNiNGY3MDMxNThkZjJmMzY2NDRhMTk3ZWM3OWFkYmY1YzUxNTU
+[scb-slack]: https://owasp.org/slack/invite
 [scb-license]: https://github.com/secureCodeBox/secureCodeBox/blob/master/LICENSE
 

--- a/demo-targets/dummy-ssh/docs/README.DockerHub-Target.md
+++ b/demo-targets/dummy-ssh/docs/README.DockerHub-Target.md
@@ -70,7 +70,7 @@ There are also vulnerable credentials which can be identified via bruteforcing:
 You are welcome, please join us on... 👋
 
 - [GitHub][scb-github]
-- [Slack][scb-slack]
+- [OWASP Slack (Channel #project-securecodebox)][scb-slack]
 - [Twitter][scb-twitter]
 
 secureCodeBox is an official [OWASP][scb-owasp] project.
@@ -87,6 +87,6 @@ As for any pre-built image usage, it is the image user's responsibility to ensur
 [scb-site]: https://www.securecodebox.io/
 [scb-github]: https://github.com/secureCodeBox/
 [scb-twitter]: https://twitter.com/secureCodeBox
-[scb-slack]: https://join.slack.com/t/securecodebox/shared_invite/enQtNDU3MTUyOTM0NTMwLTBjOWRjNjVkNGEyMjQ0ZGMyNDdlYTQxYWQ4MzNiNGY3MDMxNThkZjJmMzY2NDRhMTk3ZWM3OWFkYmY1YzUxNTU
+[scb-slack]: https://owasp.org/slack/invite
 [scb-license]: https://github.com/secureCodeBox/secureCodeBox/blob/master/LICENSE
 

--- a/demo-targets/http-webhook/README.md
+++ b/demo-targets/http-webhook/README.md
@@ -94,6 +94,6 @@ Code of secureCodeBox is licensed under the [Apache License 2.0][scb-license].
 [scb-site]: https://www.securecodebox.io/
 [scb-github]: https://github.com/secureCodeBox/
 [scb-twitter]: https://twitter.com/secureCodeBox
-[scb-slack]: https://join.slack.com/t/securecodebox/shared_invite/enQtNDU3MTUyOTM0NTMwLTBjOWRjNjVkNGEyMjQ0ZGMyNDdlYTQxYWQ4MzNiNGY3MDMxNThkZjJmMzY2NDRhMTk3ZWM3OWFkYmY1YzUxNTU
+[scb-slack]: https://owasp.org/slack/invite
 [scb-license]: https://github.com/secureCodeBox/secureCodeBox/blob/master/LICENSE
 

--- a/demo-targets/http-webhook/docs/README.ArtifactHub.md
+++ b/demo-targets/http-webhook/docs/README.ArtifactHub.md
@@ -101,7 +101,7 @@ Please have a look at [Contributing](./CONTRIBUTING.md)
 You are welcome, please join us on... 👋
 
 - [GitHub][scb-github]
-- [Slack][scb-slack]
+- [OWASP Slack (Channel #project-securecodebox)][scb-slack]
 - [Twitter][scb-twitter]
 
 secureCodeBox is an official [OWASP][scb-owasp] project.
@@ -116,6 +116,6 @@ Code of secureCodeBox is licensed under the [Apache License 2.0][scb-license].
 [scb-site]: https://www.securecodebox.io/
 [scb-github]: https://github.com/secureCodeBox/
 [scb-twitter]: https://twitter.com/secureCodeBox
-[scb-slack]: https://join.slack.com/t/securecodebox/shared_invite/enQtNDU3MTUyOTM0NTMwLTBjOWRjNjVkNGEyMjQ0ZGMyNDdlYTQxYWQ4MzNiNGY3MDMxNThkZjJmMzY2NDRhMTk3ZWM3OWFkYmY1YzUxNTU
+[scb-slack]: https://owasp.org/slack/invite
 [scb-license]: https://github.com/secureCodeBox/secureCodeBox/blob/master/LICENSE
 

--- a/demo-targets/http-webhook/docs/README.DockerHub-Target.md
+++ b/demo-targets/http-webhook/docs/README.DockerHub-Target.md
@@ -64,7 +64,7 @@ A Dummy webserver to echo HTTP requests in log.
 You are welcome, please join us on... 👋
 
 - [GitHub][scb-github]
-- [Slack][scb-slack]
+- [OWASP Slack (Channel #project-securecodebox)][scb-slack]
 - [Twitter][scb-twitter]
 
 secureCodeBox is an official [OWASP][scb-owasp] project.
@@ -81,6 +81,6 @@ As for any pre-built image usage, it is the image user's responsibility to ensur
 [scb-site]: https://www.securecodebox.io/
 [scb-github]: https://github.com/secureCodeBox/
 [scb-twitter]: https://twitter.com/secureCodeBox
-[scb-slack]: https://join.slack.com/t/securecodebox/shared_invite/enQtNDU3MTUyOTM0NTMwLTBjOWRjNjVkNGEyMjQ0ZGMyNDdlYTQxYWQ4MzNiNGY3MDMxNThkZjJmMzY2NDRhMTk3ZWM3OWFkYmY1YzUxNTU
+[scb-slack]: https://owasp.org/slack/invite
 [scb-license]: https://github.com/secureCodeBox/secureCodeBox/blob/master/LICENSE
 

--- a/demo-targets/juice-shop/README.md
+++ b/demo-targets/juice-shop/README.md
@@ -93,6 +93,6 @@ Code of secureCodeBox is licensed under the [Apache License 2.0][scb-license].
 [scb-site]: https://www.securecodebox.io/
 [scb-github]: https://github.com/secureCodeBox/
 [scb-twitter]: https://twitter.com/secureCodeBox
-[scb-slack]: https://join.slack.com/t/securecodebox/shared_invite/enQtNDU3MTUyOTM0NTMwLTBjOWRjNjVkNGEyMjQ0ZGMyNDdlYTQxYWQ4MzNiNGY3MDMxNThkZjJmMzY2NDRhMTk3ZWM3OWFkYmY1YzUxNTU
+[scb-slack]: https://owasp.org/slack/invite
 [scb-license]: https://github.com/secureCodeBox/secureCodeBox/blob/master/LICENSE
 

--- a/demo-targets/juice-shop/docs/README.ArtifactHub.md
+++ b/demo-targets/juice-shop/docs/README.ArtifactHub.md
@@ -100,7 +100,7 @@ Please have a look at [Contributing](./CONTRIBUTING.md)
 You are welcome, please join us on... 👋
 
 - [GitHub][scb-github]
-- [Slack][scb-slack]
+- [OWASP Slack (Channel #project-securecodebox)][scb-slack]
 - [Twitter][scb-twitter]
 
 secureCodeBox is an official [OWASP][scb-owasp] project.
@@ -115,6 +115,6 @@ Code of secureCodeBox is licensed under the [Apache License 2.0][scb-license].
 [scb-site]: https://www.securecodebox.io/
 [scb-github]: https://github.com/secureCodeBox/
 [scb-twitter]: https://twitter.com/secureCodeBox
-[scb-slack]: https://join.slack.com/t/securecodebox/shared_invite/enQtNDU3MTUyOTM0NTMwLTBjOWRjNjVkNGEyMjQ0ZGMyNDdlYTQxYWQ4MzNiNGY3MDMxNThkZjJmMzY2NDRhMTk3ZWM3OWFkYmY1YzUxNTU
+[scb-slack]: https://owasp.org/slack/invite
 [scb-license]: https://github.com/secureCodeBox/secureCodeBox/blob/master/LICENSE
 

--- a/demo-targets/juice-shop/docs/README.DockerHub-Target.md
+++ b/demo-targets/juice-shop/docs/README.DockerHub-Target.md
@@ -67,7 +67,7 @@ OWASP Juice Shop: Probably the most modern and sophisticated insecure web applic
 You are welcome, please join us on... 👋
 
 - [GitHub][scb-github]
-- [Slack][scb-slack]
+- [OWASP Slack (Channel #project-securecodebox)][scb-slack]
 - [Twitter][scb-twitter]
 
 secureCodeBox is an official [OWASP][scb-owasp] project.
@@ -84,6 +84,6 @@ As for any pre-built image usage, it is the image user's responsibility to ensur
 [scb-site]: https://www.securecodebox.io/
 [scb-github]: https://github.com/secureCodeBox/
 [scb-twitter]: https://twitter.com/secureCodeBox
-[scb-slack]: https://join.slack.com/t/securecodebox/shared_invite/enQtNDU3MTUyOTM0NTMwLTBjOWRjNjVkNGEyMjQ0ZGMyNDdlYTQxYWQ4MzNiNGY3MDMxNThkZjJmMzY2NDRhMTk3ZWM3OWFkYmY1YzUxNTU
+[scb-slack]: https://owasp.org/slack/invite
 [scb-license]: https://github.com/secureCodeBox/secureCodeBox/blob/master/LICENSE
 

--- a/demo-targets/old-joomla/README.md
+++ b/demo-targets/old-joomla/README.md
@@ -86,6 +86,6 @@ Code of secureCodeBox is licensed under the [Apache License 2.0][scb-license].
 [scb-site]: https://www.securecodebox.io/
 [scb-github]: https://github.com/secureCodeBox/
 [scb-twitter]: https://twitter.com/secureCodeBox
-[scb-slack]: https://join.slack.com/t/securecodebox/shared_invite/enQtNDU3MTUyOTM0NTMwLTBjOWRjNjVkNGEyMjQ0ZGMyNDdlYTQxYWQ4MzNiNGY3MDMxNThkZjJmMzY2NDRhMTk3ZWM3OWFkYmY1YzUxNTU
+[scb-slack]: https://owasp.org/slack/invite
 [scb-license]: https://github.com/secureCodeBox/secureCodeBox/blob/master/LICENSE
 

--- a/demo-targets/old-joomla/docs/README.ArtifactHub.md
+++ b/demo-targets/old-joomla/docs/README.ArtifactHub.md
@@ -93,7 +93,7 @@ Please have a look at [Contributing](./CONTRIBUTING.md)
 You are welcome, please join us on... 👋
 
 - [GitHub][scb-github]
-- [Slack][scb-slack]
+- [OWASP Slack (Channel #project-securecodebox)][scb-slack]
 - [Twitter][scb-twitter]
 
 secureCodeBox is an official [OWASP][scb-owasp] project.
@@ -108,6 +108,6 @@ Code of secureCodeBox is licensed under the [Apache License 2.0][scb-license].
 [scb-site]: https://www.securecodebox.io/
 [scb-github]: https://github.com/secureCodeBox/
 [scb-twitter]: https://twitter.com/secureCodeBox
-[scb-slack]: https://join.slack.com/t/securecodebox/shared_invite/enQtNDU3MTUyOTM0NTMwLTBjOWRjNjVkNGEyMjQ0ZGMyNDdlYTQxYWQ4MzNiNGY3MDMxNThkZjJmMzY2NDRhMTk3ZWM3OWFkYmY1YzUxNTU
+[scb-slack]: https://owasp.org/slack/invite
 [scb-license]: https://github.com/secureCodeBox/secureCodeBox/blob/master/LICENSE
 

--- a/demo-targets/old-joomla/docs/README.DockerHub-Target.md
+++ b/demo-targets/old-joomla/docs/README.DockerHub-Target.md
@@ -64,7 +64,7 @@ Insecure & Outdated Joomla Instance: Never expose it to the internet!
 You are welcome, please join us on... 👋
 
 - [GitHub][scb-github]
-- [Slack][scb-slack]
+- [OWASP Slack (Channel #project-securecodebox)][scb-slack]
 - [Twitter][scb-twitter]
 
 secureCodeBox is an official [OWASP][scb-owasp] project.
@@ -81,6 +81,6 @@ As for any pre-built image usage, it is the image user's responsibility to ensur
 [scb-site]: https://www.securecodebox.io/
 [scb-github]: https://github.com/secureCodeBox/
 [scb-twitter]: https://twitter.com/secureCodeBox
-[scb-slack]: https://join.slack.com/t/securecodebox/shared_invite/enQtNDU3MTUyOTM0NTMwLTBjOWRjNjVkNGEyMjQ0ZGMyNDdlYTQxYWQ4MzNiNGY3MDMxNThkZjJmMzY2NDRhMTk3ZWM3OWFkYmY1YzUxNTU
+[scb-slack]: https://owasp.org/slack/invite
 [scb-license]: https://github.com/secureCodeBox/secureCodeBox/blob/master/LICENSE
 

--- a/demo-targets/old-typo3/README.md
+++ b/demo-targets/old-typo3/README.md
@@ -86,6 +86,6 @@ Code of secureCodeBox is licensed under the [Apache License 2.0][scb-license].
 [scb-site]: https://www.securecodebox.io/
 [scb-github]: https://github.com/secureCodeBox/
 [scb-twitter]: https://twitter.com/secureCodeBox
-[scb-slack]: https://join.slack.com/t/securecodebox/shared_invite/enQtNDU3MTUyOTM0NTMwLTBjOWRjNjVkNGEyMjQ0ZGMyNDdlYTQxYWQ4MzNiNGY3MDMxNThkZjJmMzY2NDRhMTk3ZWM3OWFkYmY1YzUxNTU
+[scb-slack]: https://owasp.org/slack/invite
 [scb-license]: https://github.com/secureCodeBox/secureCodeBox/blob/master/LICENSE
 

--- a/demo-targets/old-typo3/docs/README.ArtifactHub.md
+++ b/demo-targets/old-typo3/docs/README.ArtifactHub.md
@@ -93,7 +93,7 @@ Please have a look at [Contributing](./CONTRIBUTING.md)
 You are welcome, please join us on... 👋
 
 - [GitHub][scb-github]
-- [Slack][scb-slack]
+- [OWASP Slack (Channel #project-securecodebox)][scb-slack]
 - [Twitter][scb-twitter]
 
 secureCodeBox is an official [OWASP][scb-owasp] project.
@@ -108,6 +108,6 @@ Code of secureCodeBox is licensed under the [Apache License 2.0][scb-license].
 [scb-site]: https://www.securecodebox.io/
 [scb-github]: https://github.com/secureCodeBox/
 [scb-twitter]: https://twitter.com/secureCodeBox
-[scb-slack]: https://join.slack.com/t/securecodebox/shared_invite/enQtNDU3MTUyOTM0NTMwLTBjOWRjNjVkNGEyMjQ0ZGMyNDdlYTQxYWQ4MzNiNGY3MDMxNThkZjJmMzY2NDRhMTk3ZWM3OWFkYmY1YzUxNTU
+[scb-slack]: https://owasp.org/slack/invite
 [scb-license]: https://github.com/secureCodeBox/secureCodeBox/blob/master/LICENSE
 

--- a/demo-targets/old-typo3/docs/README.DockerHub-Target.md
+++ b/demo-targets/old-typo3/docs/README.DockerHub-Target.md
@@ -64,7 +64,7 @@ Insecure & Outdated Typo3 Instance: Never expose it to the internet!
 You are welcome, please join us on... 👋
 
 - [GitHub][scb-github]
-- [Slack][scb-slack]
+- [OWASP Slack (Channel #project-securecodebox)][scb-slack]
 - [Twitter][scb-twitter]
 
 secureCodeBox is an official [OWASP][scb-owasp] project.
@@ -81,6 +81,6 @@ As for any pre-built image usage, it is the image user's responsibility to ensur
 [scb-site]: https://www.securecodebox.io/
 [scb-github]: https://github.com/secureCodeBox/
 [scb-twitter]: https://twitter.com/secureCodeBox
-[scb-slack]: https://join.slack.com/t/securecodebox/shared_invite/enQtNDU3MTUyOTM0NTMwLTBjOWRjNjVkNGEyMjQ0ZGMyNDdlYTQxYWQ4MzNiNGY3MDMxNThkZjJmMzY2NDRhMTk3ZWM3OWFkYmY1YzUxNTU
+[scb-slack]: https://owasp.org/slack/invite
 [scb-license]: https://github.com/secureCodeBox/secureCodeBox/blob/master/LICENSE
 

--- a/demo-targets/old-wordpress/README.md
+++ b/demo-targets/old-wordpress/README.md
@@ -81,6 +81,6 @@ Code of secureCodeBox is licensed under the [Apache License 2.0][scb-license].
 [scb-site]: https://www.securecodebox.io/
 [scb-github]: https://github.com/secureCodeBox/
 [scb-twitter]: https://twitter.com/secureCodeBox
-[scb-slack]: https://join.slack.com/t/securecodebox/shared_invite/enQtNDU3MTUyOTM0NTMwLTBjOWRjNjVkNGEyMjQ0ZGMyNDdlYTQxYWQ4MzNiNGY3MDMxNThkZjJmMzY2NDRhMTk3ZWM3OWFkYmY1YzUxNTU
+[scb-slack]: https://owasp.org/slack/invite
 [scb-license]: https://github.com/secureCodeBox/secureCodeBox/blob/master/LICENSE
 

--- a/demo-targets/old-wordpress/docs/README.ArtifactHub.md
+++ b/demo-targets/old-wordpress/docs/README.ArtifactHub.md
@@ -88,7 +88,7 @@ Please have a look at [Contributing](./CONTRIBUTING.md)
 You are welcome, please join us on... 👋
 
 - [GitHub][scb-github]
-- [Slack][scb-slack]
+- [OWASP Slack (Channel #project-securecodebox)][scb-slack]
 - [Twitter][scb-twitter]
 
 secureCodeBox is an official [OWASP][scb-owasp] project.
@@ -103,6 +103,6 @@ Code of secureCodeBox is licensed under the [Apache License 2.0][scb-license].
 [scb-site]: https://www.securecodebox.io/
 [scb-github]: https://github.com/secureCodeBox/
 [scb-twitter]: https://twitter.com/secureCodeBox
-[scb-slack]: https://join.slack.com/t/securecodebox/shared_invite/enQtNDU3MTUyOTM0NTMwLTBjOWRjNjVkNGEyMjQ0ZGMyNDdlYTQxYWQ4MzNiNGY3MDMxNThkZjJmMzY2NDRhMTk3ZWM3OWFkYmY1YzUxNTU
+[scb-slack]: https://owasp.org/slack/invite
 [scb-license]: https://github.com/secureCodeBox/secureCodeBox/blob/master/LICENSE
 

--- a/demo-targets/old-wordpress/docs/README.DockerHub-Target.md
+++ b/demo-targets/old-wordpress/docs/README.DockerHub-Target.md
@@ -64,7 +64,7 @@ Insecure & Outdated WordPress Instance: Never expose it to the internet!
 You are welcome, please join us on... 👋
 
 - [GitHub][scb-github]
-- [Slack][scb-slack]
+- [OWASP Slack (Channel #project-securecodebox)][scb-slack]
 - [Twitter][scb-twitter]
 
 secureCodeBox is an official [OWASP][scb-owasp] project.
@@ -81,6 +81,6 @@ As for any pre-built image usage, it is the image user's responsibility to ensur
 [scb-site]: https://www.securecodebox.io/
 [scb-github]: https://github.com/secureCodeBox/
 [scb-twitter]: https://twitter.com/secureCodeBox
-[scb-slack]: https://join.slack.com/t/securecodebox/shared_invite/enQtNDU3MTUyOTM0NTMwLTBjOWRjNjVkNGEyMjQ0ZGMyNDdlYTQxYWQ4MzNiNGY3MDMxNThkZjJmMzY2NDRhMTk3ZWM3OWFkYmY1YzUxNTU
+[scb-slack]: https://owasp.org/slack/invite
 [scb-license]: https://github.com/secureCodeBox/secureCodeBox/blob/master/LICENSE
 

--- a/demo-targets/swagger-petstore/README.md
+++ b/demo-targets/swagger-petstore/README.md
@@ -88,6 +88,6 @@ Code of secureCodeBox is licensed under the [Apache License 2.0][scb-license].
 [scb-site]: https://www.securecodebox.io/
 [scb-github]: https://github.com/secureCodeBox/
 [scb-twitter]: https://twitter.com/secureCodeBox
-[scb-slack]: https://join.slack.com/t/securecodebox/shared_invite/enQtNDU3MTUyOTM0NTMwLTBjOWRjNjVkNGEyMjQ0ZGMyNDdlYTQxYWQ4MzNiNGY3MDMxNThkZjJmMzY2NDRhMTk3ZWM3OWFkYmY1YzUxNTU
+[scb-slack]: https://owasp.org/slack/invite
 [scb-license]: https://github.com/secureCodeBox/secureCodeBox/blob/master/LICENSE
 

--- a/demo-targets/swagger-petstore/docs/README.ArtifactHub.md
+++ b/demo-targets/swagger-petstore/docs/README.ArtifactHub.md
@@ -95,7 +95,7 @@ Please have a look at [Contributing](./CONTRIBUTING.md)
 You are welcome, please join us on... 👋
 
 - [GitHub][scb-github]
-- [Slack][scb-slack]
+- [OWASP Slack (Channel #project-securecodebox)][scb-slack]
 - [Twitter][scb-twitter]
 
 secureCodeBox is an official [OWASP][scb-owasp] project.
@@ -110,6 +110,6 @@ Code of secureCodeBox is licensed under the [Apache License 2.0][scb-license].
 [scb-site]: https://www.securecodebox.io/
 [scb-github]: https://github.com/secureCodeBox/
 [scb-twitter]: https://twitter.com/secureCodeBox
-[scb-slack]: https://join.slack.com/t/securecodebox/shared_invite/enQtNDU3MTUyOTM0NTMwLTBjOWRjNjVkNGEyMjQ0ZGMyNDdlYTQxYWQ4MzNiNGY3MDMxNThkZjJmMzY2NDRhMTk3ZWM3OWFkYmY1YzUxNTU
+[scb-slack]: https://owasp.org/slack/invite
 [scb-license]: https://github.com/secureCodeBox/secureCodeBox/blob/master/LICENSE
 

--- a/demo-targets/swagger-petstore/docs/README.DockerHub-Target.md
+++ b/demo-targets/swagger-petstore/docs/README.DockerHub-Target.md
@@ -65,7 +65,7 @@ This is the sample petstore application with a restful API.
 You are welcome, please join us on... 👋
 
 - [GitHub][scb-github]
-- [Slack][scb-slack]
+- [OWASP Slack (Channel #project-securecodebox)][scb-slack]
 - [Twitter][scb-twitter]
 
 secureCodeBox is an official [OWASP][scb-owasp] project.
@@ -82,6 +82,6 @@ As for any pre-built image usage, it is the image user's responsibility to ensur
 [scb-site]: https://www.securecodebox.io/
 [scb-github]: https://github.com/secureCodeBox/
 [scb-twitter]: https://twitter.com/secureCodeBox
-[scb-slack]: https://join.slack.com/t/securecodebox/shared_invite/enQtNDU3MTUyOTM0NTMwLTBjOWRjNjVkNGEyMjQ0ZGMyNDdlYTQxYWQ4MzNiNGY3MDMxNThkZjJmMzY2NDRhMTk3ZWM3OWFkYmY1YzUxNTU
+[scb-slack]: https://owasp.org/slack/invite
 [scb-license]: https://github.com/secureCodeBox/secureCodeBox/blob/master/LICENSE
 

--- a/demo-targets/unsafe-https/README.md
+++ b/demo-targets/unsafe-https/README.md
@@ -83,6 +83,6 @@ Code of secureCodeBox is licensed under the [Apache License 2.0][scb-license].
 [scb-site]: https://www.securecodebox.io/
 [scb-github]: https://github.com/secureCodeBox/
 [scb-twitter]: https://twitter.com/secureCodeBox
-[scb-slack]: https://join.slack.com/t/securecodebox/shared_invite/enQtNDU3MTUyOTM0NTMwLTBjOWRjNjVkNGEyMjQ0ZGMyNDdlYTQxYWQ4MzNiNGY3MDMxNThkZjJmMzY2NDRhMTk3ZWM3OWFkYmY1YzUxNTU
+[scb-slack]: https://owasp.org/slack/invite
 [scb-license]: https://github.com/secureCodeBox/secureCodeBox/blob/master/LICENSE
 

--- a/demo-targets/unsafe-https/docs/README.ArtifactHub.md
+++ b/demo-targets/unsafe-https/docs/README.ArtifactHub.md
@@ -90,7 +90,7 @@ Please have a look at [Contributing](./CONTRIBUTING.md)
 You are welcome, please join us on... 👋
 
 - [GitHub][scb-github]
-- [Slack][scb-slack]
+- [OWASP Slack (Channel #project-securecodebox)][scb-slack]
 - [Twitter][scb-twitter]
 
 secureCodeBox is an official [OWASP][scb-owasp] project.
@@ -105,6 +105,6 @@ Code of secureCodeBox is licensed under the [Apache License 2.0][scb-license].
 [scb-site]: https://www.securecodebox.io/
 [scb-github]: https://github.com/secureCodeBox/
 [scb-twitter]: https://twitter.com/secureCodeBox
-[scb-slack]: https://join.slack.com/t/securecodebox/shared_invite/enQtNDU3MTUyOTM0NTMwLTBjOWRjNjVkNGEyMjQ0ZGMyNDdlYTQxYWQ4MzNiNGY3MDMxNThkZjJmMzY2NDRhMTk3ZWM3OWFkYmY1YzUxNTU
+[scb-slack]: https://owasp.org/slack/invite
 [scb-license]: https://github.com/secureCodeBox/secureCodeBox/blob/master/LICENSE
 

--- a/demo-targets/unsafe-https/docs/README.DockerHub-Target.md
+++ b/demo-targets/unsafe-https/docs/README.DockerHub-Target.md
@@ -66,7 +66,7 @@ which contains both private and public key and is not authorized by a third part
 You are welcome, please join us on... 👋
 
 - [GitHub][scb-github]
-- [Slack][scb-slack]
+- [OWASP Slack (Channel #project-securecodebox)][scb-slack]
 - [Twitter][scb-twitter]
 
 secureCodeBox is an official [OWASP][scb-owasp] project.
@@ -83,6 +83,6 @@ As for any pre-built image usage, it is the image user's responsibility to ensur
 [scb-site]: https://www.securecodebox.io/
 [scb-github]: https://github.com/secureCodeBox/
 [scb-twitter]: https://twitter.com/secureCodeBox
-[scb-slack]: https://join.slack.com/t/securecodebox/shared_invite/enQtNDU3MTUyOTM0NTMwLTBjOWRjNjVkNGEyMjQ0ZGMyNDdlYTQxYWQ4MzNiNGY3MDMxNThkZjJmMzY2NDRhMTk3ZWM3OWFkYmY1YzUxNTU
+[scb-slack]: https://owasp.org/slack/invite
 [scb-license]: https://github.com/secureCodeBox/secureCodeBox/blob/master/LICENSE
 

--- a/demo-targets/vulnerable-log4j/README.md
+++ b/demo-targets/vulnerable-log4j/README.md
@@ -81,6 +81,6 @@ Code of secureCodeBox is licensed under the [Apache License 2.0][scb-license].
 [scb-site]: https://www.securecodebox.io/
 [scb-github]: https://github.com/secureCodeBox/
 [scb-twitter]: https://twitter.com/secureCodeBox
-[scb-slack]: https://join.slack.com/t/securecodebox/shared_invite/enQtNDU3MTUyOTM0NTMwLTBjOWRjNjVkNGEyMjQ0ZGMyNDdlYTQxYWQ4MzNiNGY3MDMxNThkZjJmMzY2NDRhMTk3ZWM3OWFkYmY1YzUxNTU
+[scb-slack]: https://owasp.org/slack/invite
 [scb-license]: https://github.com/secureCodeBox/secureCodeBox/blob/master/LICENSE
 

--- a/demo-targets/vulnerable-log4j/docs/README.ArtifactHub.md
+++ b/demo-targets/vulnerable-log4j/docs/README.ArtifactHub.md
@@ -88,7 +88,7 @@ Please have a look at [Contributing](./CONTRIBUTING.md)
 You are welcome, please join us on... 👋
 
 - [GitHub][scb-github]
-- [Slack][scb-slack]
+- [OWASP Slack (Channel #project-securecodebox)][scb-slack]
 - [Twitter][scb-twitter]
 
 secureCodeBox is an official [OWASP][scb-owasp] project.
@@ -103,6 +103,6 @@ Code of secureCodeBox is licensed under the [Apache License 2.0][scb-license].
 [scb-site]: https://www.securecodebox.io/
 [scb-github]: https://github.com/secureCodeBox/
 [scb-twitter]: https://twitter.com/secureCodeBox
-[scb-slack]: https://join.slack.com/t/securecodebox/shared_invite/enQtNDU3MTUyOTM0NTMwLTBjOWRjNjVkNGEyMjQ0ZGMyNDdlYTQxYWQ4MzNiNGY3MDMxNThkZjJmMzY2NDRhMTk3ZWM3OWFkYmY1YzUxNTU
+[scb-slack]: https://owasp.org/slack/invite
 [scb-license]: https://github.com/secureCodeBox/secureCodeBox/blob/master/LICENSE
 

--- a/demo-targets/vulnerable-log4j/docs/README.DockerHub-Target.md
+++ b/demo-targets/vulnerable-log4j/docs/README.DockerHub-Target.md
@@ -64,7 +64,7 @@ Insecure & Outdated Java Instance using log4j: Never expose it to the internet!
 You are welcome, please join us on... 👋
 
 - [GitHub][scb-github]
-- [Slack][scb-slack]
+- [OWASP Slack (Channel #project-securecodebox)][scb-slack]
 - [Twitter][scb-twitter]
 
 secureCodeBox is an official [OWASP][scb-owasp] project.
@@ -81,6 +81,6 @@ As for any pre-built image usage, it is the image user's responsibility to ensur
 [scb-site]: https://www.securecodebox.io/
 [scb-github]: https://github.com/secureCodeBox/
 [scb-twitter]: https://twitter.com/secureCodeBox
-[scb-slack]: https://join.slack.com/t/securecodebox/shared_invite/enQtNDU3MTUyOTM0NTMwLTBjOWRjNjVkNGEyMjQ0ZGMyNDdlYTQxYWQ4MzNiNGY3MDMxNThkZjJmMzY2NDRhMTk3ZWM3OWFkYmY1YzUxNTU
+[scb-slack]: https://owasp.org/slack/invite
 [scb-license]: https://github.com/secureCodeBox/secureCodeBox/blob/master/LICENSE
 

--- a/documentation/blog/2020-10-15-sundown-and-eol-of-version-1.md
+++ b/documentation/blog/2020-10-15-sundown-and-eol-of-version-1.md
@@ -48,7 +48,7 @@ It may be possible to migrate the data collected by version 1 in Elastic. But at
 
 ## Please Sorry 🥺
 
-So you may face a major fuckup now. We understand that such a move is almost always quite a bit annoying. That's why we ask you for sorry and hope we won't lose you as a *secureCodeBox* user. If you need help moving to *secureCodeBox* version 2 don't hesitate to ask us for help! You can reach us at [Twitter](https://www.twitter.com/secureCodeBox), [Slack](https://join.slack.com/t/securecodebox/shared_invite/enQtNDU3MTUyOTM0NTMwLTBjOWRjNjVkNGEyMjQ0ZGMyNDdlYTQxYWQ4MzNiNGY3MDMxNThkZjJmMzY2NDRhMTk3ZWM3OWFkYmY1YzUxNTU), E-Mail (securecodebox [at] iteratec [dot] com) or just file an issue at GitHub.
+So you may face a major fuckup now. We understand that such a move is almost always quite a bit annoying. That's why we ask you for sorry and hope we won't lose you as a *secureCodeBox* user. If you need help moving to *secureCodeBox* version 2 don't hesitate to ask us for help! You can reach us at [Twitter](https://www.twitter.com/secureCodeBox), [OWASP Slack](https://owasp.org/slack/invite) (Channel `#project-securecodebox`), E-Mail (securecodebox [at] iteratec [dot] com) or just file an issue at GitHub.
 
 Finally to cheer you up a little cute kitten:
 

--- a/documentation/blog/2020-10-16-release-of-securecodebox-version-2.md
+++ b/documentation/blog/2020-10-16-release-of-securecodebox-version-2.md
@@ -32,7 +32,7 @@ Please note that scanning random hosts may be illegal. Please scan only hosts yo
 
 :::
 
-If you miss something in our documentation or you think it is unclear or wrong described. Please feel free to file an [issue](https://github.com/secureCodeBox/documentation/issues). If you need any help with your brand new _secureCodeBox_ don't hesitate to contact us via [Twitter](https://www.twitter.com/secureCodeBox), [Slack](https://join.slack.com/t/securecodebox/shared_invite/enQtNDU3MTUyOTM0NTMwLTBjOWRjNjVkNGEyMjQ0ZGMyNDdlYTQxYWQ4MzNiNGY3MDMxNThkZjJmMzY2NDRhMTk3ZWM3OWFkYmY1YzUxNTU), E-Mail (securecodebox [at] iteratec [dot] com) or just file an [issue](https://github.com/secureCodeBox/secureCodeBox) at GitHub.
+If you miss something in our documentation or you think it is unclear or wrong described. Please feel free to file an [issue](https://github.com/secureCodeBox/documentation/issues). If you need any help with your brand new _secureCodeBox_ don't hesitate to contact us via [Twitter](https://www.twitter.com/secureCodeBox), [OWASP Slack](https://owasp.org/slack/invite) (Channel `#project-securecodebox`), E-Mail (securecodebox [at] iteratec [dot] com) or just file an [issue](https://github.com/secureCodeBox/secureCodeBox) at GitHub.
 
 ## What's New in secureCodeBox v2
 

--- a/documentation/blog/2021-09-07-how-we-work.md
+++ b/documentation/blog/2021-09-07-how-we-work.md
@@ -78,7 +78,7 @@ If you are a regular user of the *secureCodeBox* and/or want to contribute more 
 Of course, you can stay "anonymous", create your own pull requests and issues in our repository or chat with our
 developers about new features. If you, however, want to take one step further, we are very happy if you get in touch,
 for example by writing us an [e-mail](mailto:securecodebox@iteratec.com) 
-or joining our [Slack channel](https://join.slack.com/t/securecodebox/shared_invite/enQtNDU3MTUyOTM0NTMwLTBjOWRjNjVkNGEyMjQ0ZGMyNDdlYTQxYWQ4MzNiNGY3MDMxNThkZjJmMzY2NDRhMTk3ZWM3OWFkYmY1YzUxNTU%22).
+or joining our `#project-securecodebox` channel in the [OWASP Slack](https://owasp.org/slack/invite).
 
 Of course, we will face some new challenges when we integrate new stakeholders and developers into our meetings.
 The time span of our meeting is already quite tight for all that we have to discuss, and we would probably also have

--- a/documentation/blog/2021-10-27-sast-scanning.md
+++ b/documentation/blog/2021-10-27-sast-scanning.md
@@ -351,7 +351,7 @@ For more details, see the [DefectDojo Hook Documentation][defectdojo-scb-permiss
 We hope this example shows how SAST scans can be a valuable addition to your secureCodeBox toolbelt, even if you are already using such scanners as part of the CI pipeline.
 Of course, nothing stops you from using [scheduled scans][scheduledscans] to keep re-running these scans on a regular basis to check for additional issues like [leaked secrets][semgrep-secrets] (which is also possible with [gitleaks][gitleaks]) or [high-confidence security issues][semgrep-ci] in your repositories, just to make sure the existing processes did not miss anything.
 As always, our goal is to provide a platform that works with your workflows instead of prescribing our own.
-We are looking forward to hearing your own stories and ideas for using secureCodeBox - [find us on Slack][scb-slack] or [GitHub][scb-repo] to get in touch.
+We are looking forward to hearing your own stories and ideas for using secureCodeBox - [OWASP Slack](https://owasp.org/slack/invite) (Channel `#project-securecodebox`) or [GitHub][scb-repo] to get in touch.
 
 
 [uaparser]: https://www.bleepingcomputer.com/news/security/popular-npm-library-hijacked-to-install-password-stealers-miners/
@@ -373,5 +373,4 @@ We are looking forward to hearing your own stories and ideas for using secureCod
 [cascadingscans]: /docs/hooks/cascading-scans
 [scheduledscans]: /docs/how-tos/automatically-repeating-scans
 [gitleaks]: /docs/scanners/gitleaks
-[scb-slack]: https://join.slack.com/t/securecodebox/shared_invite/enQtNDU3MTUyOTM0NTMwLTBjOWRjNjVkNGEyMjQ0ZGMyNDdlYTQxYWQ4MzNiNGY3MDMxNThkZjJmMzY2NDRhMTk3ZWM3OWFkYmY1YzUxNTU%22
 [scb-repo]: https://github.com/secureCodeBox/secureCodeBox/

--- a/documentation/blog/2022-01-18-log4shell.md
+++ b/documentation/blog/2022-01-18-log4shell.md
@@ -318,8 +318,7 @@ When a new critical vulnerability is found, it is often imperative to act quickl
 The secureCodeBox can play an invaluable role in quickly identifying affected systems and software repositories, especially if you prepare and test incident response playbooks in advance so that you only have to configure the correct detection rules and then rely on a well-tested stack of security scanners to collect your findings.
 
 How do you use the secureCodeBox?
-We are looking forward to hearing your own stories and ideas for using secureCodeBox - [find us on Slack][scb-slack] or [GitHub][scb-repo] to get in touch.
+We are looking forward to hearing your own stories and ideas for using secureCodeBox - the [OWASP Slack](https://owasp.org/slack/invite) (Channel `#project-securecodebox`) or [GitHub][scb-repo] to get in touch.
 
 
-[scb-slack]: https://join.slack.com/t/securecodebox/shared_invite/enQtNDU3MTUyOTM0NTMwLTBjOWRjNjVkNGEyMjQ0ZGMyNDdlYTQxYWQ4MzNiNGY3MDMxNThkZjJmMzY2NDRhMTk3ZWM3OWFkYmY1YzUxNTU%22
 [scb-repo]: https://github.com/secureCodeBox/secureCodeBox/

--- a/documentation/docs/getting-started/troubleshooting.md
+++ b/documentation/docs/getting-started/troubleshooting.md
@@ -9,9 +9,7 @@ path: "docs/getting-started/troubleshooting"
 ---
 
 If you experience any problems using the _secureCodeBox_, you may find an answer here.
-Should your problem not be covered here, however, you can also join our 
-[Slack Channel](https://join.slack.com/t/securecodebox/shared_invite/enQtNDU3MTUyOTM0NTMwLTBjOWRjNjVkNGEyMjQ0ZGMyNDdlYTQxYWQ4MzNiNGY3MDMxNThkZjJmMzY2NDRhMTk3ZWM3OWFkYmY1YzUxNTU%22)
-to get more specific help.
+Should your problem not be covered here, however, you can also join the [OWASP Slack](https://owasp.org/slack/invite) (Channel `#project-securecodebox`) to get more specific help.
 If you think that you encountered a general problem that should be fixed, we are very grateful if you take the time
 to create an issue in our [GitHub Repository](https://github.com/secureCodeBox/secureCodeBox/issues). 
 

--- a/documentation/docusaurus.config.js
+++ b/documentation/docusaurus.config.js
@@ -92,8 +92,8 @@ module.exports = {
                 href: "https://github.com/secureCodeBox",
               },
               {
-                label: "Slack",
-                href: 'https://join.slack.com/t/securecodebox/shared_invite/enQtNDU3MTUyOTM0NTMwLTBjOWRjNjVkNGEyMjQ0ZGMyNDdlYTQxYWQ4MzNiNGY3MDMxNThkZjJmMzY2NDRhMTk3ZWM3OWFkYmY1YzUxNTU"',
+                label: "OWASP Slack (Channel #project-securecodebox)",
+                href: 'https://owasp.org/slack/invite',
               },
               {
                 label: "Twitter",

--- a/hooks/cascading-scans/README.md
+++ b/hooks/cascading-scans/README.md
@@ -183,6 +183,6 @@ Code of secureCodeBox is licensed under the [Apache License 2.0][scb-license].
 [scb-site]: https://www.securecodebox.io/
 [scb-github]: https://github.com/secureCodeBox/
 [scb-twitter]: https://twitter.com/secureCodeBox
-[scb-slack]: https://join.slack.com/t/securecodebox/shared_invite/enQtNDU3MTUyOTM0NTMwLTBjOWRjNjVkNGEyMjQ0ZGMyNDdlYTQxYWQ4MzNiNGY3MDMxNThkZjJmMzY2NDRhMTk3ZWM3OWFkYmY1YzUxNTU
+[scb-slack]: https://owasp.org/slack/invite
 [scb-license]: https://github.com/secureCodeBox/secureCodeBox/blob/master/LICENSE
 

--- a/hooks/cascading-scans/docs/README.ArtifactHub.md
+++ b/hooks/cascading-scans/docs/README.ArtifactHub.md
@@ -191,7 +191,7 @@ Please have a look at [Contributing](./CONTRIBUTING.md)
 You are welcome, please join us on... 👋
 
 - [GitHub][scb-github]
-- [Slack][scb-slack]
+- [OWASP Slack (Channel #project-securecodebox)][scb-slack]
 - [Twitter][scb-twitter]
 
 secureCodeBox is an official [OWASP][scb-owasp] project.
@@ -206,6 +206,6 @@ Code of secureCodeBox is licensed under the [Apache License 2.0][scb-license].
 [scb-site]: https://www.securecodebox.io/
 [scb-github]: https://github.com/secureCodeBox/
 [scb-twitter]: https://twitter.com/secureCodeBox
-[scb-slack]: https://join.slack.com/t/securecodebox/shared_invite/enQtNDU3MTUyOTM0NTMwLTBjOWRjNjVkNGEyMjQ0ZGMyNDdlYTQxYWQ4MzNiNGY3MDMxNThkZjJmMzY2NDRhMTk3ZWM3OWFkYmY1YzUxNTU
+[scb-slack]: https://owasp.org/slack/invite
 [scb-license]: https://github.com/secureCodeBox/secureCodeBox/blob/master/LICENSE
 

--- a/hooks/cascading-scans/docs/README.DockerHub-Hook.md
+++ b/hooks/cascading-scans/docs/README.DockerHub-Hook.md
@@ -66,7 +66,7 @@ More information about how to use cascading scans can be found here:
 You are welcome, please join us on... 👋
 
 - [GitHub][scb-github]
-- [Slack][scb-slack]
+- [OWASP Slack (Channel #project-securecodebox)][scb-slack]
 - [Twitter][scb-twitter]
 
 secureCodeBox is an official [OWASP][scb-owasp] project.
@@ -83,6 +83,6 @@ As for any pre-built image usage, it is the image user's responsibility to ensur
 [scb-site]: https://www.securecodebox.io/
 [scb-github]: https://github.com/secureCodeBox/
 [scb-twitter]: https://twitter.com/secureCodeBox
-[scb-slack]: https://join.slack.com/t/securecodebox/shared_invite/enQtNDU3MTUyOTM0NTMwLTBjOWRjNjVkNGEyMjQ0ZGMyNDdlYTQxYWQ4MzNiNGY3MDMxNThkZjJmMzY2NDRhMTk3ZWM3OWFkYmY1YzUxNTU
+[scb-slack]: https://owasp.org/slack/invite
 [scb-license]: https://github.com/secureCodeBox/secureCodeBox/blob/master/LICENSE
 

--- a/hooks/finding-post-processing/README.md
+++ b/hooks/finding-post-processing/README.md
@@ -111,6 +111,6 @@ Code of secureCodeBox is licensed under the [Apache License 2.0][scb-license].
 [scb-site]: https://www.securecodebox.io/
 [scb-github]: https://github.com/secureCodeBox/
 [scb-twitter]: https://twitter.com/secureCodeBox
-[scb-slack]: https://join.slack.com/t/securecodebox/shared_invite/enQtNDU3MTUyOTM0NTMwLTBjOWRjNjVkNGEyMjQ0ZGMyNDdlYTQxYWQ4MzNiNGY3MDMxNThkZjJmMzY2NDRhMTk3ZWM3OWFkYmY1YzUxNTU
+[scb-slack]: https://owasp.org/slack/invite
 [scb-license]: https://github.com/secureCodeBox/secureCodeBox/blob/master/LICENSE
 

--- a/hooks/finding-post-processing/docs/README.ArtifactHub.md
+++ b/hooks/finding-post-processing/docs/README.ArtifactHub.md
@@ -119,7 +119,7 @@ Please have a look at [Contributing](./CONTRIBUTING.md)
 You are welcome, please join us on... 👋
 
 - [GitHub][scb-github]
-- [Slack][scb-slack]
+- [OWASP Slack (Channel #project-securecodebox)][scb-slack]
 - [Twitter][scb-twitter]
 
 secureCodeBox is an official [OWASP][scb-owasp] project.
@@ -134,6 +134,6 @@ Code of secureCodeBox is licensed under the [Apache License 2.0][scb-license].
 [scb-site]: https://www.securecodebox.io/
 [scb-github]: https://github.com/secureCodeBox/
 [scb-twitter]: https://twitter.com/secureCodeBox
-[scb-slack]: https://join.slack.com/t/securecodebox/shared_invite/enQtNDU3MTUyOTM0NTMwLTBjOWRjNjVkNGEyMjQ0ZGMyNDdlYTQxYWQ4MzNiNGY3MDMxNThkZjJmMzY2NDRhMTk3ZWM3OWFkYmY1YzUxNTU
+[scb-slack]: https://owasp.org/slack/invite
 [scb-license]: https://github.com/secureCodeBox/secureCodeBox/blob/master/LICENSE
 

--- a/hooks/finding-post-processing/docs/README.DockerHub-Hook.md
+++ b/hooks/finding-post-processing/docs/README.DockerHub-Hook.md
@@ -60,7 +60,7 @@ which can be used to add or update fields from your findings meeting specified c
 You are welcome, please join us on... 👋
 
 - [GitHub][scb-github]
-- [Slack][scb-slack]
+- [OWASP Slack (Channel #project-securecodebox)][scb-slack]
 - [Twitter][scb-twitter]
 
 secureCodeBox is an official [OWASP][scb-owasp] project.
@@ -77,6 +77,6 @@ As for any pre-built image usage, it is the image user's responsibility to ensur
 [scb-site]: https://www.securecodebox.io/
 [scb-github]: https://github.com/secureCodeBox/
 [scb-twitter]: https://twitter.com/secureCodeBox
-[scb-slack]: https://join.slack.com/t/securecodebox/shared_invite/enQtNDU3MTUyOTM0NTMwLTBjOWRjNjVkNGEyMjQ0ZGMyNDdlYTQxYWQ4MzNiNGY3MDMxNThkZjJmMzY2NDRhMTk3ZWM3OWFkYmY1YzUxNTU
+[scb-slack]: https://owasp.org/slack/invite
 [scb-license]: https://github.com/secureCodeBox/secureCodeBox/blob/master/LICENSE
 

--- a/hooks/generic-webhook/README.md
+++ b/hooks/generic-webhook/README.md
@@ -118,6 +118,6 @@ Code of secureCodeBox is licensed under the [Apache License 2.0][scb-license].
 [scb-site]: https://www.securecodebox.io/
 [scb-github]: https://github.com/secureCodeBox/
 [scb-twitter]: https://twitter.com/secureCodeBox
-[scb-slack]: https://join.slack.com/t/securecodebox/shared_invite/enQtNDU3MTUyOTM0NTMwLTBjOWRjNjVkNGEyMjQ0ZGMyNDdlYTQxYWQ4MzNiNGY3MDMxNThkZjJmMzY2NDRhMTk3ZWM3OWFkYmY1YzUxNTU
+[scb-slack]: https://owasp.org/slack/invite
 [scb-license]: https://github.com/secureCodeBox/secureCodeBox/blob/master/LICENSE
 

--- a/hooks/generic-webhook/docs/README.ArtifactHub.md
+++ b/hooks/generic-webhook/docs/README.ArtifactHub.md
@@ -126,7 +126,7 @@ Please have a look at [Contributing](./CONTRIBUTING.md)
 You are welcome, please join us on... 👋
 
 - [GitHub][scb-github]
-- [Slack][scb-slack]
+- [OWASP Slack (Channel #project-securecodebox)][scb-slack]
 - [Twitter][scb-twitter]
 
 secureCodeBox is an official [OWASP][scb-owasp] project.
@@ -141,6 +141,6 @@ Code of secureCodeBox is licensed under the [Apache License 2.0][scb-license].
 [scb-site]: https://www.securecodebox.io/
 [scb-github]: https://github.com/secureCodeBox/
 [scb-twitter]: https://twitter.com/secureCodeBox
-[scb-slack]: https://join.slack.com/t/securecodebox/shared_invite/enQtNDU3MTUyOTM0NTMwLTBjOWRjNjVkNGEyMjQ0ZGMyNDdlYTQxYWQ4MzNiNGY3MDMxNThkZjJmMzY2NDRhMTk3ZWM3OWFkYmY1YzUxNTU
+[scb-slack]: https://owasp.org/slack/invite
 [scb-license]: https://github.com/secureCodeBox/secureCodeBox/blob/master/LICENSE
 

--- a/hooks/generic-webhook/docs/README.DockerHub-Hook.md
+++ b/hooks/generic-webhook/docs/README.DockerHub-Hook.md
@@ -59,7 +59,7 @@ Installing the Generic WebHook hook will add a ReadOnly Hook to your namespace w
 You are welcome, please join us on... 👋
 
 - [GitHub][scb-github]
-- [Slack][scb-slack]
+- [OWASP Slack (Channel #project-securecodebox)][scb-slack]
 - [Twitter][scb-twitter]
 
 secureCodeBox is an official [OWASP][scb-owasp] project.
@@ -76,6 +76,6 @@ As for any pre-built image usage, it is the image user's responsibility to ensur
 [scb-site]: https://www.securecodebox.io/
 [scb-github]: https://github.com/secureCodeBox/
 [scb-twitter]: https://twitter.com/secureCodeBox
-[scb-slack]: https://join.slack.com/t/securecodebox/shared_invite/enQtNDU3MTUyOTM0NTMwLTBjOWRjNjVkNGEyMjQ0ZGMyNDdlYTQxYWQ4MzNiNGY3MDMxNThkZjJmMzY2NDRhMTk3ZWM3OWFkYmY1YzUxNTU
+[scb-slack]: https://owasp.org/slack/invite
 [scb-license]: https://github.com/secureCodeBox/secureCodeBox/blob/master/LICENSE
 

--- a/hooks/notification/README.md
+++ b/hooks/notification/README.md
@@ -506,6 +506,6 @@ Code of secureCodeBox is licensed under the [Apache License 2.0][scb-license].
 [scb-site]: https://www.securecodebox.io/
 [scb-github]: https://github.com/secureCodeBox/
 [scb-twitter]: https://twitter.com/secureCodeBox
-[scb-slack]: https://join.slack.com/t/securecodebox/shared_invite/enQtNDU3MTUyOTM0NTMwLTBjOWRjNjVkNGEyMjQ0ZGMyNDdlYTQxYWQ4MzNiNGY3MDMxNThkZjJmMzY2NDRhMTk3ZWM3OWFkYmY1YzUxNTU
+[scb-slack]: https://owasp.org/slack/invite
 [scb-license]: https://github.com/secureCodeBox/secureCodeBox/blob/master/LICENSE
 

--- a/hooks/notification/docs/README.ArtifactHub.md
+++ b/hooks/notification/docs/README.ArtifactHub.md
@@ -514,7 +514,7 @@ Please have a look at [Contributing](./CONTRIBUTING.md)
 You are welcome, please join us on... 👋
 
 - [GitHub][scb-github]
-- [Slack][scb-slack]
+- [OWASP Slack (Channel #project-securecodebox)][scb-slack]
 - [Twitter][scb-twitter]
 
 secureCodeBox is an official [OWASP][scb-owasp] project.
@@ -529,6 +529,6 @@ Code of secureCodeBox is licensed under the [Apache License 2.0][scb-license].
 [scb-site]: https://www.securecodebox.io/
 [scb-github]: https://github.com/secureCodeBox/
 [scb-twitter]: https://twitter.com/secureCodeBox
-[scb-slack]: https://join.slack.com/t/securecodebox/shared_invite/enQtNDU3MTUyOTM0NTMwLTBjOWRjNjVkNGEyMjQ0ZGMyNDdlYTQxYWQ4MzNiNGY3MDMxNThkZjJmMzY2NDRhMTk3ZWM3OWFkYmY1YzUxNTU
+[scb-slack]: https://owasp.org/slack/invite
 [scb-license]: https://github.com/secureCodeBox/secureCodeBox/blob/master/LICENSE
 

--- a/hooks/notification/docs/README.DockerHub-Hook.md
+++ b/hooks/notification/docs/README.DockerHub-Hook.md
@@ -61,7 +61,7 @@ You can customise the message templates on your behalf or use the already provid
 You are welcome, please join us on... 👋
 
 - [GitHub][scb-github]
-- [Slack][scb-slack]
+- [OWASP Slack (Channel #project-securecodebox)][scb-slack]
 - [Twitter][scb-twitter]
 
 secureCodeBox is an official [OWASP][scb-owasp] project.
@@ -78,6 +78,6 @@ As for any pre-built image usage, it is the image user's responsibility to ensur
 [scb-site]: https://www.securecodebox.io/
 [scb-github]: https://github.com/secureCodeBox/
 [scb-twitter]: https://twitter.com/secureCodeBox
-[scb-slack]: https://join.slack.com/t/securecodebox/shared_invite/enQtNDU3MTUyOTM0NTMwLTBjOWRjNjVkNGEyMjQ0ZGMyNDdlYTQxYWQ4MzNiNGY3MDMxNThkZjJmMzY2NDRhMTk3ZWM3OWFkYmY1YzUxNTU
+[scb-slack]: https://owasp.org/slack/invite
 [scb-license]: https://github.com/secureCodeBox/secureCodeBox/blob/master/LICENSE
 

--- a/hooks/persistence-azure-monitor/README.md
+++ b/hooks/persistence-azure-monitor/README.md
@@ -99,6 +99,6 @@ Code of secureCodeBox is licensed under the [Apache License 2.0][scb-license].
 [scb-site]: https://www.securecodebox.io/
 [scb-github]: https://github.com/secureCodeBox/
 [scb-twitter]: https://twitter.com/secureCodeBox
-[scb-slack]: https://join.slack.com/t/securecodebox/shared_invite/enQtNDU3MTUyOTM0NTMwLTBjOWRjNjVkNGEyMjQ0ZGMyNDdlYTQxYWQ4MzNiNGY3MDMxNThkZjJmMzY2NDRhMTk3ZWM3OWFkYmY1YzUxNTU
+[scb-slack]: https://owasp.org/slack/invite
 [scb-license]: https://github.com/secureCodeBox/secureCodeBox/blob/master/LICENSE
 

--- a/hooks/persistence-azure-monitor/docs/README.ArtifactHub.md
+++ b/hooks/persistence-azure-monitor/docs/README.ArtifactHub.md
@@ -107,7 +107,7 @@ Please have a look at [Contributing](./CONTRIBUTING.md)
 You are welcome, please join us on... 👋
 
 - [GitHub][scb-github]
-- [Slack][scb-slack]
+- [OWASP Slack (Channel #project-securecodebox)][scb-slack]
 - [Twitter][scb-twitter]
 
 secureCodeBox is an official [OWASP][scb-owasp] project.
@@ -122,6 +122,6 @@ Code of secureCodeBox is licensed under the [Apache License 2.0][scb-license].
 [scb-site]: https://www.securecodebox.io/
 [scb-github]: https://github.com/secureCodeBox/
 [scb-twitter]: https://twitter.com/secureCodeBox
-[scb-slack]: https://join.slack.com/t/securecodebox/shared_invite/enQtNDU3MTUyOTM0NTMwLTBjOWRjNjVkNGEyMjQ0ZGMyNDdlYTQxYWQ4MzNiNGY3MDMxNThkZjJmMzY2NDRhMTk3ZWM3OWFkYmY1YzUxNTU
+[scb-slack]: https://owasp.org/slack/invite
 [scb-license]: https://github.com/secureCodeBox/secureCodeBox/blob/master/LICENSE
 

--- a/hooks/persistence-azure-monitor/docs/README.DockerHub-Hook.md
+++ b/hooks/persistence-azure-monitor/docs/README.DockerHub-Hook.md
@@ -63,7 +63,7 @@ Installing the Azure Monitor persistenceProvider hook will add a _ReadOnly Hook_
 You are welcome, please join us on... 👋
 
 - [GitHub][scb-github]
-- [Slack][scb-slack]
+- [OWASP Slack (Channel #project-securecodebox)][scb-slack]
 - [Twitter][scb-twitter]
 
 secureCodeBox is an official [OWASP][scb-owasp] project.
@@ -80,6 +80,6 @@ As for any pre-built image usage, it is the image user's responsibility to ensur
 [scb-site]: https://www.securecodebox.io/
 [scb-github]: https://github.com/secureCodeBox/
 [scb-twitter]: https://twitter.com/secureCodeBox
-[scb-slack]: https://join.slack.com/t/securecodebox/shared_invite/enQtNDU3MTUyOTM0NTMwLTBjOWRjNjVkNGEyMjQ0ZGMyNDdlYTQxYWQ4MzNiNGY3MDMxNThkZjJmMzY2NDRhMTk3ZWM3OWFkYmY1YzUxNTU
+[scb-slack]: https://owasp.org/slack/invite
 [scb-license]: https://github.com/secureCodeBox/secureCodeBox/blob/master/LICENSE
 

--- a/hooks/persistence-defectdojo/README.md
+++ b/hooks/persistence-defectdojo/README.md
@@ -377,6 +377,6 @@ Code of secureCodeBox is licensed under the [Apache License 2.0][scb-license].
 [scb-site]: https://www.securecodebox.io/
 [scb-github]: https://github.com/secureCodeBox/
 [scb-twitter]: https://twitter.com/secureCodeBox
-[scb-slack]: https://join.slack.com/t/securecodebox/shared_invite/enQtNDU3MTUyOTM0NTMwLTBjOWRjNjVkNGEyMjQ0ZGMyNDdlYTQxYWQ4MzNiNGY3MDMxNThkZjJmMzY2NDRhMTk3ZWM3OWFkYmY1YzUxNTU
+[scb-slack]: https://owasp.org/slack/invite
 [scb-license]: https://github.com/secureCodeBox/secureCodeBox/blob/master/LICENSE
 

--- a/hooks/persistence-defectdojo/docs/README.ArtifactHub.md
+++ b/hooks/persistence-defectdojo/docs/README.ArtifactHub.md
@@ -385,7 +385,7 @@ Please have a look at [Contributing](./CONTRIBUTING.md)
 You are welcome, please join us on... 👋
 
 - [GitHub][scb-github]
-- [Slack][scb-slack]
+- [OWASP Slack (Channel #project-securecodebox)][scb-slack]
 - [Twitter][scb-twitter]
 
 secureCodeBox is an official [OWASP][scb-owasp] project.
@@ -400,6 +400,6 @@ Code of secureCodeBox is licensed under the [Apache License 2.0][scb-license].
 [scb-site]: https://www.securecodebox.io/
 [scb-github]: https://github.com/secureCodeBox/
 [scb-twitter]: https://twitter.com/secureCodeBox
-[scb-slack]: https://join.slack.com/t/securecodebox/shared_invite/enQtNDU3MTUyOTM0NTMwLTBjOWRjNjVkNGEyMjQ0ZGMyNDdlYTQxYWQ4MzNiNGY3MDMxNThkZjJmMzY2NDRhMTk3ZWM3OWFkYmY1YzUxNTU
+[scb-slack]: https://owasp.org/slack/invite
 [scb-license]: https://github.com/secureCodeBox/secureCodeBox/blob/master/LICENSE
 

--- a/hooks/persistence-defectdojo/docs/README.DockerHub-Hook.md
+++ b/hooks/persistence-defectdojo/docs/README.DockerHub-Hook.md
@@ -151,7 +151,7 @@ java -jar build/libs/defectdojo-persistenceprovider-0.1.0-SNAPSHOT.jar https://g
 You are welcome, please join us on... 👋
 
 - [GitHub][scb-github]
-- [Slack][scb-slack]
+- [OWASP Slack (Channel #project-securecodebox)][scb-slack]
 - [Twitter][scb-twitter]
 
 secureCodeBox is an official [OWASP][scb-owasp] project.
@@ -168,6 +168,6 @@ As for any pre-built image usage, it is the image user's responsibility to ensur
 [scb-site]: https://www.securecodebox.io/
 [scb-github]: https://github.com/secureCodeBox/
 [scb-twitter]: https://twitter.com/secureCodeBox
-[scb-slack]: https://join.slack.com/t/securecodebox/shared_invite/enQtNDU3MTUyOTM0NTMwLTBjOWRjNjVkNGEyMjQ0ZGMyNDdlYTQxYWQ4MzNiNGY3MDMxNThkZjJmMzY2NDRhMTk3ZWM3OWFkYmY1YzUxNTU
+[scb-slack]: https://owasp.org/slack/invite
 [scb-license]: https://github.com/secureCodeBox/secureCodeBox/blob/master/LICENSE
 

--- a/hooks/persistence-dependencytrack/README.md
+++ b/hooks/persistence-dependencytrack/README.md
@@ -106,7 +106,7 @@ Code of secureCodeBox is licensed under the [Apache License 2.0][scb-license].
 [scb-site]: https://www.securecodebox.io/
 [scb-github]: https://github.com/secureCodeBox/
 [scb-twitter]: https://twitter.com/secureCodeBox
-[scb-slack]: https://join.slack.com/t/securecodebox/shared_invite/enQtNDU3MTUyOTM0NTMwLTBjOWRjNjVkNGEyMjQ0ZGMyNDdlYTQxYWQ4MzNiNGY3MDMxNThkZjJmMzY2NDRhMTk3ZWM3OWFkYmY1YzUxNTU
+[scb-slack]: https://owasp.org/slack/invite
 [scb-license]: https://github.com/secureCodeBox/secureCodeBox/blob/master/LICENSE
 [dependencytrack.org]: https://dependencytrack.org/
 [dt-api-docs]: https://docs.dependencytrack.org/integrations/rest-api/

--- a/hooks/persistence-dependencytrack/docs/README.ArtifactHub.md
+++ b/hooks/persistence-dependencytrack/docs/README.ArtifactHub.md
@@ -114,7 +114,7 @@ Please have a look at [Contributing](./CONTRIBUTING.md)
 You are welcome, please join us on... 👋
 
 - [GitHub][scb-github]
-- [Slack][scb-slack]
+- [OWASP Slack (Channel #project-securecodebox)][scb-slack]
 - [Twitter][scb-twitter]
 
 secureCodeBox is an official [OWASP][scb-owasp] project.
@@ -129,7 +129,7 @@ Code of secureCodeBox is licensed under the [Apache License 2.0][scb-license].
 [scb-site]: https://www.securecodebox.io/
 [scb-github]: https://github.com/secureCodeBox/
 [scb-twitter]: https://twitter.com/secureCodeBox
-[scb-slack]: https://join.slack.com/t/securecodebox/shared_invite/enQtNDU3MTUyOTM0NTMwLTBjOWRjNjVkNGEyMjQ0ZGMyNDdlYTQxYWQ4MzNiNGY3MDMxNThkZjJmMzY2NDRhMTk3ZWM3OWFkYmY1YzUxNTU
+[scb-slack]: https://owasp.org/slack/invite
 [scb-license]: https://github.com/secureCodeBox/secureCodeBox/blob/master/LICENSE
 [dependencytrack.org]: https://dependencytrack.org/
 [dt-api-docs]: https://docs.dependencytrack.org/integrations/rest-api/

--- a/hooks/persistence-dependencytrack/docs/README.DockerHub-Hook.md
+++ b/hooks/persistence-dependencytrack/docs/README.DockerHub-Hook.md
@@ -63,7 +63,7 @@ To use the _secureCodeBox_ to generate SBOMs, you can use the [Trivy-SBOM scanne
 You are welcome, please join us on... 👋
 
 - [GitHub][scb-github]
-- [Slack][scb-slack]
+- [OWASP Slack (Channel #project-securecodebox)][scb-slack]
 - [Twitter][scb-twitter]
 
 secureCodeBox is an official [OWASP][scb-owasp] project.
@@ -80,7 +80,7 @@ As for any pre-built image usage, it is the image user's responsibility to ensur
 [scb-site]: https://www.securecodebox.io/
 [scb-github]: https://github.com/secureCodeBox/
 [scb-twitter]: https://twitter.com/secureCodeBox
-[scb-slack]: https://join.slack.com/t/securecodebox/shared_invite/enQtNDU3MTUyOTM0NTMwLTBjOWRjNjVkNGEyMjQ0ZGMyNDdlYTQxYWQ4MzNiNGY3MDMxNThkZjJmMzY2NDRhMTk3ZWM3OWFkYmY1YzUxNTU
+[scb-slack]: https://owasp.org/slack/invite
 [scb-license]: https://github.com/secureCodeBox/secureCodeBox/blob/master/LICENSE
 [dependencytrack.org]: https://dependencytrack.org/
 [dt-api-docs]: https://docs.dependencytrack.org/integrations/rest-api/

--- a/hooks/persistence-elastic/README.md
+++ b/hooks/persistence-elastic/README.md
@@ -115,6 +115,6 @@ Code of secureCodeBox is licensed under the [Apache License 2.0][scb-license].
 [scb-site]: https://www.securecodebox.io/
 [scb-github]: https://github.com/secureCodeBox/
 [scb-twitter]: https://twitter.com/secureCodeBox
-[scb-slack]: https://join.slack.com/t/securecodebox/shared_invite/enQtNDU3MTUyOTM0NTMwLTBjOWRjNjVkNGEyMjQ0ZGMyNDdlYTQxYWQ4MzNiNGY3MDMxNThkZjJmMzY2NDRhMTk3ZWM3OWFkYmY1YzUxNTU
+[scb-slack]: https://owasp.org/slack/invite
 [scb-license]: https://github.com/secureCodeBox/secureCodeBox/blob/master/LICENSE
 [elastic.io]: https://www.elastic.co/products/elasticsearch

--- a/hooks/persistence-elastic/docs/README.ArtifactHub.md
+++ b/hooks/persistence-elastic/docs/README.ArtifactHub.md
@@ -123,7 +123,7 @@ Please have a look at [Contributing](./CONTRIBUTING.md)
 You are welcome, please join us on... 👋
 
 - [GitHub][scb-github]
-- [Slack][scb-slack]
+- [OWASP Slack (Channel #project-securecodebox)][scb-slack]
 - [Twitter][scb-twitter]
 
 secureCodeBox is an official [OWASP][scb-owasp] project.
@@ -138,6 +138,6 @@ Code of secureCodeBox is licensed under the [Apache License 2.0][scb-license].
 [scb-site]: https://www.securecodebox.io/
 [scb-github]: https://github.com/secureCodeBox/
 [scb-twitter]: https://twitter.com/secureCodeBox
-[scb-slack]: https://join.slack.com/t/securecodebox/shared_invite/enQtNDU3MTUyOTM0NTMwLTBjOWRjNjVkNGEyMjQ0ZGMyNDdlYTQxYWQ4MzNiNGY3MDMxNThkZjJmMzY2NDRhMTk3ZWM3OWFkYmY1YzUxNTU
+[scb-slack]: https://owasp.org/slack/invite
 [scb-license]: https://github.com/secureCodeBox/secureCodeBox/blob/master/LICENSE
 [elastic.io]: https://www.elastic.co/products/elasticsearch

--- a/hooks/persistence-elastic/docs/README.DockerHub-Hook.md
+++ b/hooks/persistence-elastic/docs/README.DockerHub-Hook.md
@@ -61,7 +61,7 @@ Installing the Elasticsearch persistenceProvider hook will add a _ReadOnly Hook_
 You are welcome, please join us on... 👋
 
 - [GitHub][scb-github]
-- [Slack][scb-slack]
+- [OWASP Slack (Channel #project-securecodebox)][scb-slack]
 - [Twitter][scb-twitter]
 
 secureCodeBox is an official [OWASP][scb-owasp] project.
@@ -78,6 +78,6 @@ As for any pre-built image usage, it is the image user's responsibility to ensur
 [scb-site]: https://www.securecodebox.io/
 [scb-github]: https://github.com/secureCodeBox/
 [scb-twitter]: https://twitter.com/secureCodeBox
-[scb-slack]: https://join.slack.com/t/securecodebox/shared_invite/enQtNDU3MTUyOTM0NTMwLTBjOWRjNjVkNGEyMjQ0ZGMyNDdlYTQxYWQ4MzNiNGY3MDMxNThkZjJmMzY2NDRhMTk3ZWM3OWFkYmY1YzUxNTU
+[scb-slack]: https://owasp.org/slack/invite
 [scb-license]: https://github.com/secureCodeBox/secureCodeBox/blob/master/LICENSE
 [elastic.io]: https://www.elastic.co/products/elasticsearch

--- a/hooks/update-field-hook/README.md
+++ b/hooks/update-field-hook/README.md
@@ -85,6 +85,6 @@ Code of secureCodeBox is licensed under the [Apache License 2.0][scb-license].
 [scb-site]: https://www.securecodebox.io/
 [scb-github]: https://github.com/secureCodeBox/
 [scb-twitter]: https://twitter.com/secureCodeBox
-[scb-slack]: https://join.slack.com/t/securecodebox/shared_invite/enQtNDU3MTUyOTM0NTMwLTBjOWRjNjVkNGEyMjQ0ZGMyNDdlYTQxYWQ4MzNiNGY3MDMxNThkZjJmMzY2NDRhMTk3ZWM3OWFkYmY1YzUxNTU
+[scb-slack]: https://owasp.org/slack/invite
 [scb-license]: https://github.com/secureCodeBox/secureCodeBox/blob/master/LICENSE
 

--- a/hooks/update-field-hook/docs/README.ArtifactHub.md
+++ b/hooks/update-field-hook/docs/README.ArtifactHub.md
@@ -93,7 +93,7 @@ Please have a look at [Contributing](./CONTRIBUTING.md)
 You are welcome, please join us on... 👋
 
 - [GitHub][scb-github]
-- [Slack][scb-slack]
+- [OWASP Slack (Channel #project-securecodebox)][scb-slack]
 - [Twitter][scb-twitter]
 
 secureCodeBox is an official [OWASP][scb-owasp] project.
@@ -108,6 +108,6 @@ Code of secureCodeBox is licensed under the [Apache License 2.0][scb-license].
 [scb-site]: https://www.securecodebox.io/
 [scb-github]: https://github.com/secureCodeBox/
 [scb-twitter]: https://twitter.com/secureCodeBox
-[scb-slack]: https://join.slack.com/t/securecodebox/shared_invite/enQtNDU3MTUyOTM0NTMwLTBjOWRjNjVkNGEyMjQ0ZGMyNDdlYTQxYWQ4MzNiNGY3MDMxNThkZjJmMzY2NDRhMTk3ZWM3OWFkYmY1YzUxNTU
+[scb-slack]: https://owasp.org/slack/invite
 [scb-license]: https://github.com/secureCodeBox/secureCodeBox/blob/master/LICENSE
 

--- a/hooks/update-field-hook/docs/README.DockerHub-Hook.md
+++ b/hooks/update-field-hook/docs/README.DockerHub-Hook.md
@@ -60,7 +60,7 @@ docker pull securecodebox/hook-update-field-hook
 You are welcome, please join us on... 👋
 
 - [GitHub][scb-github]
-- [Slack][scb-slack]
+- [OWASP Slack (Channel #project-securecodebox)][scb-slack]
 - [Twitter][scb-twitter]
 
 secureCodeBox is an official [OWASP][scb-owasp] project.
@@ -77,6 +77,6 @@ As for any pre-built image usage, it is the image user's responsibility to ensur
 [scb-site]: https://www.securecodebox.io/
 [scb-github]: https://github.com/secureCodeBox/
 [scb-twitter]: https://twitter.com/secureCodeBox
-[scb-slack]: https://join.slack.com/t/securecodebox/shared_invite/enQtNDU3MTUyOTM0NTMwLTBjOWRjNjVkNGEyMjQ0ZGMyNDdlYTQxYWQ4MzNiNGY3MDMxNThkZjJmMzY2NDRhMTk3ZWM3OWFkYmY1YzUxNTU
+[scb-slack]: https://owasp.org/slack/invite
 [scb-license]: https://github.com/secureCodeBox/secureCodeBox/blob/master/LICENSE
 

--- a/lurker/docs/README.DockerHub-Core.md
+++ b/lurker/docs/README.DockerHub-Core.md
@@ -61,7 +61,7 @@ The secureCodeBox operator is running on Kubernetes and is the core component of
 You are welcome, please join us on... 👋
 
 - [GitHub][scb-github]
-- [Slack][scb-slack]
+- [OWASP Slack (Channel #project-securecodebox)][scb-slack]
 - [Twitter][scb-twitter]
 
 secureCodeBox is an official [OWASP][scb-owasp] project.
@@ -80,5 +80,5 @@ As for any pre-built image usage, it is the image user's responsibility to ensur
 [scb-site]: https://www.securecodebox.io/
 [scb-github]: https://github.com/secureCodeBox/
 [scb-twitter]: https://twitter.com/secureCodeBox
-[scb-slack]: https://join.slack.com/t/securecodebox/shared_invite/enQtNDU3MTUyOTM0NTMwLTBjOWRjNjVkNGEyMjQ0ZGMyNDdlYTQxYWQ4MzNiNGY3MDMxNThkZjJmMzY2NDRhMTk3ZWM3OWFkYmY1YzUxNTU
+[scb-slack]: https://owasp.org/slack/invite
 [scb-license]: https://github.com/secureCodeBox/secureCodeBox/blob/master/LICENSE

--- a/operator/README.md
+++ b/operator/README.md
@@ -119,6 +119,6 @@ Code of secureCodeBox is licensed under the [Apache License 2.0][scb-license].
 [scb-site]: https://www.securecodebox.io/
 [scb-github]: https://github.com/secureCodeBox/
 [scb-twitter]: https://twitter.com/secureCodeBox
-[scb-slack]: https://join.slack.com/t/securecodebox/shared_invite/enQtNDU3MTUyOTM0NTMwLTBjOWRjNjVkNGEyMjQ0ZGMyNDdlYTQxYWQ4MzNiNGY3MDMxNThkZjJmMzY2NDRhMTk3ZWM3OWFkYmY1YzUxNTU
+[scb-slack]: https://owasp.org/slack/invite
 [scb-license]: https://github.com/secureCodeBox/secureCodeBox/blob/master/LICENSE
 

--- a/operator/docs/README.ArtifactHub.md
+++ b/operator/docs/README.ArtifactHub.md
@@ -124,7 +124,7 @@ Please have a look at [Contributing](./CONTRIBUTING.md)
 You are welcome, please join us on... 👋
 
 - [GitHub][scb-github]
-- [Slack][scb-slack]
+- [OWASP Slack (Channel #project-securecodebox)][scb-slack]
 - [Twitter][scb-twitter]
 
 secureCodeBox is an official [OWASP][scb-owasp] project.
@@ -139,6 +139,6 @@ Code of secureCodeBox is licensed under the [Apache License 2.0][scb-license].
 [scb-site]: https://www.securecodebox.io/
 [scb-github]: https://github.com/secureCodeBox/
 [scb-twitter]: https://twitter.com/secureCodeBox
-[scb-slack]: https://join.slack.com/t/securecodebox/shared_invite/enQtNDU3MTUyOTM0NTMwLTBjOWRjNjVkNGEyMjQ0ZGMyNDdlYTQxYWQ4MzNiNGY3MDMxNThkZjJmMzY2NDRhMTk3ZWM3OWFkYmY1YzUxNTU
+[scb-slack]: https://owasp.org/slack/invite
 [scb-license]: https://github.com/secureCodeBox/secureCodeBox/blob/master/LICENSE
 

--- a/operator/docs/README.DockerHub-Core.md
+++ b/operator/docs/README.DockerHub-Core.md
@@ -61,7 +61,7 @@ The secureCodeBox operator is running on Kubernetes and is the core component of
 You are welcome, please join us on... 👋
 
 - [GitHub][scb-github]
-- [Slack][scb-slack]
+- [OWASP Slack (Channel #project-securecodebox)][scb-slack]
 - [Twitter][scb-twitter]
 
 secureCodeBox is an official [OWASP][scb-owasp] project.
@@ -78,6 +78,6 @@ As for any pre-built image usage, it is the image user's responsibility to ensur
 [scb-site]: https://www.securecodebox.io/
 [scb-github]: https://github.com/secureCodeBox/
 [scb-twitter]: https://twitter.com/secureCodeBox
-[scb-slack]: https://join.slack.com/t/securecodebox/shared_invite/enQtNDU3MTUyOTM0NTMwLTBjOWRjNjVkNGEyMjQ0ZGMyNDdlYTQxYWQ4MzNiNGY3MDMxNThkZjJmMzY2NDRhMTk3ZWM3OWFkYmY1YzUxNTU
+[scb-slack]: https://owasp.org/slack/invite
 [scb-license]: https://github.com/secureCodeBox/secureCodeBox/blob/master/LICENSE
 

--- a/scanners/amass/README.md
+++ b/scanners/amass/README.md
@@ -116,7 +116,7 @@ Code of secureCodeBox is licensed under the [Apache License 2.0][scb-license].
 [scb-site]: https://www.securecodebox.io/
 [scb-github]: https://github.com/secureCodeBox/
 [scb-twitter]: https://twitter.com/secureCodeBox
-[scb-slack]: https://join.slack.com/t/securecodebox/shared_invite/enQtNDU3MTUyOTM0NTMwLTBjOWRjNjVkNGEyMjQ0ZGMyNDdlYTQxYWQ4MzNiNGY3MDMxNThkZjJmMzY2NDRhMTk3ZWM3OWFkYmY1YzUxNTU
+[scb-slack]: https://owasp.org/slack/invite
 [scb-license]: https://github.com/secureCodeBox/secureCodeBox/blob/master/LICENSE
 [owasp_amass_project]: https://owasp.org/www-project-amass/
 [amass github]: https://github.com/OWASP/Amass

--- a/scanners/amass/docs/README.ArtifactHub.md
+++ b/scanners/amass/docs/README.ArtifactHub.md
@@ -121,7 +121,7 @@ Please have a look at [Contributing](./CONTRIBUTING.md)
 You are welcome, please join us on... 👋
 
 - [GitHub][scb-github]
-- [Slack][scb-slack]
+- [OWASP Slack (Channel #project-securecodebox)][scb-slack]
 - [Twitter][scb-twitter]
 
 secureCodeBox is an official [OWASP][scb-owasp] project.
@@ -136,7 +136,7 @@ Code of secureCodeBox is licensed under the [Apache License 2.0][scb-license].
 [scb-site]: https://www.securecodebox.io/
 [scb-github]: https://github.com/secureCodeBox/
 [scb-twitter]: https://twitter.com/secureCodeBox
-[scb-slack]: https://join.slack.com/t/securecodebox/shared_invite/enQtNDU3MTUyOTM0NTMwLTBjOWRjNjVkNGEyMjQ0ZGMyNDdlYTQxYWQ4MzNiNGY3MDMxNThkZjJmMzY2NDRhMTk3ZWM3OWFkYmY1YzUxNTU
+[scb-slack]: https://owasp.org/slack/invite
 [scb-license]: https://github.com/secureCodeBox/secureCodeBox/blob/master/LICENSE
 [owasp_amass_project]: https://owasp.org/www-project-amass/
 [amass github]: https://github.com/OWASP/Amass

--- a/scanners/amass/docs/README.DockerHub-Parser.md
+++ b/scanners/amass/docs/README.DockerHub-Parser.md
@@ -69,7 +69,7 @@ The [OWASP Amass Project][owasp_amass_project] has developed a tool to help info
 You are welcome, please join us on... 👋
 
 - [GitHub][scb-github]
-- [Slack][scb-slack]
+- [OWASP Slack (Channel #project-securecodebox)][scb-slack]
 - [Twitter][scb-twitter]
 
 secureCodeBox is an official [OWASP][scb-owasp] project.
@@ -86,7 +86,7 @@ As for any pre-built image usage, it is the image user's responsibility to ensur
 [scb-site]: https://www.securecodebox.io/
 [scb-github]: https://github.com/secureCodeBox/
 [scb-twitter]: https://twitter.com/secureCodeBox
-[scb-slack]: https://join.slack.com/t/securecodebox/shared_invite/enQtNDU3MTUyOTM0NTMwLTBjOWRjNjVkNGEyMjQ0ZGMyNDdlYTQxYWQ4MzNiNGY3MDMxNThkZjJmMzY2NDRhMTk3ZWM3OWFkYmY1YzUxNTU
+[scb-slack]: https://owasp.org/slack/invite
 [scb-license]: https://github.com/secureCodeBox/secureCodeBox/blob/master/LICENSE
 [owasp_amass_project]: https://owasp.org/www-project-amass/
 [amass github]: https://github.com/OWASP/Amass

--- a/scanners/amass/docs/README.DockerHub-Scanner.md
+++ b/scanners/amass/docs/README.DockerHub-Scanner.md
@@ -82,7 +82,7 @@ Special command line options:
 You are welcome, please join us on... 👋
 
 - [GitHub][scb-github]
-- [Slack][scb-slack]
+- [OWASP Slack (Channel #project-securecodebox)][scb-slack]
 - [Twitter][scb-twitter]
 
 secureCodeBox is an official [OWASP][scb-owasp] project.
@@ -99,7 +99,7 @@ As for any pre-built image usage, it is the image user's responsibility to ensur
 [scb-site]: https://www.securecodebox.io/
 [scb-github]: https://github.com/secureCodeBox/
 [scb-twitter]: https://twitter.com/secureCodeBox
-[scb-slack]: https://join.slack.com/t/securecodebox/shared_invite/enQtNDU3MTUyOTM0NTMwLTBjOWRjNjVkNGEyMjQ0ZGMyNDdlYTQxYWQ4MzNiNGY3MDMxNThkZjJmMzY2NDRhMTk3ZWM3OWFkYmY1YzUxNTU
+[scb-slack]: https://owasp.org/slack/invite
 [scb-license]: https://github.com/secureCodeBox/secureCodeBox/blob/master/LICENSE
 [owasp_amass_project]: https://owasp.org/www-project-amass/
 [amass github]: https://github.com/OWASP/Amass

--- a/scanners/cmseek/README.md
+++ b/scanners/cmseek/README.md
@@ -114,6 +114,6 @@ Code of secureCodeBox is licensed under the [Apache License 2.0][scb-license].
 [scb-site]: https://www.securecodebox.io/
 [scb-github]: https://github.com/secureCodeBox/
 [scb-twitter]: https://twitter.com/secureCodeBox
-[scb-slack]: https://join.slack.com/t/securecodebox/shared_invite/enQtNDU3MTUyOTM0NTMwLTBjOWRjNjVkNGEyMjQ0ZGMyNDdlYTQxYWQ4MzNiNGY3MDMxNThkZjJmMzY2NDRhMTk3ZWM3OWFkYmY1YzUxNTU
+[scb-slack]: https://owasp.org/slack/invite
 [scb-license]: https://github.com/secureCodeBox/secureCodeBox/blob/master/LICENSE
 

--- a/scanners/cmseek/docs/README.ArtifactHub.md
+++ b/scanners/cmseek/docs/README.ArtifactHub.md
@@ -121,7 +121,7 @@ Please have a look at [Contributing](./CONTRIBUTING.md)
 You are welcome, please join us on... 👋
 
 - [GitHub][scb-github]
-- [Slack][scb-slack]
+- [OWASP Slack (Channel #project-securecodebox)][scb-slack]
 - [Twitter][scb-twitter]
 
 secureCodeBox is an official [OWASP][scb-owasp] project.
@@ -136,6 +136,6 @@ Code of secureCodeBox is licensed under the [Apache License 2.0][scb-license].
 [scb-site]: https://www.securecodebox.io/
 [scb-github]: https://github.com/secureCodeBox/
 [scb-twitter]: https://twitter.com/secureCodeBox
-[scb-slack]: https://join.slack.com/t/securecodebox/shared_invite/enQtNDU3MTUyOTM0NTMwLTBjOWRjNjVkNGEyMjQ0ZGMyNDdlYTQxYWQ4MzNiNGY3MDMxNThkZjJmMzY2NDRhMTk3ZWM3OWFkYmY1YzUxNTU
+[scb-slack]: https://owasp.org/slack/invite
 [scb-license]: https://github.com/secureCodeBox/secureCodeBox/blob/master/LICENSE
 

--- a/scanners/cmseek/docs/README.DockerHub-Parser.md
+++ b/scanners/cmseek/docs/README.DockerHub-Parser.md
@@ -62,7 +62,7 @@ To learn more about the CMSeeK scanner itself, visit the CMSeeK GitHub repositor
 You are welcome, please join us on... 👋
 
 - [GitHub][scb-github]
-- [Slack][scb-slack]
+- [OWASP Slack (Channel #project-securecodebox)][scb-slack]
 - [Twitter][scb-twitter]
 
 secureCodeBox is an official [OWASP][scb-owasp] project.
@@ -79,6 +79,6 @@ As for any pre-built image usage, it is the image user's responsibility to ensur
 [scb-site]: https://www.securecodebox.io/
 [scb-github]: https://github.com/secureCodeBox/
 [scb-twitter]: https://twitter.com/secureCodeBox
-[scb-slack]: https://join.slack.com/t/securecodebox/shared_invite/enQtNDU3MTUyOTM0NTMwLTBjOWRjNjVkNGEyMjQ0ZGMyNDdlYTQxYWQ4MzNiNGY3MDMxNThkZjJmMzY2NDRhMTk3ZWM3OWFkYmY1YzUxNTU
+[scb-slack]: https://owasp.org/slack/invite
 [scb-license]: https://github.com/secureCodeBox/secureCodeBox/blob/master/LICENSE
 

--- a/scanners/cmseek/docs/README.DockerHub-Scanner.md
+++ b/scanners/cmseek/docs/README.DockerHub-Scanner.md
@@ -77,7 +77,7 @@ Some useful example parameters listed below:
 You are welcome, please join us on... 👋
 
 - [GitHub][scb-github]
-- [Slack][scb-slack]
+- [OWASP Slack (Channel #project-securecodebox)][scb-slack]
 - [Twitter][scb-twitter]
 
 secureCodeBox is an official [OWASP][scb-owasp] project.
@@ -94,6 +94,6 @@ As for any pre-built image usage, it is the image user's responsibility to ensur
 [scb-site]: https://www.securecodebox.io/
 [scb-github]: https://github.com/secureCodeBox/
 [scb-twitter]: https://twitter.com/secureCodeBox
-[scb-slack]: https://join.slack.com/t/securecodebox/shared_invite/enQtNDU3MTUyOTM0NTMwLTBjOWRjNjVkNGEyMjQ0ZGMyNDdlYTQxYWQ4MzNiNGY3MDMxNThkZjJmMzY2NDRhMTk3ZWM3OWFkYmY1YzUxNTU
+[scb-slack]: https://owasp.org/slack/invite
 [scb-license]: https://github.com/secureCodeBox/secureCodeBox/blob/master/LICENSE
 

--- a/scanners/doggo/README.md
+++ b/scanners/doggo/README.md
@@ -104,7 +104,7 @@ Code of secureCodeBox is licensed under the [Apache License 2.0][scb-license].
 [scb-site]: https://www.securecodebox.io/
 [scb-github]: https://github.com/secureCodeBox/
 [scb-twitter]: https://twitter.com/secureCodeBox
-[scb-slack]: https://join.slack.com/t/securecodebox/shared_invite/enQtNDU3MTUyOTM0NTMwLTBjOWRjNjVkNGEyMjQ0ZGMyNDdlYTQxYWQ4MzNiNGY3MDMxNThkZjJmMzY2NDRhMTk3ZWM3OWFkYmY1YzUxNTU
+[scb-slack]: https://owasp.org/slack/invite
 [scb-license]: https://github.com/secureCodeBox/secureCodeBox/blob/master/LICENSE
 [doggo GitHub]: https://github.com/mr-karan/doggo
 [doggo Demo]: https://doggo.mrkaran.dev/

--- a/scanners/doggo/docs/README.ArtifactHub.md
+++ b/scanners/doggo/docs/README.ArtifactHub.md
@@ -111,7 +111,7 @@ Please have a look at [Contributing](./CONTRIBUTING.md)
 You are welcome, please join us on... 👋
 
 - [GitHub][scb-github]
-- [Slack][scb-slack]
+- [OWASP Slack (Channel #project-securecodebox)][scb-slack]
 - [Twitter][scb-twitter]
 
 secureCodeBox is an official [OWASP][scb-owasp] project.
@@ -126,7 +126,7 @@ Code of secureCodeBox is licensed under the [Apache License 2.0][scb-license].
 [scb-site]: https://www.securecodebox.io/
 [scb-github]: https://github.com/secureCodeBox/
 [scb-twitter]: https://twitter.com/secureCodeBox
-[scb-slack]: https://join.slack.com/t/securecodebox/shared_invite/enQtNDU3MTUyOTM0NTMwLTBjOWRjNjVkNGEyMjQ0ZGMyNDdlYTQxYWQ4MzNiNGY3MDMxNThkZjJmMzY2NDRhMTk3ZWM3OWFkYmY1YzUxNTU
+[scb-slack]: https://owasp.org/slack/invite
 [scb-license]: https://github.com/secureCodeBox/secureCodeBox/blob/master/LICENSE
 [doggo GitHub]: https://github.com/mr-karan/doggo
 [doggo Demo]: https://doggo.mrkaran.dev/

--- a/scanners/doggo/docs/README.DockerHub-Parser.md
+++ b/scanners/doggo/docs/README.DockerHub-Parser.md
@@ -61,7 +61,7 @@ To learn more about the doggo scanner itself visit [doggo GitHub].
 You are welcome, please join us on... 👋
 
 - [GitHub][scb-github]
-- [Slack][scb-slack]
+- [OWASP Slack (Channel #project-securecodebox)][scb-slack]
 - [Twitter][scb-twitter]
 
 secureCodeBox is an official [OWASP][scb-owasp] project.
@@ -78,7 +78,7 @@ As for any pre-built image usage, it is the image user's responsibility to ensur
 [scb-site]: https://www.securecodebox.io/
 [scb-github]: https://github.com/secureCodeBox/
 [scb-twitter]: https://twitter.com/secureCodeBox
-[scb-slack]: https://join.slack.com/t/securecodebox/shared_invite/enQtNDU3MTUyOTM0NTMwLTBjOWRjNjVkNGEyMjQ0ZGMyNDdlYTQxYWQ4MzNiNGY3MDMxNThkZjJmMzY2NDRhMTk3ZWM3OWFkYmY1YzUxNTU
+[scb-slack]: https://owasp.org/slack/invite
 [scb-license]: https://github.com/secureCodeBox/secureCodeBox/blob/master/LICENSE
 [doggo GitHub]: https://github.com/mr-karan/doggo
 [doggo Demo]: https://doggo.mrkaran.dev/

--- a/scanners/doggo/docs/README.DockerHub-Scanner.md
+++ b/scanners/doggo/docs/README.DockerHub-Scanner.md
@@ -67,7 +67,7 @@ The following security scan configuration example are based on the [doggo User G
 You are welcome, please join us on... 👋
 
 - [GitHub][scb-github]
-- [Slack][scb-slack]
+- [OWASP Slack (Channel #project-securecodebox)][scb-slack]
 - [Twitter][scb-twitter]
 
 secureCodeBox is an official [OWASP][scb-owasp] project.
@@ -84,7 +84,7 @@ As for any pre-built image usage, it is the image user's responsibility to ensur
 [scb-site]: https://www.securecodebox.io/
 [scb-github]: https://github.com/secureCodeBox/
 [scb-twitter]: https://twitter.com/secureCodeBox
-[scb-slack]: https://join.slack.com/t/securecodebox/shared_invite/enQtNDU3MTUyOTM0NTMwLTBjOWRjNjVkNGEyMjQ0ZGMyNDdlYTQxYWQ4MzNiNGY3MDMxNThkZjJmMzY2NDRhMTk3ZWM3OWFkYmY1YzUxNTU
+[scb-slack]: https://owasp.org/slack/invite
 [scb-license]: https://github.com/secureCodeBox/secureCodeBox/blob/master/LICENSE
 [doggo GitHub]: https://github.com/mr-karan/doggo
 [doggo Demo]: https://doggo.mrkaran.dev/

--- a/scanners/ffuf/README.md
+++ b/scanners/ffuf/README.md
@@ -213,6 +213,6 @@ Code of secureCodeBox is licensed under the [Apache License 2.0][scb-license].
 [scb-site]: https://www.securecodebox.io/
 [scb-github]: https://github.com/secureCodeBox/
 [scb-twitter]: https://twitter.com/secureCodeBox
-[scb-slack]: https://join.slack.com/t/securecodebox/shared_invite/enQtNDU3MTUyOTM0NTMwLTBjOWRjNjVkNGEyMjQ0ZGMyNDdlYTQxYWQ4MzNiNGY3MDMxNThkZjJmMzY2NDRhMTk3ZWM3OWFkYmY1YzUxNTU
+[scb-slack]: https://owasp.org/slack/invite
 [scb-license]: https://github.com/secureCodeBox/secureCodeBox/blob/master/LICENSE
 

--- a/scanners/ffuf/docs/README.ArtifactHub.md
+++ b/scanners/ffuf/docs/README.ArtifactHub.md
@@ -218,7 +218,7 @@ Please have a look at [Contributing](./CONTRIBUTING.md)
 You are welcome, please join us on... 👋
 
 - [GitHub][scb-github]
-- [Slack][scb-slack]
+- [OWASP Slack (Channel #project-securecodebox)][scb-slack]
 - [Twitter][scb-twitter]
 
 secureCodeBox is an official [OWASP][scb-owasp] project.
@@ -233,6 +233,6 @@ Code of secureCodeBox is licensed under the [Apache License 2.0][scb-license].
 [scb-site]: https://www.securecodebox.io/
 [scb-github]: https://github.com/secureCodeBox/
 [scb-twitter]: https://twitter.com/secureCodeBox
-[scb-slack]: https://join.slack.com/t/securecodebox/shared_invite/enQtNDU3MTUyOTM0NTMwLTBjOWRjNjVkNGEyMjQ0ZGMyNDdlYTQxYWQ4MzNiNGY3MDMxNThkZjJmMzY2NDRhMTk3ZWM3OWFkYmY1YzUxNTU
+[scb-slack]: https://owasp.org/slack/invite
 [scb-license]: https://github.com/secureCodeBox/secureCodeBox/blob/master/LICENSE
 

--- a/scanners/ffuf/docs/README.DockerHub-Parser.md
+++ b/scanners/ffuf/docs/README.DockerHub-Parser.md
@@ -63,7 +63,7 @@ With this scanner the secure code box also installs SecLists wordlists.
 You are welcome, please join us on... 👋
 
 - [GitHub][scb-github]
-- [Slack][scb-slack]
+- [OWASP Slack (Channel #project-securecodebox)][scb-slack]
 - [Twitter][scb-twitter]
 
 secureCodeBox is an official [OWASP][scb-owasp] project.
@@ -80,6 +80,6 @@ As for any pre-built image usage, it is the image user's responsibility to ensur
 [scb-site]: https://www.securecodebox.io/
 [scb-github]: https://github.com/secureCodeBox/
 [scb-twitter]: https://twitter.com/secureCodeBox
-[scb-slack]: https://join.slack.com/t/securecodebox/shared_invite/enQtNDU3MTUyOTM0NTMwLTBjOWRjNjVkNGEyMjQ0ZGMyNDdlYTQxYWQ4MzNiNGY3MDMxNThkZjJmMzY2NDRhMTk3ZWM3OWFkYmY1YzUxNTU
+[scb-slack]: https://owasp.org/slack/invite
 [scb-license]: https://github.com/secureCodeBox/secureCodeBox/blob/master/LICENSE
 

--- a/scanners/ffuf/docs/README.DockerHub-Scanner.md
+++ b/scanners/ffuf/docs/README.DockerHub-Scanner.md
@@ -159,7 +159,7 @@ More information and examples: https://github.com/ffuf/ffuf
 You are welcome, please join us on... 👋
 
 - [GitHub][scb-github]
-- [Slack][scb-slack]
+- [OWASP Slack (Channel #project-securecodebox)][scb-slack]
 - [Twitter][scb-twitter]
 
 secureCodeBox is an official [OWASP][scb-owasp] project.
@@ -176,6 +176,6 @@ As for any pre-built image usage, it is the image user's responsibility to ensur
 [scb-site]: https://www.securecodebox.io/
 [scb-github]: https://github.com/secureCodeBox/
 [scb-twitter]: https://twitter.com/secureCodeBox
-[scb-slack]: https://join.slack.com/t/securecodebox/shared_invite/enQtNDU3MTUyOTM0NTMwLTBjOWRjNjVkNGEyMjQ0ZGMyNDdlYTQxYWQ4MzNiNGY3MDMxNThkZjJmMzY2NDRhMTk3ZWM3OWFkYmY1YzUxNTU
+[scb-slack]: https://owasp.org/slack/invite
 [scb-license]: https://github.com/secureCodeBox/secureCodeBox/blob/master/LICENSE
 

--- a/scanners/git-repo-scanner/README.md
+++ b/scanners/git-repo-scanner/README.md
@@ -142,6 +142,6 @@ Code of secureCodeBox is licensed under the [Apache License 2.0][scb-license].
 [scb-site]: https://www.securecodebox.io/
 [scb-github]: https://github.com/secureCodeBox/
 [scb-twitter]: https://twitter.com/secureCodeBox
-[scb-slack]: https://join.slack.com/t/securecodebox/shared_invite/enQtNDU3MTUyOTM0NTMwLTBjOWRjNjVkNGEyMjQ0ZGMyNDdlYTQxYWQ4MzNiNGY3MDMxNThkZjJmMzY2NDRhMTk3ZWM3OWFkYmY1YzUxNTU
+[scb-slack]: https://owasp.org/slack/invite
 [scb-license]: https://github.com/secureCodeBox/secureCodeBox/blob/master/LICENSE
 

--- a/scanners/git-repo-scanner/docs/README.ArtifactHub.md
+++ b/scanners/git-repo-scanner/docs/README.ArtifactHub.md
@@ -149,7 +149,7 @@ Please have a look at [Contributing](./CONTRIBUTING.md)
 You are welcome, please join us on... 👋
 
 - [GitHub][scb-github]
-- [Slack][scb-slack]
+- [OWASP Slack (Channel #project-securecodebox)][scb-slack]
 - [Twitter][scb-twitter]
 
 secureCodeBox is an official [OWASP][scb-owasp] project.
@@ -164,6 +164,6 @@ Code of secureCodeBox is licensed under the [Apache License 2.0][scb-license].
 [scb-site]: https://www.securecodebox.io/
 [scb-github]: https://github.com/secureCodeBox/
 [scb-twitter]: https://twitter.com/secureCodeBox
-[scb-slack]: https://join.slack.com/t/securecodebox/shared_invite/enQtNDU3MTUyOTM0NTMwLTBjOWRjNjVkNGEyMjQ0ZGMyNDdlYTQxYWQ4MzNiNGY3MDMxNThkZjJmMzY2NDRhMTk3ZWM3OWFkYmY1YzUxNTU
+[scb-slack]: https://owasp.org/slack/invite
 [scb-license]: https://github.com/secureCodeBox/secureCodeBox/blob/master/LICENSE
 

--- a/scanners/git-repo-scanner/docs/README.DockerHub-Parser.md
+++ b/scanners/git-repo-scanner/docs/README.DockerHub-Parser.md
@@ -61,7 +61,7 @@ is to provide a cascading input for the [gitleaks](/docs/scanners/gitleaks) and 
 You are welcome, please join us on... 👋
 
 - [GitHub][scb-github]
-- [Slack][scb-slack]
+- [OWASP Slack (Channel #project-securecodebox)][scb-slack]
 - [Twitter][scb-twitter]
 
 secureCodeBox is an official [OWASP][scb-owasp] project.
@@ -78,6 +78,6 @@ As for any pre-built image usage, it is the image user's responsibility to ensur
 [scb-site]: https://www.securecodebox.io/
 [scb-github]: https://github.com/secureCodeBox/
 [scb-twitter]: https://twitter.com/secureCodeBox
-[scb-slack]: https://join.slack.com/t/securecodebox/shared_invite/enQtNDU3MTUyOTM0NTMwLTBjOWRjNjVkNGEyMjQ0ZGMyNDdlYTQxYWQ4MzNiNGY3MDMxNThkZjJmMzY2NDRhMTk3ZWM3OWFkYmY1YzUxNTU
+[scb-slack]: https://owasp.org/slack/invite
 [scb-license]: https://github.com/secureCodeBox/secureCodeBox/blob/master/LICENSE
 

--- a/scanners/git-repo-scanner/docs/README.DockerHub-Scanner.md
+++ b/scanners/git-repo-scanner/docs/README.DockerHub-Scanner.md
@@ -105,7 +105,7 @@ on the Gitlab server are going to be discovered.
 You are welcome, please join us on... 👋
 
 - [GitHub][scb-github]
-- [Slack][scb-slack]
+- [OWASP Slack (Channel #project-securecodebox)][scb-slack]
 - [Twitter][scb-twitter]
 
 secureCodeBox is an official [OWASP][scb-owasp] project.
@@ -122,6 +122,6 @@ As for any pre-built image usage, it is the image user's responsibility to ensur
 [scb-site]: https://www.securecodebox.io/
 [scb-github]: https://github.com/secureCodeBox/
 [scb-twitter]: https://twitter.com/secureCodeBox
-[scb-slack]: https://join.slack.com/t/securecodebox/shared_invite/enQtNDU3MTUyOTM0NTMwLTBjOWRjNjVkNGEyMjQ0ZGMyNDdlYTQxYWQ4MzNiNGY3MDMxNThkZjJmMzY2NDRhMTk3ZWM3OWFkYmY1YzUxNTU
+[scb-slack]: https://owasp.org/slack/invite
 [scb-license]: https://github.com/secureCodeBox/secureCodeBox/blob/master/LICENSE
 

--- a/scanners/gitleaks/README.md
+++ b/scanners/gitleaks/README.md
@@ -149,6 +149,6 @@ Code of secureCodeBox is licensed under the [Apache License 2.0][scb-license].
 [scb-site]: https://www.securecodebox.io/
 [scb-github]: https://github.com/secureCodeBox/
 [scb-twitter]: https://twitter.com/secureCodeBox
-[scb-slack]: https://join.slack.com/t/securecodebox/shared_invite/enQtNDU3MTUyOTM0NTMwLTBjOWRjNjVkNGEyMjQ0ZGMyNDdlYTQxYWQ4MzNiNGY3MDMxNThkZjJmMzY2NDRhMTk3ZWM3OWFkYmY1YzUxNTU
+[scb-slack]: https://owasp.org/slack/invite
 [scb-license]: https://github.com/secureCodeBox/secureCodeBox/blob/master/LICENSE
 

--- a/scanners/gitleaks/docs/README.ArtifactHub.md
+++ b/scanners/gitleaks/docs/README.ArtifactHub.md
@@ -154,7 +154,7 @@ Please have a look at [Contributing](./CONTRIBUTING.md)
 You are welcome, please join us on... 👋
 
 - [GitHub][scb-github]
-- [Slack][scb-slack]
+- [OWASP Slack (Channel #project-securecodebox)][scb-slack]
 - [Twitter][scb-twitter]
 
 secureCodeBox is an official [OWASP][scb-owasp] project.
@@ -169,6 +169,6 @@ Code of secureCodeBox is licensed under the [Apache License 2.0][scb-license].
 [scb-site]: https://www.securecodebox.io/
 [scb-github]: https://github.com/secureCodeBox/
 [scb-twitter]: https://twitter.com/secureCodeBox
-[scb-slack]: https://join.slack.com/t/securecodebox/shared_invite/enQtNDU3MTUyOTM0NTMwLTBjOWRjNjVkNGEyMjQ0ZGMyNDdlYTQxYWQ4MzNiNGY3MDMxNThkZjJmMzY2NDRhMTk3ZWM3OWFkYmY1YzUxNTU
+[scb-slack]: https://owasp.org/slack/invite
 [scb-license]: https://github.com/secureCodeBox/secureCodeBox/blob/master/LICENSE
 

--- a/scanners/gitleaks/docs/README.DockerHub-Parser.md
+++ b/scanners/gitleaks/docs/README.DockerHub-Parser.md
@@ -64,7 +64,7 @@ To learn more about gitleaks visit [https://github.com/zricethezav/gitleaks](htt
 You are welcome, please join us on... 👋
 
 - [GitHub][scb-github]
-- [Slack][scb-slack]
+- [OWASP Slack (Channel #project-securecodebox)][scb-slack]
 - [Twitter][scb-twitter]
 
 secureCodeBox is an official [OWASP][scb-owasp] project.
@@ -81,6 +81,6 @@ As for any pre-built image usage, it is the image user's responsibility to ensur
 [scb-site]: https://www.securecodebox.io/
 [scb-github]: https://github.com/secureCodeBox/
 [scb-twitter]: https://twitter.com/secureCodeBox
-[scb-slack]: https://join.slack.com/t/securecodebox/shared_invite/enQtNDU3MTUyOTM0NTMwLTBjOWRjNjVkNGEyMjQ0ZGMyNDdlYTQxYWQ4MzNiNGY3MDMxNThkZjJmMzY2NDRhMTk3ZWM3OWFkYmY1YzUxNTU
+[scb-slack]: https://owasp.org/slack/invite
 [scb-license]: https://github.com/secureCodeBox/secureCodeBox/blob/master/LICENSE
 

--- a/scanners/kube-hunter/README.md
+++ b/scanners/kube-hunter/README.md
@@ -108,7 +108,7 @@ Code of secureCodeBox is licensed under the [Apache License 2.0][scb-license].
 [scb-site]: https://www.securecodebox.io/
 [scb-github]: https://github.com/secureCodeBox/
 [scb-twitter]: https://twitter.com/secureCodeBox
-[scb-slack]: https://join.slack.com/t/securecodebox/shared_invite/enQtNDU3MTUyOTM0NTMwLTBjOWRjNjVkNGEyMjQ0ZGMyNDdlYTQxYWQ4MzNiNGY3MDMxNThkZjJmMzY2NDRhMTk3ZWM3OWFkYmY1YzUxNTU
+[scb-slack]: https://owasp.org/slack/invite
 [scb-license]: https://github.com/secureCodeBox/secureCodeBox/blob/master/LICENSE
 [kube-hunter Website]: https://kube-hunter.aquasec.com/
 [kube-hunter GitHub]: https://github.com/aquasecurity/kube-hunter

--- a/scanners/kube-hunter/docs/README.ArtifactHub.md
+++ b/scanners/kube-hunter/docs/README.ArtifactHub.md
@@ -113,7 +113,7 @@ Please have a look at [Contributing](./CONTRIBUTING.md)
 You are welcome, please join us on... 👋
 
 - [GitHub][scb-github]
-- [Slack][scb-slack]
+- [OWASP Slack (Channel #project-securecodebox)][scb-slack]
 - [Twitter][scb-twitter]
 
 secureCodeBox is an official [OWASP][scb-owasp] project.
@@ -128,7 +128,7 @@ Code of secureCodeBox is licensed under the [Apache License 2.0][scb-license].
 [scb-site]: https://www.securecodebox.io/
 [scb-github]: https://github.com/secureCodeBox/
 [scb-twitter]: https://twitter.com/secureCodeBox
-[scb-slack]: https://join.slack.com/t/securecodebox/shared_invite/enQtNDU3MTUyOTM0NTMwLTBjOWRjNjVkNGEyMjQ0ZGMyNDdlYTQxYWQ4MzNiNGY3MDMxNThkZjJmMzY2NDRhMTk3ZWM3OWFkYmY1YzUxNTU
+[scb-slack]: https://owasp.org/slack/invite
 [scb-license]: https://github.com/secureCodeBox/secureCodeBox/blob/master/LICENSE
 [kube-hunter Website]: https://kube-hunter.aquasec.com/
 [kube-hunter GitHub]: https://github.com/aquasecurity/kube-hunter

--- a/scanners/kube-hunter/docs/README.DockerHub-Parser.md
+++ b/scanners/kube-hunter/docs/README.DockerHub-Parser.md
@@ -61,7 +61,7 @@ To learn more about the kube-hunter scanner itself visit [kube-hunter GitHub] or
 You are welcome, please join us on... 👋
 
 - [GitHub][scb-github]
-- [Slack][scb-slack]
+- [OWASP Slack (Channel #project-securecodebox)][scb-slack]
 - [Twitter][scb-twitter]
 
 secureCodeBox is an official [OWASP][scb-owasp] project.
@@ -78,7 +78,7 @@ As for any pre-built image usage, it is the image user's responsibility to ensur
 [scb-site]: https://www.securecodebox.io/
 [scb-github]: https://github.com/secureCodeBox/
 [scb-twitter]: https://twitter.com/secureCodeBox
-[scb-slack]: https://join.slack.com/t/securecodebox/shared_invite/enQtNDU3MTUyOTM0NTMwLTBjOWRjNjVkNGEyMjQ0ZGMyNDdlYTQxYWQ4MzNiNGY3MDMxNThkZjJmMzY2NDRhMTk3ZWM3OWFkYmY1YzUxNTU
+[scb-slack]: https://owasp.org/slack/invite
 [scb-license]: https://github.com/secureCodeBox/secureCodeBox/blob/master/LICENSE
 [kube-hunter Website]: https://kube-hunter.aquasec.com/
 [kube-hunter GitHub]: https://github.com/aquasecurity/kube-hunter

--- a/scanners/kube-hunter/docs/README.DockerHub-Scanner.md
+++ b/scanners/kube-hunter/docs/README.DockerHub-Scanner.md
@@ -69,7 +69,7 @@ The following security scan configuration example are based on the [kube-hunter 
 You are welcome, please join us on... 👋
 
 - [GitHub][scb-github]
-- [Slack][scb-slack]
+- [OWASP Slack (Channel #project-securecodebox)][scb-slack]
 - [Twitter][scb-twitter]
 
 secureCodeBox is an official [OWASP][scb-owasp] project.
@@ -86,7 +86,7 @@ As for any pre-built image usage, it is the image user's responsibility to ensur
 [scb-site]: https://www.securecodebox.io/
 [scb-github]: https://github.com/secureCodeBox/
 [scb-twitter]: https://twitter.com/secureCodeBox
-[scb-slack]: https://join.slack.com/t/securecodebox/shared_invite/enQtNDU3MTUyOTM0NTMwLTBjOWRjNjVkNGEyMjQ0ZGMyNDdlYTQxYWQ4MzNiNGY3MDMxNThkZjJmMzY2NDRhMTk3ZWM3OWFkYmY1YzUxNTU
+[scb-slack]: https://owasp.org/slack/invite
 [scb-license]: https://github.com/secureCodeBox/secureCodeBox/blob/master/LICENSE
 [kube-hunter Website]: https://kube-hunter.aquasec.com/
 [kube-hunter GitHub]: https://github.com/aquasecurity/kube-hunter

--- a/scanners/kubeaudit/README.md
+++ b/scanners/kubeaudit/README.md
@@ -110,6 +110,6 @@ Code of secureCodeBox is licensed under the [Apache License 2.0][scb-license].
 [scb-site]: https://www.securecodebox.io/
 [scb-github]: https://github.com/secureCodeBox/
 [scb-twitter]: https://twitter.com/secureCodeBox
-[scb-slack]: https://join.slack.com/t/securecodebox/shared_invite/enQtNDU3MTUyOTM0NTMwLTBjOWRjNjVkNGEyMjQ0ZGMyNDdlYTQxYWQ4MzNiNGY3MDMxNThkZjJmMzY2NDRhMTk3ZWM3OWFkYmY1YzUxNTU
+[scb-slack]: https://owasp.org/slack/invite
 [scb-license]: https://github.com/secureCodeBox/secureCodeBox/blob/master/LICENSE
 [kubeaudit GitHub]: https://github.com/Shopify/kubeaudit/

--- a/scanners/kubeaudit/docs/README.ArtifactHub.md
+++ b/scanners/kubeaudit/docs/README.ArtifactHub.md
@@ -117,7 +117,7 @@ Please have a look at [Contributing](./CONTRIBUTING.md)
 You are welcome, please join us on... 👋
 
 - [GitHub][scb-github]
-- [Slack][scb-slack]
+- [OWASP Slack (Channel #project-securecodebox)][scb-slack]
 - [Twitter][scb-twitter]
 
 secureCodeBox is an official [OWASP][scb-owasp] project.
@@ -132,6 +132,6 @@ Code of secureCodeBox is licensed under the [Apache License 2.0][scb-license].
 [scb-site]: https://www.securecodebox.io/
 [scb-github]: https://github.com/secureCodeBox/
 [scb-twitter]: https://twitter.com/secureCodeBox
-[scb-slack]: https://join.slack.com/t/securecodebox/shared_invite/enQtNDU3MTUyOTM0NTMwLTBjOWRjNjVkNGEyMjQ0ZGMyNDdlYTQxYWQ4MzNiNGY3MDMxNThkZjJmMzY2NDRhMTk3ZWM3OWFkYmY1YzUxNTU
+[scb-slack]: https://owasp.org/slack/invite
 [scb-license]: https://github.com/secureCodeBox/secureCodeBox/blob/master/LICENSE
 [kubeaudit GitHub]: https://github.com/Shopify/kubeaudit/

--- a/scanners/kubeaudit/docs/README.DockerHub-Parser.md
+++ b/scanners/kubeaudit/docs/README.DockerHub-Parser.md
@@ -64,7 +64,7 @@ To learn more about the kubeaudit itself visit [kubeaudit GitHub].
 You are welcome, please join us on... 👋
 
 - [GitHub][scb-github]
-- [Slack][scb-slack]
+- [OWASP Slack (Channel #project-securecodebox)][scb-slack]
 - [Twitter][scb-twitter]
 
 secureCodeBox is an official [OWASP][scb-owasp] project.
@@ -81,6 +81,6 @@ As for any pre-built image usage, it is the image user's responsibility to ensur
 [scb-site]: https://www.securecodebox.io/
 [scb-github]: https://github.com/secureCodeBox/
 [scb-twitter]: https://twitter.com/secureCodeBox
-[scb-slack]: https://join.slack.com/t/securecodebox/shared_invite/enQtNDU3MTUyOTM0NTMwLTBjOWRjNjVkNGEyMjQ0ZGMyNDdlYTQxYWQ4MzNiNGY3MDMxNThkZjJmMzY2NDRhMTk3ZWM3OWFkYmY1YzUxNTU
+[scb-slack]: https://owasp.org/slack/invite
 [scb-license]: https://github.com/secureCodeBox/secureCodeBox/blob/master/LICENSE
 [kubeaudit GitHub]: https://github.com/Shopify/kubeaudit/

--- a/scanners/kubeaudit/docs/README.DockerHub-Scanner.md
+++ b/scanners/kubeaudit/docs/README.DockerHub-Scanner.md
@@ -72,7 +72,7 @@ The following security scan configuration example are based on the [kube-hunter 
 You are welcome, please join us on... 👋
 
 - [GitHub][scb-github]
-- [Slack][scb-slack]
+- [OWASP Slack (Channel #project-securecodebox)][scb-slack]
 - [Twitter][scb-twitter]
 
 secureCodeBox is an official [OWASP][scb-owasp] project.
@@ -89,6 +89,6 @@ As for any pre-built image usage, it is the image user's responsibility to ensur
 [scb-site]: https://www.securecodebox.io/
 [scb-github]: https://github.com/secureCodeBox/
 [scb-twitter]: https://twitter.com/secureCodeBox
-[scb-slack]: https://join.slack.com/t/securecodebox/shared_invite/enQtNDU3MTUyOTM0NTMwLTBjOWRjNjVkNGEyMjQ0ZGMyNDdlYTQxYWQ4MzNiNGY3MDMxNThkZjJmMzY2NDRhMTk3ZWM3OWFkYmY1YzUxNTU
+[scb-slack]: https://owasp.org/slack/invite
 [scb-license]: https://github.com/secureCodeBox/secureCodeBox/blob/master/LICENSE
 [kubeaudit GitHub]: https://github.com/Shopify/kubeaudit/

--- a/scanners/ncrack/README.md
+++ b/scanners/ncrack/README.md
@@ -254,7 +254,7 @@ Code of secureCodeBox is licensed under the [Apache License 2.0][scb-license].
 [scb-site]: https://www.securecodebox.io/
 [scb-github]: https://github.com/secureCodeBox/
 [scb-twitter]: https://twitter.com/secureCodeBox
-[scb-slack]: https://join.slack.com/t/securecodebox/shared_invite/enQtNDU3MTUyOTM0NTMwLTBjOWRjNjVkNGEyMjQ0ZGMyNDdlYTQxYWQ4MzNiNGY3MDMxNThkZjJmMzY2NDRhMTk3ZWM3OWFkYmY1YzUxNTU
+[scb-slack]: https://owasp.org/slack/invite
 [scb-license]: https://github.com/secureCodeBox/secureCodeBox/blob/master/LICENSE
 [Ncrack Website]: https://nmap.org/ncrack/
 [Ncrack GitHub]: https://github.com/nmap/ncrack

--- a/scanners/ncrack/docs/README.ArtifactHub.md
+++ b/scanners/ncrack/docs/README.ArtifactHub.md
@@ -261,7 +261,7 @@ Please have a look at [Contributing](./CONTRIBUTING.md)
 You are welcome, please join us on... 👋
 
 - [GitHub][scb-github]
-- [Slack][scb-slack]
+- [OWASP Slack (Channel #project-securecodebox)][scb-slack]
 - [Twitter][scb-twitter]
 
 secureCodeBox is an official [OWASP][scb-owasp] project.
@@ -276,7 +276,7 @@ Code of secureCodeBox is licensed under the [Apache License 2.0][scb-license].
 [scb-site]: https://www.securecodebox.io/
 [scb-github]: https://github.com/secureCodeBox/
 [scb-twitter]: https://twitter.com/secureCodeBox
-[scb-slack]: https://join.slack.com/t/securecodebox/shared_invite/enQtNDU3MTUyOTM0NTMwLTBjOWRjNjVkNGEyMjQ0ZGMyNDdlYTQxYWQ4MzNiNGY3MDMxNThkZjJmMzY2NDRhMTk3ZWM3OWFkYmY1YzUxNTU
+[scb-slack]: https://owasp.org/slack/invite
 [scb-license]: https://github.com/secureCodeBox/secureCodeBox/blob/master/LICENSE
 [Ncrack Website]: https://nmap.org/ncrack/
 [Ncrack GitHub]: https://github.com/nmap/ncrack

--- a/scanners/ncrack/docs/README.DockerHub-Parser.md
+++ b/scanners/ncrack/docs/README.DockerHub-Parser.md
@@ -61,7 +61,7 @@ To learn more about the Ncrack scanner itself visit [Ncrack GitHub] or [Ncrack W
 You are welcome, please join us on... 👋
 
 - [GitHub][scb-github]
-- [Slack][scb-slack]
+- [OWASP Slack (Channel #project-securecodebox)][scb-slack]
 - [Twitter][scb-twitter]
 
 secureCodeBox is an official [OWASP][scb-owasp] project.
@@ -78,7 +78,7 @@ As for any pre-built image usage, it is the image user's responsibility to ensur
 [scb-site]: https://www.securecodebox.io/
 [scb-github]: https://github.com/secureCodeBox/
 [scb-twitter]: https://twitter.com/secureCodeBox
-[scb-slack]: https://join.slack.com/t/securecodebox/shared_invite/enQtNDU3MTUyOTM0NTMwLTBjOWRjNjVkNGEyMjQ0ZGMyNDdlYTQxYWQ4MzNiNGY3MDMxNThkZjJmMzY2NDRhMTk3ZWM3OWFkYmY1YzUxNTU
+[scb-slack]: https://owasp.org/slack/invite
 [scb-license]: https://github.com/secureCodeBox/secureCodeBox/blob/master/LICENSE
 [Ncrack Website]: https://nmap.org/ncrack/
 [Ncrack GitHub]: https://github.com/nmap/ncrack

--- a/scanners/ncrack/docs/README.DockerHub-Scanner.md
+++ b/scanners/ncrack/docs/README.DockerHub-Scanner.md
@@ -140,7 +140,7 @@ SEE THE MAN PAGE (http://nmap.org/ncrack/man.html) FOR MORE OPTIONS AND EXAMPLES
 You are welcome, please join us on... 👋
 
 - [GitHub][scb-github]
-- [Slack][scb-slack]
+- [OWASP Slack (Channel #project-securecodebox)][scb-slack]
 - [Twitter][scb-twitter]
 
 secureCodeBox is an official [OWASP][scb-owasp] project.
@@ -157,7 +157,7 @@ As for any pre-built image usage, it is the image user's responsibility to ensur
 [scb-site]: https://www.securecodebox.io/
 [scb-github]: https://github.com/secureCodeBox/
 [scb-twitter]: https://twitter.com/secureCodeBox
-[scb-slack]: https://join.slack.com/t/securecodebox/shared_invite/enQtNDU3MTUyOTM0NTMwLTBjOWRjNjVkNGEyMjQ0ZGMyNDdlYTQxYWQ4MzNiNGY3MDMxNThkZjJmMzY2NDRhMTk3ZWM3OWFkYmY1YzUxNTU
+[scb-slack]: https://owasp.org/slack/invite
 [scb-license]: https://github.com/secureCodeBox/secureCodeBox/blob/master/LICENSE
 [Ncrack Website]: https://nmap.org/ncrack/
 [Ncrack GitHub]: https://github.com/nmap/ncrack

--- a/scanners/nikto/README.md
+++ b/scanners/nikto/README.md
@@ -125,7 +125,7 @@ Code of secureCodeBox is licensed under the [Apache License 2.0][scb-license].
 [scb-site]: https://www.securecodebox.io/
 [scb-github]: https://github.com/secureCodeBox/
 [scb-twitter]: https://twitter.com/secureCodeBox
-[scb-slack]: https://join.slack.com/t/securecodebox/shared_invite/enQtNDU3MTUyOTM0NTMwLTBjOWRjNjVkNGEyMjQ0ZGMyNDdlYTQxYWQ4MzNiNGY3MDMxNThkZjJmMzY2NDRhMTk3ZWM3OWFkYmY1YzUxNTU
+[scb-slack]: https://owasp.org/slack/invite
 [scb-license]: https://github.com/secureCodeBox/secureCodeBox/blob/master/LICENSE
 [cirt.net]: https://cirt.net/
 [nikto github]: https://github.com/sullo/nikto

--- a/scanners/nikto/docs/README.ArtifactHub.md
+++ b/scanners/nikto/docs/README.ArtifactHub.md
@@ -130,7 +130,7 @@ Please have a look at [Contributing](./CONTRIBUTING.md)
 You are welcome, please join us on... 👋
 
 - [GitHub][scb-github]
-- [Slack][scb-slack]
+- [OWASP Slack (Channel #project-securecodebox)][scb-slack]
 - [Twitter][scb-twitter]
 
 secureCodeBox is an official [OWASP][scb-owasp] project.
@@ -145,7 +145,7 @@ Code of secureCodeBox is licensed under the [Apache License 2.0][scb-license].
 [scb-site]: https://www.securecodebox.io/
 [scb-github]: https://github.com/secureCodeBox/
 [scb-twitter]: https://twitter.com/secureCodeBox
-[scb-slack]: https://join.slack.com/t/securecodebox/shared_invite/enQtNDU3MTUyOTM0NTMwLTBjOWRjNjVkNGEyMjQ0ZGMyNDdlYTQxYWQ4MzNiNGY3MDMxNThkZjJmMzY2NDRhMTk3ZWM3OWFkYmY1YzUxNTU
+[scb-slack]: https://owasp.org/slack/invite
 [scb-license]: https://github.com/secureCodeBox/secureCodeBox/blob/master/LICENSE
 [cirt.net]: https://cirt.net/
 [nikto github]: https://github.com/sullo/nikto

--- a/scanners/nikto/docs/README.DockerHub-Parser.md
+++ b/scanners/nikto/docs/README.DockerHub-Parser.md
@@ -59,7 +59,7 @@ Nikto is a free software command-line vulnerability scanner that scans webserver
 You are welcome, please join us on... 👋
 
 - [GitHub][scb-github]
-- [Slack][scb-slack]
+- [OWASP Slack (Channel #project-securecodebox)][scb-slack]
 - [Twitter][scb-twitter]
 
 secureCodeBox is an official [OWASP][scb-owasp] project.
@@ -76,7 +76,7 @@ As for any pre-built image usage, it is the image user's responsibility to ensur
 [scb-site]: https://www.securecodebox.io/
 [scb-github]: https://github.com/secureCodeBox/
 [scb-twitter]: https://twitter.com/secureCodeBox
-[scb-slack]: https://join.slack.com/t/securecodebox/shared_invite/enQtNDU3MTUyOTM0NTMwLTBjOWRjNjVkNGEyMjQ0ZGMyNDdlYTQxYWQ4MzNiNGY3MDMxNThkZjJmMzY2NDRhMTk3ZWM3OWFkYmY1YzUxNTU
+[scb-slack]: https://owasp.org/slack/invite
 [scb-license]: https://github.com/secureCodeBox/secureCodeBox/blob/master/LICENSE
 [cirt.net]: https://cirt.net/
 [nikto github]: https://github.com/sullo/nikto

--- a/scanners/nikto/docs/README.DockerHub-Scanner.md
+++ b/scanners/nikto/docs/README.DockerHub-Scanner.md
@@ -86,7 +86,7 @@ Nikto also has a comprehensive list of [command line options documented](https:/
 You are welcome, please join us on... 👋
 
 - [GitHub][scb-github]
-- [Slack][scb-slack]
+- [OWASP Slack (Channel #project-securecodebox)][scb-slack]
 - [Twitter][scb-twitter]
 
 secureCodeBox is an official [OWASP][scb-owasp] project.
@@ -103,7 +103,7 @@ As for any pre-built image usage, it is the image user's responsibility to ensur
 [scb-site]: https://www.securecodebox.io/
 [scb-github]: https://github.com/secureCodeBox/
 [scb-twitter]: https://twitter.com/secureCodeBox
-[scb-slack]: https://join.slack.com/t/securecodebox/shared_invite/enQtNDU3MTUyOTM0NTMwLTBjOWRjNjVkNGEyMjQ0ZGMyNDdlYTQxYWQ4MzNiNGY3MDMxNThkZjJmMzY2NDRhMTk3ZWM3OWFkYmY1YzUxNTU
+[scb-slack]: https://owasp.org/slack/invite
 [scb-license]: https://github.com/secureCodeBox/secureCodeBox/blob/master/LICENSE
 [cirt.net]: https://cirt.net/
 [nikto github]: https://github.com/sullo/nikto

--- a/scanners/nmap/README.md
+++ b/scanners/nmap/README.md
@@ -177,6 +177,6 @@ Code of secureCodeBox is licensed under the [Apache License 2.0][scb-license].
 [scb-site]: https://www.securecodebox.io/
 [scb-github]: https://github.com/secureCodeBox/
 [scb-twitter]: https://twitter.com/secureCodeBox
-[scb-slack]: https://join.slack.com/t/securecodebox/shared_invite/enQtNDU3MTUyOTM0NTMwLTBjOWRjNjVkNGEyMjQ0ZGMyNDdlYTQxYWQ4MzNiNGY3MDMxNThkZjJmMzY2NDRhMTk3ZWM3OWFkYmY1YzUxNTU
+[scb-slack]: https://owasp.org/slack/invite
 [scb-license]: https://github.com/secureCodeBox/secureCodeBox/blob/master/LICENSE
 

--- a/scanners/nmap/docs/README.ArtifactHub.md
+++ b/scanners/nmap/docs/README.ArtifactHub.md
@@ -182,7 +182,7 @@ Please have a look at [Contributing](./CONTRIBUTING.md)
 You are welcome, please join us on... 👋
 
 - [GitHub][scb-github]
-- [Slack][scb-slack]
+- [OWASP Slack (Channel #project-securecodebox)][scb-slack]
 - [Twitter][scb-twitter]
 
 secureCodeBox is an official [OWASP][scb-owasp] project.
@@ -197,6 +197,6 @@ Code of secureCodeBox is licensed under the [Apache License 2.0][scb-license].
 [scb-site]: https://www.securecodebox.io/
 [scb-github]: https://github.com/secureCodeBox/
 [scb-twitter]: https://twitter.com/secureCodeBox
-[scb-slack]: https://join.slack.com/t/securecodebox/shared_invite/enQtNDU3MTUyOTM0NTMwLTBjOWRjNjVkNGEyMjQ0ZGMyNDdlYTQxYWQ4MzNiNGY3MDMxNThkZjJmMzY2NDRhMTk3ZWM3OWFkYmY1YzUxNTU
+[scb-slack]: https://owasp.org/slack/invite
 [scb-license]: https://github.com/secureCodeBox/secureCodeBox/blob/master/LICENSE
 

--- a/scanners/nmap/docs/README.DockerHub-Parser.md
+++ b/scanners/nmap/docs/README.DockerHub-Parser.md
@@ -76,7 +76,7 @@ Scripts without an existing parser will only generate an open port finding. Scri
 You are welcome, please join us on... 👋
 
 - [GitHub][scb-github]
-- [Slack][scb-slack]
+- [OWASP Slack (Channel #project-securecodebox)][scb-slack]
 - [Twitter][scb-twitter]
 
 secureCodeBox is an official [OWASP][scb-owasp] project.
@@ -93,6 +93,6 @@ As for any pre-built image usage, it is the image user's responsibility to ensur
 [scb-site]: https://www.securecodebox.io/
 [scb-github]: https://github.com/secureCodeBox/
 [scb-twitter]: https://twitter.com/secureCodeBox
-[scb-slack]: https://join.slack.com/t/securecodebox/shared_invite/enQtNDU3MTUyOTM0NTMwLTBjOWRjNjVkNGEyMjQ0ZGMyNDdlYTQxYWQ4MzNiNGY3MDMxNThkZjJmMzY2NDRhMTk3ZWM3OWFkYmY1YzUxNTU
+[scb-slack]: https://owasp.org/slack/invite
 [scb-license]: https://github.com/secureCodeBox/secureCodeBox/blob/master/LICENSE
 

--- a/scanners/nmap/docs/README.DockerHub-Scanner.md
+++ b/scanners/nmap/docs/README.DockerHub-Scanner.md
@@ -93,7 +93,7 @@ Some useful example parameters listed below:
 You are welcome, please join us on... 👋
 
 - [GitHub][scb-github]
-- [Slack][scb-slack]
+- [OWASP Slack (Channel #project-securecodebox)][scb-slack]
 - [Twitter][scb-twitter]
 
 secureCodeBox is an official [OWASP][scb-owasp] project.
@@ -110,6 +110,6 @@ As for any pre-built image usage, it is the image user's responsibility to ensur
 [scb-site]: https://www.securecodebox.io/
 [scb-github]: https://github.com/secureCodeBox/
 [scb-twitter]: https://twitter.com/secureCodeBox
-[scb-slack]: https://join.slack.com/t/securecodebox/shared_invite/enQtNDU3MTUyOTM0NTMwLTBjOWRjNjVkNGEyMjQ0ZGMyNDdlYTQxYWQ4MzNiNGY3MDMxNThkZjJmMzY2NDRhMTk3ZWM3OWFkYmY1YzUxNTU
+[scb-slack]: https://owasp.org/slack/invite
 [scb-license]: https://github.com/secureCodeBox/secureCodeBox/blob/master/LICENSE
 

--- a/scanners/nuclei/README.md
+++ b/scanners/nuclei/README.md
@@ -224,7 +224,7 @@ Code of secureCodeBox is licensed under the [Apache License 2.0][scb-license].
 [scb-site]: https://www.securecodebox.io/
 [scb-github]: https://github.com/secureCodeBox/
 [scb-twitter]: https://twitter.com/secureCodeBox
-[scb-slack]: https://join.slack.com/t/securecodebox/shared_invite/enQtNDU3MTUyOTM0NTMwLTBjOWRjNjVkNGEyMjQ0ZGMyNDdlYTQxYWQ4MzNiNGY3MDMxNThkZjJmMzY2NDRhMTk3ZWM3OWFkYmY1YzUxNTU
+[scb-slack]: https://owasp.org/slack/invite
 [scb-license]: https://github.com/secureCodeBox/secureCodeBox/blob/master/LICENSE
 [Nuclei Website]: https://nuclei.projectdiscovery.io/
 [Nuclei GitHub]: https://github.com/projectdiscovery/nuclei

--- a/scanners/nuclei/docs/README.ArtifactHub.md
+++ b/scanners/nuclei/docs/README.ArtifactHub.md
@@ -231,7 +231,7 @@ Please have a look at [Contributing](./CONTRIBUTING.md)
 You are welcome, please join us on... 👋
 
 - [GitHub][scb-github]
-- [Slack][scb-slack]
+- [OWASP Slack (Channel #project-securecodebox)][scb-slack]
 - [Twitter][scb-twitter]
 
 secureCodeBox is an official [OWASP][scb-owasp] project.
@@ -246,7 +246,7 @@ Code of secureCodeBox is licensed under the [Apache License 2.0][scb-license].
 [scb-site]: https://www.securecodebox.io/
 [scb-github]: https://github.com/secureCodeBox/
 [scb-twitter]: https://twitter.com/secureCodeBox
-[scb-slack]: https://join.slack.com/t/securecodebox/shared_invite/enQtNDU3MTUyOTM0NTMwLTBjOWRjNjVkNGEyMjQ0ZGMyNDdlYTQxYWQ4MzNiNGY3MDMxNThkZjJmMzY2NDRhMTk3ZWM3OWFkYmY1YzUxNTU
+[scb-slack]: https://owasp.org/slack/invite
 [scb-license]: https://github.com/secureCodeBox/secureCodeBox/blob/master/LICENSE
 [Nuclei Website]: https://nuclei.projectdiscovery.io/
 [Nuclei GitHub]: https://github.com/projectdiscovery/nuclei

--- a/scanners/nuclei/docs/README.DockerHub-Parser.md
+++ b/scanners/nuclei/docs/README.DockerHub-Parser.md
@@ -61,7 +61,7 @@ To learn more about the Nuclei scanner itself visit [Nuclei GitHub] or [Nuclei W
 You are welcome, please join us on... 👋
 
 - [GitHub][scb-github]
-- [Slack][scb-slack]
+- [OWASP Slack (Channel #project-securecodebox)][scb-slack]
 - [Twitter][scb-twitter]
 
 secureCodeBox is an official [OWASP][scb-owasp] project.
@@ -78,7 +78,7 @@ As for any pre-built image usage, it is the image user's responsibility to ensur
 [scb-site]: https://www.securecodebox.io/
 [scb-github]: https://github.com/secureCodeBox/
 [scb-twitter]: https://twitter.com/secureCodeBox
-[scb-slack]: https://join.slack.com/t/securecodebox/shared_invite/enQtNDU3MTUyOTM0NTMwLTBjOWRjNjVkNGEyMjQ0ZGMyNDdlYTQxYWQ4MzNiNGY3MDMxNThkZjJmMzY2NDRhMTk3ZWM3OWFkYmY1YzUxNTU
+[scb-slack]: https://owasp.org/slack/invite
 [scb-license]: https://github.com/secureCodeBox/secureCodeBox/blob/master/LICENSE
 [Nuclei Website]: https://nuclei.projectdiscovery.io/
 [Nuclei GitHub]: https://github.com/projectdiscovery/nuclei

--- a/scanners/screenshooter/README.md
+++ b/scanners/screenshooter/README.md
@@ -105,6 +105,6 @@ Code of secureCodeBox is licensed under the [Apache License 2.0][scb-license].
 [scb-site]: https://www.securecodebox.io/
 [scb-github]: https://github.com/secureCodeBox/
 [scb-twitter]: https://twitter.com/secureCodeBox
-[scb-slack]: https://join.slack.com/t/securecodebox/shared_invite/enQtNDU3MTUyOTM0NTMwLTBjOWRjNjVkNGEyMjQ0ZGMyNDdlYTQxYWQ4MzNiNGY3MDMxNThkZjJmMzY2NDRhMTk3ZWM3OWFkYmY1YzUxNTU
+[scb-slack]: https://owasp.org/slack/invite
 [scb-license]: https://github.com/secureCodeBox/secureCodeBox/blob/master/LICENSE
 

--- a/scanners/screenshooter/docs/README.ArtifactHub.md
+++ b/scanners/screenshooter/docs/README.ArtifactHub.md
@@ -110,7 +110,7 @@ Please have a look at [Contributing](./CONTRIBUTING.md)
 You are welcome, please join us on... 👋
 
 - [GitHub][scb-github]
-- [Slack][scb-slack]
+- [OWASP Slack (Channel #project-securecodebox)][scb-slack]
 - [Twitter][scb-twitter]
 
 secureCodeBox is an official [OWASP][scb-owasp] project.
@@ -125,6 +125,6 @@ Code of secureCodeBox is licensed under the [Apache License 2.0][scb-license].
 [scb-site]: https://www.securecodebox.io/
 [scb-github]: https://github.com/secureCodeBox/
 [scb-twitter]: https://twitter.com/secureCodeBox
-[scb-slack]: https://join.slack.com/t/securecodebox/shared_invite/enQtNDU3MTUyOTM0NTMwLTBjOWRjNjVkNGEyMjQ0ZGMyNDdlYTQxYWQ4MzNiNGY3MDMxNThkZjJmMzY2NDRhMTk3ZWM3OWFkYmY1YzUxNTU
+[scb-slack]: https://owasp.org/slack/invite
 [scb-license]: https://github.com/secureCodeBox/secureCodeBox/blob/master/LICENSE
 

--- a/scanners/screenshooter/docs/README.DockerHub-Parser.md
+++ b/scanners/screenshooter/docs/README.DockerHub-Parser.md
@@ -60,7 +60,7 @@ Screenshoter is a simple scanner that takes Screenshots of Websites. Therefore i
 You are welcome, please join us on... 👋
 
 - [GitHub][scb-github]
-- [Slack][scb-slack]
+- [OWASP Slack (Channel #project-securecodebox)][scb-slack]
 - [Twitter][scb-twitter]
 
 secureCodeBox is an official [OWASP][scb-owasp] project.
@@ -77,6 +77,6 @@ As for any pre-built image usage, it is the image user's responsibility to ensur
 [scb-site]: https://www.securecodebox.io/
 [scb-github]: https://github.com/secureCodeBox/
 [scb-twitter]: https://twitter.com/secureCodeBox
-[scb-slack]: https://join.slack.com/t/securecodebox/shared_invite/enQtNDU3MTUyOTM0NTMwLTBjOWRjNjVkNGEyMjQ0ZGMyNDdlYTQxYWQ4MzNiNGY3MDMxNThkZjJmMzY2NDRhMTk3ZWM3OWFkYmY1YzUxNTU
+[scb-slack]: https://owasp.org/slack/invite
 [scb-license]: https://github.com/secureCodeBox/secureCodeBox/blob/master/LICENSE
 

--- a/scanners/screenshooter/docs/README.DockerHub-Scanner.md
+++ b/scanners/screenshooter/docs/README.DockerHub-Scanner.md
@@ -66,7 +66,7 @@ You have to provide only the URL to the screenshooter. Be careful, the protocol 
 You are welcome, please join us on... 👋
 
 - [GitHub][scb-github]
-- [Slack][scb-slack]
+- [OWASP Slack (Channel #project-securecodebox)][scb-slack]
 - [Twitter][scb-twitter]
 
 secureCodeBox is an official [OWASP][scb-owasp] project.
@@ -83,6 +83,6 @@ As for any pre-built image usage, it is the image user's responsibility to ensur
 [scb-site]: https://www.securecodebox.io/
 [scb-github]: https://github.com/secureCodeBox/
 [scb-twitter]: https://twitter.com/secureCodeBox
-[scb-slack]: https://join.slack.com/t/securecodebox/shared_invite/enQtNDU3MTUyOTM0NTMwLTBjOWRjNjVkNGEyMjQ0ZGMyNDdlYTQxYWQ4MzNiNGY3MDMxNThkZjJmMzY2NDRhMTk3ZWM3OWFkYmY1YzUxNTU
+[scb-slack]: https://owasp.org/slack/invite
 [scb-license]: https://github.com/secureCodeBox/secureCodeBox/blob/master/LICENSE
 

--- a/scanners/semgrep/README.md
+++ b/scanners/semgrep/README.md
@@ -210,6 +210,6 @@ Code of secureCodeBox is licensed under the [Apache License 2.0][scb-license].
 [scb-site]: https://www.securecodebox.io/
 [scb-github]: https://github.com/secureCodeBox/
 [scb-twitter]: https://twitter.com/secureCodeBox
-[scb-slack]: https://join.slack.com/t/securecodebox/shared_invite/enQtNDU3MTUyOTM0NTMwLTBjOWRjNjVkNGEyMjQ0ZGMyNDdlYTQxYWQ4MzNiNGY3MDMxNThkZjJmMzY2NDRhMTk3ZWM3OWFkYmY1YzUxNTU
+[scb-slack]: https://owasp.org/slack/invite
 [scb-license]: https://github.com/secureCodeBox/secureCodeBox/blob/master/LICENSE
 

--- a/scanners/semgrep/docs/README.ArtifactHub.md
+++ b/scanners/semgrep/docs/README.ArtifactHub.md
@@ -215,7 +215,7 @@ Please have a look at [Contributing](./CONTRIBUTING.md)
 You are welcome, please join us on... 👋
 
 - [GitHub][scb-github]
-- [Slack][scb-slack]
+- [OWASP Slack (Channel #project-securecodebox)][scb-slack]
 - [Twitter][scb-twitter]
 
 secureCodeBox is an official [OWASP][scb-owasp] project.
@@ -230,6 +230,6 @@ Code of secureCodeBox is licensed under the [Apache License 2.0][scb-license].
 [scb-site]: https://www.securecodebox.io/
 [scb-github]: https://github.com/secureCodeBox/
 [scb-twitter]: https://twitter.com/secureCodeBox
-[scb-slack]: https://join.slack.com/t/securecodebox/shared_invite/enQtNDU3MTUyOTM0NTMwLTBjOWRjNjVkNGEyMjQ0ZGMyNDdlYTQxYWQ4MzNiNGY3MDMxNThkZjJmMzY2NDRhMTk3ZWM3OWFkYmY1YzUxNTU
+[scb-slack]: https://owasp.org/slack/invite
 [scb-license]: https://github.com/secureCodeBox/secureCodeBox/blob/master/LICENSE
 

--- a/scanners/semgrep/docs/README.DockerHub-Parser.md
+++ b/scanners/semgrep/docs/README.DockerHub-Parser.md
@@ -62,7 +62,7 @@ To learn more about semgrep, visit [semgrep.dev](https://semgrep.dev).
 You are welcome, please join us on... 👋
 
 - [GitHub][scb-github]
-- [Slack][scb-slack]
+- [OWASP Slack (Channel #project-securecodebox)][scb-slack]
 - [Twitter][scb-twitter]
 
 secureCodeBox is an official [OWASP][scb-owasp] project.
@@ -79,6 +79,6 @@ As for any pre-built image usage, it is the image user's responsibility to ensur
 [scb-site]: https://www.securecodebox.io/
 [scb-github]: https://github.com/secureCodeBox/
 [scb-twitter]: https://twitter.com/secureCodeBox
-[scb-slack]: https://join.slack.com/t/securecodebox/shared_invite/enQtNDU3MTUyOTM0NTMwLTBjOWRjNjVkNGEyMjQ0ZGMyNDdlYTQxYWQ4MzNiNGY3MDMxNThkZjJmMzY2NDRhMTk3ZWM3OWFkYmY1YzUxNTU
+[scb-slack]: https://owasp.org/slack/invite
 [scb-license]: https://github.com/secureCodeBox/secureCodeBox/blob/master/LICENSE
 

--- a/scanners/ssh-audit/README.md
+++ b/scanners/ssh-audit/README.md
@@ -140,7 +140,7 @@ Code of secureCodeBox is licensed under the [Apache License 2.0][scb-license].
 [scb-site]: https://www.securecodebox.io/
 [scb-github]: https://github.com/secureCodeBox/
 [scb-twitter]: https://twitter.com/secureCodeBox
-[scb-slack]: https://join.slack.com/t/securecodebox/shared_invite/enQtNDU3MTUyOTM0NTMwLTBjOWRjNjVkNGEyMjQ0ZGMyNDdlYTQxYWQ4MzNiNGY3MDMxNThkZjJmMzY2NDRhMTk3ZWM3OWFkYmY1YzUxNTU
+[scb-slack]: https://owasp.org/slack/invite
 [scb-license]: https://github.com/secureCodeBox/secureCodeBox/blob/master/LICENSE
 [ssh-audit GitHub]: https://github.com/jtesta/ssh-audit
 [ssh-audit Documentation]: https://github.com/jtesta/ssh-audit#usage

--- a/scanners/ssh-audit/docs/README.ArtifactHub.md
+++ b/scanners/ssh-audit/docs/README.ArtifactHub.md
@@ -147,7 +147,7 @@ Please have a look at [Contributing](./CONTRIBUTING.md)
 You are welcome, please join us on... 👋
 
 - [GitHub][scb-github]
-- [Slack][scb-slack]
+- [OWASP Slack (Channel #project-securecodebox)][scb-slack]
 - [Twitter][scb-twitter]
 
 secureCodeBox is an official [OWASP][scb-owasp] project.
@@ -162,7 +162,7 @@ Code of secureCodeBox is licensed under the [Apache License 2.0][scb-license].
 [scb-site]: https://www.securecodebox.io/
 [scb-github]: https://github.com/secureCodeBox/
 [scb-twitter]: https://twitter.com/secureCodeBox
-[scb-slack]: https://join.slack.com/t/securecodebox/shared_invite/enQtNDU3MTUyOTM0NTMwLTBjOWRjNjVkNGEyMjQ0ZGMyNDdlYTQxYWQ4MzNiNGY3MDMxNThkZjJmMzY2NDRhMTk3ZWM3OWFkYmY1YzUxNTU
+[scb-slack]: https://owasp.org/slack/invite
 [scb-license]: https://github.com/secureCodeBox/secureCodeBox/blob/master/LICENSE
 [ssh-audit GitHub]: https://github.com/jtesta/ssh-audit
 [ssh-audit Documentation]: https://github.com/jtesta/ssh-audit#usage

--- a/scanners/ssh-audit/docs/README.DockerHub-Parser.md
+++ b/scanners/ssh-audit/docs/README.DockerHub-Parser.md
@@ -62,7 +62,7 @@ To learn more about the ssh-audit scanner itself visit [ssh-audit GitHub].
 You are welcome, please join us on... 👋
 
 - [GitHub][scb-github]
-- [Slack][scb-slack]
+- [OWASP Slack (Channel #project-securecodebox)][scb-slack]
 - [Twitter][scb-twitter]
 
 secureCodeBox is an official [OWASP][scb-owasp] project.
@@ -79,7 +79,7 @@ As for any pre-built image usage, it is the image user's responsibility to ensur
 [scb-site]: https://www.securecodebox.io/
 [scb-github]: https://github.com/secureCodeBox/
 [scb-twitter]: https://twitter.com/secureCodeBox
-[scb-slack]: https://join.slack.com/t/securecodebox/shared_invite/enQtNDU3MTUyOTM0NTMwLTBjOWRjNjVkNGEyMjQ0ZGMyNDdlYTQxYWQ4MzNiNGY3MDMxNThkZjJmMzY2NDRhMTk3ZWM3OWFkYmY1YzUxNTU
+[scb-slack]: https://owasp.org/slack/invite
 [scb-license]: https://github.com/secureCodeBox/secureCodeBox/blob/master/LICENSE
 [ssh-audit GitHub]: https://github.com/jtesta/ssh-audit
 [ssh-audit Documentation]: https://github.com/jtesta/ssh-audit#usage

--- a/scanners/ssh-audit/docs/README.DockerHub-Scanner.md
+++ b/scanners/ssh-audit/docs/README.DockerHub-Scanner.md
@@ -105,7 +105,7 @@ usage: ssh-audit.py [options] <host>
 You are welcome, please join us on... 👋
 
 - [GitHub][scb-github]
-- [Slack][scb-slack]
+- [OWASP Slack (Channel #project-securecodebox)][scb-slack]
 - [Twitter][scb-twitter]
 
 secureCodeBox is an official [OWASP][scb-owasp] project.
@@ -122,7 +122,7 @@ As for any pre-built image usage, it is the image user's responsibility to ensur
 [scb-site]: https://www.securecodebox.io/
 [scb-github]: https://github.com/secureCodeBox/
 [scb-twitter]: https://twitter.com/secureCodeBox
-[scb-slack]: https://join.slack.com/t/securecodebox/shared_invite/enQtNDU3MTUyOTM0NTMwLTBjOWRjNjVkNGEyMjQ0ZGMyNDdlYTQxYWQ4MzNiNGY3MDMxNThkZjJmMzY2NDRhMTk3ZWM3OWFkYmY1YzUxNTU
+[scb-slack]: https://owasp.org/slack/invite
 [scb-license]: https://github.com/secureCodeBox/secureCodeBox/blob/master/LICENSE
 [ssh-audit GitHub]: https://github.com/jtesta/ssh-audit
 [ssh-audit Documentation]: https://github.com/jtesta/ssh-audit#usage

--- a/scanners/ssh-scan/README.md
+++ b/scanners/ssh-scan/README.md
@@ -139,7 +139,7 @@ Code of secureCodeBox is licensed under the [Apache License 2.0][scb-license].
 [scb-site]: https://www.securecodebox.io/
 [scb-github]: https://github.com/secureCodeBox/
 [scb-twitter]: https://twitter.com/secureCodeBox
-[scb-slack]: https://join.slack.com/t/securecodebox/shared_invite/enQtNDU3MTUyOTM0NTMwLTBjOWRjNjVkNGEyMjQ0ZGMyNDdlYTQxYWQ4MzNiNGY3MDMxNThkZjJmMzY2NDRhMTk3ZWM3OWFkYmY1YzUxNTU
+[scb-slack]: https://owasp.org/slack/invite
 [scb-license]: https://github.com/secureCodeBox/secureCodeBox/blob/master/LICENSE
 [ssh_scan GitHub]: https://github.com/mozilla/ssh_scan
 [ssh_scan Documentation]: https://github.com/mozilla/ssh_scan#example-command-line-usage

--- a/scanners/ssh-scan/docs/README.ArtifactHub.md
+++ b/scanners/ssh-scan/docs/README.ArtifactHub.md
@@ -146,7 +146,7 @@ Please have a look at [Contributing](./CONTRIBUTING.md)
 You are welcome, please join us on... 👋
 
 - [GitHub][scb-github]
-- [Slack][scb-slack]
+- [OWASP Slack (Channel #project-securecodebox)][scb-slack]
 - [Twitter][scb-twitter]
 
 secureCodeBox is an official [OWASP][scb-owasp] project.
@@ -161,7 +161,7 @@ Code of secureCodeBox is licensed under the [Apache License 2.0][scb-license].
 [scb-site]: https://www.securecodebox.io/
 [scb-github]: https://github.com/secureCodeBox/
 [scb-twitter]: https://twitter.com/secureCodeBox
-[scb-slack]: https://join.slack.com/t/securecodebox/shared_invite/enQtNDU3MTUyOTM0NTMwLTBjOWRjNjVkNGEyMjQ0ZGMyNDdlYTQxYWQ4MzNiNGY3MDMxNThkZjJmMzY2NDRhMTk3ZWM3OWFkYmY1YzUxNTU
+[scb-slack]: https://owasp.org/slack/invite
 [scb-license]: https://github.com/secureCodeBox/secureCodeBox/blob/master/LICENSE
 [ssh_scan GitHub]: https://github.com/mozilla/ssh_scan
 [ssh_scan Documentation]: https://github.com/mozilla/ssh_scan#example-command-line-usage

--- a/scanners/ssh-scan/docs/README.DockerHub-Parser.md
+++ b/scanners/ssh-scan/docs/README.DockerHub-Parser.md
@@ -62,7 +62,7 @@ To learn more about the ssh_scan scanner itself visit [ssh_scan GitHub].
 You are welcome, please join us on... 👋
 
 - [GitHub][scb-github]
-- [Slack][scb-slack]
+- [OWASP Slack (Channel #project-securecodebox)][scb-slack]
 - [Twitter][scb-twitter]
 
 secureCodeBox is an official [OWASP][scb-owasp] project.
@@ -79,7 +79,7 @@ As for any pre-built image usage, it is the image user's responsibility to ensur
 [scb-site]: https://www.securecodebox.io/
 [scb-github]: https://github.com/secureCodeBox/
 [scb-twitter]: https://twitter.com/secureCodeBox
-[scb-slack]: https://join.slack.com/t/securecodebox/shared_invite/enQtNDU3MTUyOTM0NTMwLTBjOWRjNjVkNGEyMjQ0ZGMyNDdlYTQxYWQ4MzNiNGY3MDMxNThkZjJmMzY2NDRhMTk3ZWM3OWFkYmY1YzUxNTU
+[scb-slack]: https://owasp.org/slack/invite
 [scb-license]: https://github.com/secureCodeBox/secureCodeBox/blob/master/LICENSE
 [ssh_scan GitHub]: https://github.com/mozilla/ssh_scan
 [ssh_scan Documentation]: https://github.com/mozilla/ssh_scan#example-command-line-usage

--- a/scanners/sslyze/README.md
+++ b/scanners/sslyze/README.md
@@ -209,7 +209,7 @@ Code of secureCodeBox is licensed under the [Apache License 2.0][scb-license].
 [scb-site]: https://www.securecodebox.io/
 [scb-github]: https://github.com/secureCodeBox/
 [scb-twitter]: https://twitter.com/secureCodeBox
-[scb-slack]: https://join.slack.com/t/securecodebox/shared_invite/enQtNDU3MTUyOTM0NTMwLTBjOWRjNjVkNGEyMjQ0ZGMyNDdlYTQxYWQ4MzNiNGY3MDMxNThkZjJmMzY2NDRhMTk3ZWM3OWFkYmY1YzUxNTU
+[scb-slack]: https://owasp.org/slack/invite
 [scb-license]: https://github.com/secureCodeBox/secureCodeBox/blob/master/LICENSE
 [SSLyze GitHub]: https://github.com/nabla-c0d3/sslyze
 [SSLyze Documentation]: https://nabla-c0d3.github.io/sslyze/documentation/

--- a/scanners/sslyze/docs/README.ArtifactHub.md
+++ b/scanners/sslyze/docs/README.ArtifactHub.md
@@ -216,7 +216,7 @@ Please have a look at [Contributing](./CONTRIBUTING.md)
 You are welcome, please join us on... 👋
 
 - [GitHub][scb-github]
-- [Slack][scb-slack]
+- [OWASP Slack (Channel #project-securecodebox)][scb-slack]
 - [Twitter][scb-twitter]
 
 secureCodeBox is an official [OWASP][scb-owasp] project.
@@ -231,7 +231,7 @@ Code of secureCodeBox is licensed under the [Apache License 2.0][scb-license].
 [scb-site]: https://www.securecodebox.io/
 [scb-github]: https://github.com/secureCodeBox/
 [scb-twitter]: https://twitter.com/secureCodeBox
-[scb-slack]: https://join.slack.com/t/securecodebox/shared_invite/enQtNDU3MTUyOTM0NTMwLTBjOWRjNjVkNGEyMjQ0ZGMyNDdlYTQxYWQ4MzNiNGY3MDMxNThkZjJmMzY2NDRhMTk3ZWM3OWFkYmY1YzUxNTU
+[scb-slack]: https://owasp.org/slack/invite
 [scb-license]: https://github.com/secureCodeBox/secureCodeBox/blob/master/LICENSE
 [SSLyze GitHub]: https://github.com/nabla-c0d3/sslyze
 [SSLyze Documentation]: https://nabla-c0d3.github.io/sslyze/documentation/

--- a/scanners/sslyze/docs/README.DockerHub-Parser.md
+++ b/scanners/sslyze/docs/README.DockerHub-Parser.md
@@ -60,7 +60,7 @@ docker pull securecodebox/parser-sslyze
 You are welcome, please join us on... 👋
 
 - [GitHub][scb-github]
-- [Slack][scb-slack]
+- [OWASP Slack (Channel #project-securecodebox)][scb-slack]
 - [Twitter][scb-twitter]
 
 secureCodeBox is an official [OWASP][scb-owasp] project.
@@ -77,7 +77,7 @@ As for any pre-built image usage, it is the image user's responsibility to ensur
 [scb-site]: https://www.securecodebox.io/
 [scb-github]: https://github.com/secureCodeBox/
 [scb-twitter]: https://twitter.com/secureCodeBox
-[scb-slack]: https://join.slack.com/t/securecodebox/shared_invite/enQtNDU3MTUyOTM0NTMwLTBjOWRjNjVkNGEyMjQ0ZGMyNDdlYTQxYWQ4MzNiNGY3MDMxNThkZjJmMzY2NDRhMTk3ZWM3OWFkYmY1YzUxNTU
+[scb-slack]: https://owasp.org/slack/invite
 [scb-license]: https://github.com/secureCodeBox/secureCodeBox/blob/master/LICENSE
 [SSLyze GitHub]: https://github.com/nabla-c0d3/sslyze
 [SSLyze Documentation]: https://nabla-c0d3.github.io/sslyze/documentation/

--- a/scanners/sslyze/docs/README.DockerHub-Scanner.md
+++ b/scanners/sslyze/docs/README.DockerHub-Scanner.md
@@ -172,7 +172,7 @@ Scan commands:
 You are welcome, please join us on... 👋
 
 - [GitHub][scb-github]
-- [Slack][scb-slack]
+- [OWASP Slack (Channel #project-securecodebox)][scb-slack]
 - [Twitter][scb-twitter]
 
 secureCodeBox is an official [OWASP][scb-owasp] project.
@@ -189,7 +189,7 @@ As for any pre-built image usage, it is the image user's responsibility to ensur
 [scb-site]: https://www.securecodebox.io/
 [scb-github]: https://github.com/secureCodeBox/
 [scb-twitter]: https://twitter.com/secureCodeBox
-[scb-slack]: https://join.slack.com/t/securecodebox/shared_invite/enQtNDU3MTUyOTM0NTMwLTBjOWRjNjVkNGEyMjQ0ZGMyNDdlYTQxYWQ4MzNiNGY3MDMxNThkZjJmMzY2NDRhMTk3ZWM3OWFkYmY1YzUxNTU
+[scb-slack]: https://owasp.org/slack/invite
 [scb-license]: https://github.com/secureCodeBox/secureCodeBox/blob/master/LICENSE
 [SSLyze GitHub]: https://github.com/nabla-c0d3/sslyze
 [SSLyze Documentation]: https://nabla-c0d3.github.io/sslyze/documentation/

--- a/scanners/test-scan/README.md
+++ b/scanners/test-scan/README.md
@@ -99,6 +99,6 @@ Code of secureCodeBox is licensed under the [Apache License 2.0][scb-license].
 [scb-site]: https://www.securecodebox.io/
 [scb-github]: https://github.com/secureCodeBox/
 [scb-twitter]: https://twitter.com/secureCodeBox
-[scb-slack]: https://join.slack.com/t/securecodebox/shared_invite/enQtNDU3MTUyOTM0NTMwLTBjOWRjNjVkNGEyMjQ0ZGMyNDdlYTQxYWQ4MzNiNGY3MDMxNThkZjJmMzY2NDRhMTk3ZWM3OWFkYmY1YzUxNTU
+[scb-slack]: https://owasp.org/slack/invite
 [scb-license]: https://github.com/secureCodeBox/secureCodeBox/blob/master/LICENSE
 

--- a/scanners/test-scan/docs/README.ArtifactHub.md
+++ b/scanners/test-scan/docs/README.ArtifactHub.md
@@ -105,7 +105,7 @@ Please have a look at [Contributing](./CONTRIBUTING.md)
 You are welcome, please join us on... 👋
 
 - [GitHub][scb-github]
-- [Slack][scb-slack]
+- [OWASP Slack (Channel #project-securecodebox)][scb-slack]
 - [Twitter][scb-twitter]
 
 secureCodeBox is an official [OWASP][scb-owasp] project.
@@ -120,6 +120,6 @@ Code of secureCodeBox is licensed under the [Apache License 2.0][scb-license].
 [scb-site]: https://www.securecodebox.io/
 [scb-github]: https://github.com/secureCodeBox/
 [scb-twitter]: https://twitter.com/secureCodeBox
-[scb-slack]: https://join.slack.com/t/securecodebox/shared_invite/enQtNDU3MTUyOTM0NTMwLTBjOWRjNjVkNGEyMjQ0ZGMyNDdlYTQxYWQ4MzNiNGY3MDMxNThkZjJmMzY2NDRhMTk3ZWM3OWFkYmY1YzUxNTU
+[scb-slack]: https://owasp.org/slack/invite
 [scb-license]: https://github.com/secureCodeBox/secureCodeBox/blob/master/LICENSE
 

--- a/scanners/test-scan/docs/README.DockerHub-Parser.md
+++ b/scanners/test-scan/docs/README.DockerHub-Parser.md
@@ -61,7 +61,7 @@ It's rather unlikely that you'll need this outside of testing usecases, as it do
 You are welcome, please join us on... 👋
 
 - [GitHub][scb-github]
-- [Slack][scb-slack]
+- [OWASP Slack (Channel #project-securecodebox)][scb-slack]
 - [Twitter][scb-twitter]
 
 secureCodeBox is an official [OWASP][scb-owasp] project.
@@ -78,6 +78,6 @@ As for any pre-built image usage, it is the image user's responsibility to ensur
 [scb-site]: https://www.securecodebox.io/
 [scb-github]: https://github.com/secureCodeBox/
 [scb-twitter]: https://twitter.com/secureCodeBox
-[scb-slack]: https://join.slack.com/t/securecodebox/shared_invite/enQtNDU3MTUyOTM0NTMwLTBjOWRjNjVkNGEyMjQ0ZGMyNDdlYTQxYWQ4MzNiNGY3MDMxNThkZjJmMzY2NDRhMTk3ZWM3OWFkYmY1YzUxNTU
+[scb-slack]: https://owasp.org/slack/invite
 [scb-license]: https://github.com/secureCodeBox/secureCodeBox/blob/master/LICENSE
 

--- a/scanners/test-scan/docs/README.DockerHub-Scanner.md
+++ b/scanners/test-scan/docs/README.DockerHub-Scanner.md
@@ -61,7 +61,7 @@ It's rather unlikely that you'll need this outside of testing usecases, as it do
 You are welcome, please join us on... 👋
 
 - [GitHub][scb-github]
-- [Slack][scb-slack]
+- [OWASP Slack (Channel #project-securecodebox)][scb-slack]
 - [Twitter][scb-twitter]
 
 secureCodeBox is an official [OWASP][scb-owasp] project.
@@ -78,6 +78,6 @@ As for any pre-built image usage, it is the image user's responsibility to ensur
 [scb-site]: https://www.securecodebox.io/
 [scb-github]: https://github.com/secureCodeBox/
 [scb-twitter]: https://twitter.com/secureCodeBox
-[scb-slack]: https://join.slack.com/t/securecodebox/shared_invite/enQtNDU3MTUyOTM0NTMwLTBjOWRjNjVkNGEyMjQ0ZGMyNDdlYTQxYWQ4MzNiNGY3MDMxNThkZjJmMzY2NDRhMTk3ZWM3OWFkYmY1YzUxNTU
+[scb-slack]: https://owasp.org/slack/invite
 [scb-license]: https://github.com/secureCodeBox/secureCodeBox/blob/master/LICENSE
 

--- a/scanners/trivy-sbom/README.md
+++ b/scanners/trivy-sbom/README.md
@@ -116,7 +116,7 @@ Code of secureCodeBox is licensed under the [Apache License 2.0][scb-license].
 [scb-site]: https://www.securecodebox.io/
 [scb-github]: https://github.com/secureCodeBox/
 [scb-twitter]: https://twitter.com/secureCodeBox
-[scb-slack]: https://join.slack.com/t/securecodebox/shared_invite/enQtNDU3MTUyOTM0NTMwLTBjOWRjNjVkNGEyMjQ0ZGMyNDdlYTQxYWQ4MzNiNGY3MDMxNThkZjJmMzY2NDRhMTk3ZWM3OWFkYmY1YzUxNTU
+[scb-slack]: https://owasp.org/slack/invite
 [scb-license]: https://github.com/secureCodeBox/secureCodeBox/blob/master/LICENSE
 [dependencytrack.org]: https://dependencytrack.org/
 [persistence-dependencytrack]: https://www.securecodebox.io/docs/hooks/dependency-track

--- a/scanners/trivy-sbom/docs/README.ArtifactHub.md
+++ b/scanners/trivy-sbom/docs/README.ArtifactHub.md
@@ -123,7 +123,7 @@ Please have a look at [Contributing](./CONTRIBUTING.md)
 You are welcome, please join us on... 👋
 
 - [GitHub][scb-github]
-- [Slack][scb-slack]
+- [OWASP Slack (Channel #project-securecodebox)][scb-slack]
 - [Twitter][scb-twitter]
 
 secureCodeBox is an official [OWASP][scb-owasp] project.
@@ -138,7 +138,7 @@ Code of secureCodeBox is licensed under the [Apache License 2.0][scb-license].
 [scb-site]: https://www.securecodebox.io/
 [scb-github]: https://github.com/secureCodeBox/
 [scb-twitter]: https://twitter.com/secureCodeBox
-[scb-slack]: https://join.slack.com/t/securecodebox/shared_invite/enQtNDU3MTUyOTM0NTMwLTBjOWRjNjVkNGEyMjQ0ZGMyNDdlYTQxYWQ4MzNiNGY3MDMxNThkZjJmMzY2NDRhMTk3ZWM3OWFkYmY1YzUxNTU
+[scb-slack]: https://owasp.org/slack/invite
 [scb-license]: https://github.com/secureCodeBox/secureCodeBox/blob/master/LICENSE
 [dependencytrack.org]: https://dependencytrack.org/
 [persistence-dependencytrack]: https://www.securecodebox.io/docs/hooks/dependency-track

--- a/scanners/trivy-sbom/docs/README.DockerHub-Parser.md
+++ b/scanners/trivy-sbom/docs/README.DockerHub-Parser.md
@@ -68,7 +68,7 @@ You can use the [Dependency-Track hook][persistence-dependencytrack] to send the
 You are welcome, please join us on... 👋
 
 - [GitHub][scb-github]
-- [Slack][scb-slack]
+- [OWASP Slack (Channel #project-securecodebox)][scb-slack]
 - [Twitter][scb-twitter]
 
 secureCodeBox is an official [OWASP][scb-owasp] project.
@@ -85,7 +85,7 @@ As for any pre-built image usage, it is the image user's responsibility to ensur
 [scb-site]: https://www.securecodebox.io/
 [scb-github]: https://github.com/secureCodeBox/
 [scb-twitter]: https://twitter.com/secureCodeBox
-[scb-slack]: https://join.slack.com/t/securecodebox/shared_invite/enQtNDU3MTUyOTM0NTMwLTBjOWRjNjVkNGEyMjQ0ZGMyNDdlYTQxYWQ4MzNiNGY3MDMxNThkZjJmMzY2NDRhMTk3ZWM3OWFkYmY1YzUxNTU
+[scb-slack]: https://owasp.org/slack/invite
 [scb-license]: https://github.com/secureCodeBox/secureCodeBox/blob/master/LICENSE
 [dependencytrack.org]: https://dependencytrack.org/
 [persistence-dependencytrack]: https://www.securecodebox.io/docs/hooks/dependency-track

--- a/scanners/trivy/README.md
+++ b/scanners/trivy/README.md
@@ -159,6 +159,6 @@ Code of secureCodeBox is licensed under the [Apache License 2.0][scb-license].
 [scb-site]: https://www.securecodebox.io/
 [scb-github]: https://github.com/secureCodeBox/
 [scb-twitter]: https://twitter.com/secureCodeBox
-[scb-slack]: https://join.slack.com/t/securecodebox/shared_invite/enQtNDU3MTUyOTM0NTMwLTBjOWRjNjVkNGEyMjQ0ZGMyNDdlYTQxYWQ4MzNiNGY3MDMxNThkZjJmMzY2NDRhMTk3ZWM3OWFkYmY1YzUxNTU
+[scb-slack]: https://owasp.org/slack/invite
 [scb-license]: https://github.com/secureCodeBox/secureCodeBox/blob/master/LICENSE
 

--- a/scanners/trivy/docs/README.ArtifactHub.md
+++ b/scanners/trivy/docs/README.ArtifactHub.md
@@ -166,7 +166,7 @@ Please have a look at [Contributing](./CONTRIBUTING.md)
 You are welcome, please join us on... 👋
 
 - [GitHub][scb-github]
-- [Slack][scb-slack]
+- [OWASP Slack (Channel #project-securecodebox)][scb-slack]
 - [Twitter][scb-twitter]
 
 secureCodeBox is an official [OWASP][scb-owasp] project.
@@ -181,6 +181,6 @@ Code of secureCodeBox is licensed under the [Apache License 2.0][scb-license].
 [scb-site]: https://www.securecodebox.io/
 [scb-github]: https://github.com/secureCodeBox/
 [scb-twitter]: https://twitter.com/secureCodeBox
-[scb-slack]: https://join.slack.com/t/securecodebox/shared_invite/enQtNDU3MTUyOTM0NTMwLTBjOWRjNjVkNGEyMjQ0ZGMyNDdlYTQxYWQ4MzNiNGY3MDMxNThkZjJmMzY2NDRhMTk3ZWM3OWFkYmY1YzUxNTU
+[scb-slack]: https://owasp.org/slack/invite
 [scb-license]: https://github.com/secureCodeBox/secureCodeBox/blob/master/LICENSE
 

--- a/scanners/trivy/docs/README.DockerHub-Parser.md
+++ b/scanners/trivy/docs/README.DockerHub-Parser.md
@@ -65,7 +65,7 @@ To learn more about the Trivy scanner itself visit [Trivy's GitHub Repository](h
 You are welcome, please join us on... 👋
 
 - [GitHub][scb-github]
-- [Slack][scb-slack]
+- [OWASP Slack (Channel #project-securecodebox)][scb-slack]
 - [Twitter][scb-twitter]
 
 secureCodeBox is an official [OWASP][scb-owasp] project.
@@ -82,6 +82,6 @@ As for any pre-built image usage, it is the image user's responsibility to ensur
 [scb-site]: https://www.securecodebox.io/
 [scb-github]: https://github.com/secureCodeBox/
 [scb-twitter]: https://twitter.com/secureCodeBox
-[scb-slack]: https://join.slack.com/t/securecodebox/shared_invite/enQtNDU3MTUyOTM0NTMwLTBjOWRjNjVkNGEyMjQ0ZGMyNDdlYTQxYWQ4MzNiNGY3MDMxNThkZjJmMzY2NDRhMTk3ZWM3OWFkYmY1YzUxNTU
+[scb-slack]: https://owasp.org/slack/invite
 [scb-license]: https://github.com/secureCodeBox/secureCodeBox/blob/master/LICENSE
 

--- a/scanners/typo3scan/README.md
+++ b/scanners/typo3scan/README.md
@@ -120,6 +120,6 @@ Code of secureCodeBox is licensed under the [Apache License 2.0][scb-license].
 [scb-site]: https://www.securecodebox.io/
 [scb-github]: https://github.com/secureCodeBox/
 [scb-twitter]: https://twitter.com/secureCodeBox
-[scb-slack]: https://join.slack.com/t/securecodebox/shared_invite/enQtNDU3MTUyOTM0NTMwLTBjOWRjNjVkNGEyMjQ0ZGMyNDdlYTQxYWQ4MzNiNGY3MDMxNThkZjJmMzY2NDRhMTk3ZWM3OWFkYmY1YzUxNTU
+[scb-slack]: https://owasp.org/slack/invite
 [scb-license]: https://github.com/secureCodeBox/secureCodeBox/blob/master/LICENSE
 

--- a/scanners/typo3scan/docs/README.ArtifactHub.md
+++ b/scanners/typo3scan/docs/README.ArtifactHub.md
@@ -127,7 +127,7 @@ Please have a look at [Contributing](./CONTRIBUTING.md)
 You are welcome, please join us on... 👋
 
 - [GitHub][scb-github]
-- [Slack][scb-slack]
+- [OWASP Slack (Channel #project-securecodebox)][scb-slack]
 - [Twitter][scb-twitter]
 
 secureCodeBox is an official [OWASP][scb-owasp] project.
@@ -142,6 +142,6 @@ Code of secureCodeBox is licensed under the [Apache License 2.0][scb-license].
 [scb-site]: https://www.securecodebox.io/
 [scb-github]: https://github.com/secureCodeBox/
 [scb-twitter]: https://twitter.com/secureCodeBox
-[scb-slack]: https://join.slack.com/t/securecodebox/shared_invite/enQtNDU3MTUyOTM0NTMwLTBjOWRjNjVkNGEyMjQ0ZGMyNDdlYTQxYWQ4MzNiNGY3MDMxNThkZjJmMzY2NDRhMTk3ZWM3OWFkYmY1YzUxNTU
+[scb-slack]: https://owasp.org/slack/invite
 [scb-license]: https://github.com/secureCodeBox/secureCodeBox/blob/master/LICENSE
 

--- a/scanners/typo3scan/docs/README.DockerHub-Parser.md
+++ b/scanners/typo3scan/docs/README.DockerHub-Parser.md
@@ -61,7 +61,7 @@ To learn more about the Typo3Scan scanner itself, visit the Typo3Scan GitHub rep
 You are welcome, please join us on... 👋
 
 - [GitHub][scb-github]
-- [Slack][scb-slack]
+- [OWASP Slack (Channel #project-securecodebox)][scb-slack]
 - [Twitter][scb-twitter]
 
 secureCodeBox is an official [OWASP][scb-owasp] project.
@@ -78,6 +78,6 @@ As for any pre-built image usage, it is the image user's responsibility to ensur
 [scb-site]: https://www.securecodebox.io/
 [scb-github]: https://github.com/secureCodeBox/
 [scb-twitter]: https://twitter.com/secureCodeBox
-[scb-slack]: https://join.slack.com/t/securecodebox/shared_invite/enQtNDU3MTUyOTM0NTMwLTBjOWRjNjVkNGEyMjQ0ZGMyNDdlYTQxYWQ4MzNiNGY3MDMxNThkZjJmMzY2NDRhMTk3ZWM3OWFkYmY1YzUxNTU
+[scb-slack]: https://owasp.org/slack/invite
 [scb-license]: https://github.com/secureCodeBox/secureCodeBox/blob/master/LICENSE
 

--- a/scanners/typo3scan/docs/README.DockerHub-Scanner.md
+++ b/scanners/typo3scan/docs/README.DockerHub-Scanner.md
@@ -83,7 +83,7 @@ Some useful example parameters listed below:
 You are welcome, please join us on... 👋
 
 - [GitHub][scb-github]
-- [Slack][scb-slack]
+- [OWASP Slack (Channel #project-securecodebox)][scb-slack]
 - [Twitter][scb-twitter]
 
 secureCodeBox is an official [OWASP][scb-owasp] project.
@@ -100,6 +100,6 @@ As for any pre-built image usage, it is the image user's responsibility to ensur
 [scb-site]: https://www.securecodebox.io/
 [scb-github]: https://github.com/secureCodeBox/
 [scb-twitter]: https://twitter.com/secureCodeBox
-[scb-slack]: https://join.slack.com/t/securecodebox/shared_invite/enQtNDU3MTUyOTM0NTMwLTBjOWRjNjVkNGEyMjQ0ZGMyNDdlYTQxYWQ4MzNiNGY3MDMxNThkZjJmMzY2NDRhMTk3ZWM3OWFkYmY1YzUxNTU
+[scb-slack]: https://owasp.org/slack/invite
 [scb-license]: https://github.com/secureCodeBox/secureCodeBox/blob/master/LICENSE
 

--- a/scanners/whatweb/README.md
+++ b/scanners/whatweb/README.md
@@ -237,6 +237,6 @@ Code of secureCodeBox is licensed under the [Apache License 2.0][scb-license].
 [scb-site]: https://www.securecodebox.io/
 [scb-github]: https://github.com/secureCodeBox/
 [scb-twitter]: https://twitter.com/secureCodeBox
-[scb-slack]: https://join.slack.com/t/securecodebox/shared_invite/enQtNDU3MTUyOTM0NTMwLTBjOWRjNjVkNGEyMjQ0ZGMyNDdlYTQxYWQ4MzNiNGY3MDMxNThkZjJmMzY2NDRhMTk3ZWM3OWFkYmY1YzUxNTU
+[scb-slack]: https://owasp.org/slack/invite
 [scb-license]: https://github.com/secureCodeBox/secureCodeBox/blob/master/LICENSE
 [whatweb]: https://morningstarsecurity.com/research/whatweb

--- a/scanners/whatweb/docs/README.ArtifactHub.md
+++ b/scanners/whatweb/docs/README.ArtifactHub.md
@@ -242,7 +242,7 @@ Please have a look at [Contributing](./CONTRIBUTING.md)
 You are welcome, please join us on... 👋
 
 - [GitHub][scb-github]
-- [Slack][scb-slack]
+- [OWASP Slack (Channel #project-securecodebox)][scb-slack]
 - [Twitter][scb-twitter]
 
 secureCodeBox is an official [OWASP][scb-owasp] project.
@@ -257,6 +257,6 @@ Code of secureCodeBox is licensed under the [Apache License 2.0][scb-license].
 [scb-site]: https://www.securecodebox.io/
 [scb-github]: https://github.com/secureCodeBox/
 [scb-twitter]: https://twitter.com/secureCodeBox
-[scb-slack]: https://join.slack.com/t/securecodebox/shared_invite/enQtNDU3MTUyOTM0NTMwLTBjOWRjNjVkNGEyMjQ0ZGMyNDdlYTQxYWQ4MzNiNGY3MDMxNThkZjJmMzY2NDRhMTk3ZWM3OWFkYmY1YzUxNTU
+[scb-slack]: https://owasp.org/slack/invite
 [scb-license]: https://github.com/secureCodeBox/secureCodeBox/blob/master/LICENSE
 [whatweb]: https://morningstarsecurity.com/research/whatweb

--- a/scanners/whatweb/docs/README.DockerHub-Parser.md
+++ b/scanners/whatweb/docs/README.DockerHub-Parser.md
@@ -62,7 +62,7 @@ To learn more about the whatweb scanner itself visit [https://morningstarsecurit
 You are welcome, please join us on... 👋
 
 - [GitHub][scb-github]
-- [Slack][scb-slack]
+- [OWASP Slack (Channel #project-securecodebox)][scb-slack]
 - [Twitter][scb-twitter]
 
 secureCodeBox is an official [OWASP][scb-owasp] project.
@@ -79,6 +79,6 @@ As for any pre-built image usage, it is the image user's responsibility to ensur
 [scb-site]: https://www.securecodebox.io/
 [scb-github]: https://github.com/secureCodeBox/
 [scb-twitter]: https://twitter.com/secureCodeBox
-[scb-slack]: https://join.slack.com/t/securecodebox/shared_invite/enQtNDU3MTUyOTM0NTMwLTBjOWRjNjVkNGEyMjQ0ZGMyNDdlYTQxYWQ4MzNiNGY3MDMxNThkZjJmMzY2NDRhMTk3ZWM3OWFkYmY1YzUxNTU
+[scb-slack]: https://owasp.org/slack/invite
 [scb-license]: https://github.com/secureCodeBox/secureCodeBox/blob/master/LICENSE
 [whatweb]: https://morningstarsecurity.com/research/whatweb

--- a/scanners/whatweb/docs/README.DockerHub-Scanner.md
+++ b/scanners/whatweb/docs/README.DockerHub-Scanner.md
@@ -198,7 +198,7 @@ EXAMPLE USAGE:
 You are welcome, please join us on... 👋
 
 - [GitHub][scb-github]
-- [Slack][scb-slack]
+- [OWASP Slack (Channel #project-securecodebox)][scb-slack]
 - [Twitter][scb-twitter]
 
 secureCodeBox is an official [OWASP][scb-owasp] project.
@@ -215,6 +215,6 @@ As for any pre-built image usage, it is the image user's responsibility to ensur
 [scb-site]: https://www.securecodebox.io/
 [scb-github]: https://github.com/secureCodeBox/
 [scb-twitter]: https://twitter.com/secureCodeBox
-[scb-slack]: https://join.slack.com/t/securecodebox/shared_invite/enQtNDU3MTUyOTM0NTMwLTBjOWRjNjVkNGEyMjQ0ZGMyNDdlYTQxYWQ4MzNiNGY3MDMxNThkZjJmMzY2NDRhMTk3ZWM3OWFkYmY1YzUxNTU
+[scb-slack]: https://owasp.org/slack/invite
 [scb-license]: https://github.com/secureCodeBox/secureCodeBox/blob/master/LICENSE
 [whatweb]: https://morningstarsecurity.com/research/whatweb

--- a/scanners/wpscan/README.md
+++ b/scanners/wpscan/README.md
@@ -145,7 +145,7 @@ Code of secureCodeBox is licensed under the [Apache License 2.0][scb-license].
 [scb-site]: https://www.securecodebox.io/
 [scb-github]: https://github.com/secureCodeBox/
 [scb-twitter]: https://twitter.com/secureCodeBox
-[scb-slack]: https://join.slack.com/t/securecodebox/shared_invite/enQtNDU3MTUyOTM0NTMwLTBjOWRjNjVkNGEyMjQ0ZGMyNDdlYTQxYWQ4MzNiNGY3MDMxNThkZjJmMzY2NDRhMTk3ZWM3OWFkYmY1YzUxNTU
+[scb-slack]: https://owasp.org/slack/invite
 [scb-license]: https://github.com/secureCodeBox/secureCodeBox/blob/master/LICENSE
 [wpscan.org]: https://wpscan.org/
 [WPScan Documentation]: https://github.com/wpscanteam/wpscan/wiki/WPScan-User-Documentation

--- a/scanners/wpscan/docs/README.ArtifactHub.md
+++ b/scanners/wpscan/docs/README.ArtifactHub.md
@@ -150,7 +150,7 @@ Please have a look at [Contributing](./CONTRIBUTING.md)
 You are welcome, please join us on... 👋
 
 - [GitHub][scb-github]
-- [Slack][scb-slack]
+- [OWASP Slack (Channel #project-securecodebox)][scb-slack]
 - [Twitter][scb-twitter]
 
 secureCodeBox is an official [OWASP][scb-owasp] project.
@@ -165,7 +165,7 @@ Code of secureCodeBox is licensed under the [Apache License 2.0][scb-license].
 [scb-site]: https://www.securecodebox.io/
 [scb-github]: https://github.com/secureCodeBox/
 [scb-twitter]: https://twitter.com/secureCodeBox
-[scb-slack]: https://join.slack.com/t/securecodebox/shared_invite/enQtNDU3MTUyOTM0NTMwLTBjOWRjNjVkNGEyMjQ0ZGMyNDdlYTQxYWQ4MzNiNGY3MDMxNThkZjJmMzY2NDRhMTk3ZWM3OWFkYmY1YzUxNTU
+[scb-slack]: https://owasp.org/slack/invite
 [scb-license]: https://github.com/secureCodeBox/secureCodeBox/blob/master/LICENSE
 [wpscan.org]: https://wpscan.org/
 [WPScan Documentation]: https://github.com/wpscanteam/wpscan/wiki/WPScan-User-Documentation

--- a/scanners/wpscan/docs/README.DockerHub-Parser.md
+++ b/scanners/wpscan/docs/README.DockerHub-Parser.md
@@ -64,7 +64,7 @@ To learn more about the WPScan scanner itself visit [wpscan.org].
 You are welcome, please join us on... 👋
 
 - [GitHub][scb-github]
-- [Slack][scb-slack]
+- [OWASP Slack (Channel #project-securecodebox)][scb-slack]
 - [Twitter][scb-twitter]
 
 secureCodeBox is an official [OWASP][scb-owasp] project.
@@ -81,7 +81,7 @@ As for any pre-built image usage, it is the image user's responsibility to ensur
 [scb-site]: https://www.securecodebox.io/
 [scb-github]: https://github.com/secureCodeBox/
 [scb-twitter]: https://twitter.com/secureCodeBox
-[scb-slack]: https://join.slack.com/t/securecodebox/shared_invite/enQtNDU3MTUyOTM0NTMwLTBjOWRjNjVkNGEyMjQ0ZGMyNDdlYTQxYWQ4MzNiNGY3MDMxNThkZjJmMzY2NDRhMTk3ZWM3OWFkYmY1YzUxNTU
+[scb-slack]: https://owasp.org/slack/invite
 [scb-license]: https://github.com/secureCodeBox/secureCodeBox/blob/master/LICENSE
 [wpscan.org]: https://wpscan.org/
 [WPScan Documentation]: https://github.com/wpscanteam/wpscan/wiki/WPScan-User-Documentation

--- a/scanners/wpscan/docs/README.DockerHub-Scanner.md
+++ b/scanners/wpscan/docs/README.DockerHub-Scanner.md
@@ -106,7 +106,7 @@ Incompatible choices (only one of each group/s can be used):
 You are welcome, please join us on... 👋
 
 - [GitHub][scb-github]
-- [Slack][scb-slack]
+- [OWASP Slack (Channel #project-securecodebox)][scb-slack]
 - [Twitter][scb-twitter]
 
 secureCodeBox is an official [OWASP][scb-owasp] project.
@@ -123,7 +123,7 @@ As for any pre-built image usage, it is the image user's responsibility to ensur
 [scb-site]: https://www.securecodebox.io/
 [scb-github]: https://github.com/secureCodeBox/
 [scb-twitter]: https://twitter.com/secureCodeBox
-[scb-slack]: https://join.slack.com/t/securecodebox/shared_invite/enQtNDU3MTUyOTM0NTMwLTBjOWRjNjVkNGEyMjQ0ZGMyNDdlYTQxYWQ4MzNiNGY3MDMxNThkZjJmMzY2NDRhMTk3ZWM3OWFkYmY1YzUxNTU
+[scb-slack]: https://owasp.org/slack/invite
 [scb-license]: https://github.com/secureCodeBox/secureCodeBox/blob/master/LICENSE
 [wpscan.org]: https://wpscan.org/
 [WPScan Documentation]: https://github.com/wpscanteam/wpscan/wiki/WPScan-User-Documentation

--- a/scanners/zap-advanced/README.md
+++ b/scanners/zap-advanced/README.md
@@ -538,7 +538,7 @@ Code of secureCodeBox is licensed under the [Apache License 2.0][scb-license].
 [scb-site]: https://www.securecodebox.io/
 [scb-github]: https://github.com/secureCodeBox/
 [scb-twitter]: https://twitter.com/secureCodeBox
-[scb-slack]: https://join.slack.com/t/securecodebox/shared_invite/enQtNDU3MTUyOTM0NTMwLTBjOWRjNjVkNGEyMjQ0ZGMyNDdlYTQxYWQ4MzNiNGY3MDMxNThkZjJmMzY2NDRhMTk3ZWM3OWFkYmY1YzUxNTU
+[scb-slack]: https://owasp.org/slack/invite
 [scb-license]: https://github.com/secureCodeBox/secureCodeBox/blob/master/LICENSE
 [zap owasp project]: https://owasp.org/www-project-zap/
 [zap github]: https://github.com/zaproxy/zaproxy/

--- a/scanners/zap-advanced/docs/README.ArtifactHub.md
+++ b/scanners/zap-advanced/docs/README.ArtifactHub.md
@@ -543,7 +543,7 @@ Please have a look at [Contributing](./CONTRIBUTING.md)
 You are welcome, please join us on... 👋
 
 - [GitHub][scb-github]
-- [Slack][scb-slack]
+- [OWASP Slack (Channel #project-securecodebox)][scb-slack]
 - [Twitter][scb-twitter]
 
 secureCodeBox is an official [OWASP][scb-owasp] project.
@@ -558,7 +558,7 @@ Code of secureCodeBox is licensed under the [Apache License 2.0][scb-license].
 [scb-site]: https://www.securecodebox.io/
 [scb-github]: https://github.com/secureCodeBox/
 [scb-twitter]: https://twitter.com/secureCodeBox
-[scb-slack]: https://join.slack.com/t/securecodebox/shared_invite/enQtNDU3MTUyOTM0NTMwLTBjOWRjNjVkNGEyMjQ0ZGMyNDdlYTQxYWQ4MzNiNGY3MDMxNThkZjJmMzY2NDRhMTk3ZWM3OWFkYmY1YzUxNTU
+[scb-slack]: https://owasp.org/slack/invite
 [scb-license]: https://github.com/secureCodeBox/secureCodeBox/blob/master/LICENSE
 [zap owasp project]: https://owasp.org/www-project-zap/
 [zap github]: https://github.com/zaproxy/zaproxy/

--- a/scanners/zap-advanced/docs/README.DockerHub-Scanner.md
+++ b/scanners/zap-advanced/docs/README.DockerHub-Scanner.md
@@ -89,7 +89,7 @@ optional arguments:
 You are welcome, please join us on... 👋
 
 - [GitHub][scb-github]
-- [Slack][scb-slack]
+- [OWASP Slack (Channel #project-securecodebox)][scb-slack]
 - [Twitter][scb-twitter]
 
 secureCodeBox is an official [OWASP][scb-owasp] project.
@@ -106,7 +106,7 @@ As for any pre-built image usage, it is the image user's responsibility to ensur
 [scb-site]: https://www.securecodebox.io/
 [scb-github]: https://github.com/secureCodeBox/
 [scb-twitter]: https://twitter.com/secureCodeBox
-[scb-slack]: https://join.slack.com/t/securecodebox/shared_invite/enQtNDU3MTUyOTM0NTMwLTBjOWRjNjVkNGEyMjQ0ZGMyNDdlYTQxYWQ4MzNiNGY3MDMxNThkZjJmMzY2NDRhMTk3ZWM3OWFkYmY1YzUxNTU
+[scb-slack]: https://owasp.org/slack/invite
 [scb-license]: https://github.com/secureCodeBox/secureCodeBox/blob/master/LICENSE
 [zap owasp project]: https://owasp.org/www-project-zap/
 [zap github]: https://github.com/zaproxy/zaproxy/

--- a/scanners/zap/README.md
+++ b/scanners/zap/README.md
@@ -308,7 +308,7 @@ Code of secureCodeBox is licensed under the [Apache License 2.0][scb-license].
 [scb-site]: https://www.securecodebox.io/
 [scb-github]: https://github.com/secureCodeBox/
 [scb-twitter]: https://twitter.com/secureCodeBox
-[scb-slack]: https://join.slack.com/t/securecodebox/shared_invite/enQtNDU3MTUyOTM0NTMwLTBjOWRjNjVkNGEyMjQ0ZGMyNDdlYTQxYWQ4MzNiNGY3MDMxNThkZjJmMzY2NDRhMTk3ZWM3OWFkYmY1YzUxNTU
+[scb-slack]: https://owasp.org/slack/invite
 [scb-license]: https://github.com/secureCodeBox/secureCodeBox/blob/master/LICENSE
 [zap owasp project]: https://owasp.org/www-project-zap/
 [zap github]: https://github.com/zaproxy/zaproxy/

--- a/scanners/zap/docs/README.ArtifactHub.md
+++ b/scanners/zap/docs/README.ArtifactHub.md
@@ -313,7 +313,7 @@ Please have a look at [Contributing](./CONTRIBUTING.md)
 You are welcome, please join us on... 👋
 
 - [GitHub][scb-github]
-- [Slack][scb-slack]
+- [OWASP Slack (Channel #project-securecodebox)][scb-slack]
 - [Twitter][scb-twitter]
 
 secureCodeBox is an official [OWASP][scb-owasp] project.
@@ -328,7 +328,7 @@ Code of secureCodeBox is licensed under the [Apache License 2.0][scb-license].
 [scb-site]: https://www.securecodebox.io/
 [scb-github]: https://github.com/secureCodeBox/
 [scb-twitter]: https://twitter.com/secureCodeBox
-[scb-slack]: https://join.slack.com/t/securecodebox/shared_invite/enQtNDU3MTUyOTM0NTMwLTBjOWRjNjVkNGEyMjQ0ZGMyNDdlYTQxYWQ4MzNiNGY3MDMxNThkZjJmMzY2NDRhMTk3ZWM3OWFkYmY1YzUxNTU
+[scb-slack]: https://owasp.org/slack/invite
 [scb-license]: https://github.com/secureCodeBox/secureCodeBox/blob/master/LICENSE
 [zap owasp project]: https://owasp.org/www-project-zap/
 [zap github]: https://github.com/zaproxy/zaproxy/

--- a/scanners/zap/docs/README.DockerHub-Parser.md
+++ b/scanners/zap/docs/README.DockerHub-Parser.md
@@ -63,7 +63,7 @@ To learn more about the ZAP Automation Framework itself visit [https://www.zapro
 You are welcome, please join us on... 👋
 
 - [GitHub][scb-github]
-- [Slack][scb-slack]
+- [OWASP Slack (Channel #project-securecodebox)][scb-slack]
 - [Twitter][scb-twitter]
 
 secureCodeBox is an official [OWASP][scb-owasp] project.
@@ -80,7 +80,7 @@ As for any pre-built image usage, it is the image user's responsibility to ensur
 [scb-site]: https://www.securecodebox.io/
 [scb-github]: https://github.com/secureCodeBox/
 [scb-twitter]: https://twitter.com/secureCodeBox
-[scb-slack]: https://join.slack.com/t/securecodebox/shared_invite/enQtNDU3MTUyOTM0NTMwLTBjOWRjNjVkNGEyMjQ0ZGMyNDdlYTQxYWQ4MzNiNGY3MDMxNThkZjJmMzY2NDRhMTk3ZWM3OWFkYmY1YzUxNTU
+[scb-slack]: https://owasp.org/slack/invite
 [scb-license]: https://github.com/secureCodeBox/secureCodeBox/blob/master/LICENSE
 [zap owasp project]: https://owasp.org/www-project-zap/
 [zap github]: https://github.com/zaproxy/zaproxy/


### PR DESCRIPTION
## Description

Old Slack Space is depracated and will be shut down soon.
This should replace it everywhere.

(Old link is still left in a example zap finding of the securecodebox.io website but i didn't want to manaully modify this. Should be regenerated once the website is updated)

Closes #2109

### Checklist

* [x] Test your changes as thoroughly as possible before you commit them. Preferably, automate your test by unit/integration tests.
* [x] Make sure that all your commits are signed-off and that you are added to the [Contributors](https://github.com/secureCodeBox/secureCodeBox/blob/main/CONTRIBUTORS.md) file.
* [ ] Make sure that all CI finish successfully.
* [ ] Optional (but appreciated): Make sure that all commits are [Verified](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits).
