### PR TITLE
Fix issue in Markdown for DefectDojo Hook breaking the Website build

### DIFF
--- a/hooks/persistence-defectdojo/.helm-docs.gotmpl
+++ b/hooks/persistence-defectdojo/.helm-docs.gotmpl
@@ -299,6 +299,5 @@ spec:
 {{- end }}
 
 {{- define "extra.scannerLinksSection" -}}
-{{- end }}
-
 [dd-scan-types-src]:  https://github.com/secureCodeBox/secureCodeBox/blob/main/hooks/persistence-defectdojo/hook/src/main/java/io/securecodebox/persistence/util/ScanNameMapping.java
+{{- end }}

--- a/hooks/persistence-defectdojo/README.md
+++ b/hooks/persistence-defectdojo/README.md
@@ -1,6 +1,4 @@
-
-
-[dd-scan-types-src]:  https://github.com/secureCodeBox/secureCodeBox/blob/main/hooks/persistence-defectdojo/hook/src/main/java/io/securecodebox/persistence/util/ScanNameMapping.java---
+---
 title: "DefectDojo"
 category: "hook"
 type: "persistenceProvider"
@@ -353,4 +351,4 @@ Code of secureCodeBox is licensed under the [Apache License 2.0][scb-license].
 [scb-mastodon]: https://infosec.exchange/@secureCodeBox
 [scb-slack]:    https://owasp.org/slack/invite
 [scb-license]:  https://github.com/secureCodeBox/secureCodeBox/blob/master/LICENSE
-
+[dd-scan-types-src]:  https://github.com/secureCodeBox/secureCodeBox/blob/main/hooks/persistence-defectdojo/hook/src/main/java/io/securecodebox/persistence/util/ScanNameMapping.java

--- a/hooks/persistence-defectdojo/docs/README.ArtifactHub.md
+++ b/hooks/persistence-defectdojo/docs/README.ArtifactHub.md
@@ -1,6 +1,4 @@
-
-
-[dd-scan-types-src]:  https://github.com/secureCodeBox/secureCodeBox/blob/main/hooks/persistence-defectdojo/hook/src/main/java/io/securecodebox/persistence/util/ScanNameMapping.java<!--
+<!--
 SPDX-FileCopyrightText: the secureCodeBox authors
 
 SPDX-License-Identifier: Apache-2.0
@@ -376,4 +374,4 @@ Code of secureCodeBox is licensed under the [Apache License 2.0][scb-license].
 [scb-mastodon]: https://infosec.exchange/@secureCodeBox
 [scb-slack]:    https://owasp.org/slack/invite
 [scb-license]:  https://github.com/secureCodeBox/secureCodeBox/blob/master/LICENSE
-
+[dd-scan-types-src]:  https://github.com/secureCodeBox/secureCodeBox/blob/main/hooks/persistence-defectdojo/hook/src/main/java/io/securecodebox/persistence/util/ScanNameMapping.java

--- a/hooks/persistence-defectdojo/docs/README.DockerHub-Hook.md
+++ b/hooks/persistence-defectdojo/docs/README.DockerHub-Hook.md
@@ -1,6 +1,4 @@
-
-
-[dd-scan-types-src]:  https://github.com/secureCodeBox/secureCodeBox/blob/main/hooks/persistence-defectdojo/hook/src/main/java/io/securecodebox/persistence/util/ScanNameMapping.java<!--
+<!--
 SPDX-FileCopyrightText: the secureCodeBox authors
 
 SPDX-License-Identifier: Apache-2.0
@@ -153,4 +151,4 @@ As for any pre-built image usage, it is the image user's responsibility to ensur
 [scb-mastodon]: https://infosec.exchange/@secureCodeBox
 [scb-slack]:    https://owasp.org/slack/invite
 [scb-license]:  https://github.com/secureCodeBox/secureCodeBox/blob/master/LICENSE
-
+[dd-scan-types-src]:  https://github.com/secureCodeBox/secureCodeBox/blob/main/hooks/persistence-defectdojo/hook/src/main/java/io/securecodebox/persistence/util/ScanNameMapping.java


### PR DESCRIPTION
## Description

Minor issue in the markdown caused the build to fail because the site could not be generated properly.

### Checklist

* [x] Test your changes as thoroughly as possible before you commit them. Preferably, automate your test by unit/integration tests.
* [x] Make sure that all your commits are signed-off and that you are added to the [Contributors](https://github.com/secureCodeBox/secureCodeBox/blob/main/CONTRIBUTORS.md) file.
* [ ] Make sure that all CI finish successfully.
* [ ] Optional (but appreciated): Make sure that all commits are [Verified](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits).
