### PR TITLE
Add a wait before refetching DefectDojo results (closes #2057)

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -51,3 +51,4 @@ Committing with `git commit -s` will add the sign-off at the end of the commit m
 - Lukas Fischer <lukas.fischer@iteratec.com>
 - Heiko Kiesel <heiko.kiesel@iteratec.com>
 - Frank Belter <frank.belter@iteratec.com>
+- Maximilian Dorner <maximilian.dorner@clever-soft.com>

--- a/hooks/persistence-defectdojo/hook/src/main/java/io/securecodebox/persistence/service/DeduplicationAwaitingService.java
+++ b/hooks/persistence-defectdojo/hook/src/main/java/io/securecodebox/persistence/service/DeduplicationAwaitingService.java
@@ -1,0 +1,33 @@
+// SPDX-FileCopyrightText: the secureCodeBox authors
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package io.securecodebox.persistence.service;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.concurrent.TimeUnit;
+
+public class DeduplicationAwaitingService {
+    private static final Logger LOG = LoggerFactory.getLogger(DeduplicationAwaitingService.class);
+
+    Integer refetchWaitSeconds;
+
+    public void refetchWait() {
+      try {
+        refetchWaitSeconds = Integer.valueOf(System.getenv("DEFECTDOJO_REFETCH_WAIT_SECONDS"));
+        if (refetchWaitSeconds > 0) {
+          LOG.info("Waiting for {} seconds for deduplication to finish before continuing", refetchWaitSeconds);
+          try {
+            TimeUnit.SECONDS.sleep(refetchWaitSeconds);
+          } catch (InterruptedException e) {
+            LOG.warn("Sleeping failed: ", e);
+          }
+        }
+      } catch (NumberFormatException e) {
+          LOG.warn("Could not convert the value of DEFECTDOJO_REFETCH_WAIT_SECONDS to an integer: ",e);
+      }
+    }
+}
+ 

--- a/hooks/persistence-defectdojo/hook/src/main/java/io/securecodebox/persistence/strategies/VersionedEngagementsStrategy.java
+++ b/hooks/persistence-defectdojo/hook/src/main/java/io/securecodebox/persistence/strategies/VersionedEngagementsStrategy.java
@@ -25,6 +25,7 @@ import java.time.format.DateTimeFormatter;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
+import java.util.concurrent.TimeUnit;
 
 /**
  * VersionedEngagementsStrategy creates a new Engagement for every new version of the software.
@@ -113,6 +114,12 @@ public class VersionedEngagementsStrategy implements Strategy {
     );
 
     LOG.info("Uploaded Scan Report as testID {} to DefectDojo", testId);
+
+    var refetchWaitSeconds = config.getRefetchWaitSeconds();
+    if (!(refetchWaitSeconds == 0)) {
+      LOG.info("Waiting for {} seconds before continuing...", refetchWaitSeconds);
+      TimeUnit.SECONDS.sleep(refetchWaitSeconds);
+    }
 
     return findingService.search(Map.of("test", String.valueOf(testId)));
   }


### PR DESCRIPTION
## Description
My aim is to resolve issue #2057 with this change by adding a wait before the refetching the DefectDojo results.

### Checklist

* [ ] Test your changes as thoroughly as possible before you commit them. Preferably, automate your test by unit/integration tests.
* [x] Make sure that all your commits are signed-off and that you are added to the [Contributors](https://github.com/secureCodeBox/secureCodeBox/blob/main/CONTRIBUTORS.md) file.
* [ ] Make sure that all CI finish successfully.
* [ ] Optional (but appreciated): Make sure that all commits are [Verified](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits).
