### PR TITLE
Ensure Lurker Does Not Run Out of Memory When Uploading Large Scan Results

### DIFF
--- a/lurker/main.go
+++ b/lurker/main.go
@@ -87,6 +87,12 @@ func uploadFile(path, url string) error {
 	}
 
 	req.ContentLength = size
+	// with the default TransferEncoding golang sends out the requests for empty files without
+	// the required Content-Length header this is valid, but not accepted by S3 compatible APIs
+	if size == 0 {
+		req.TransferEncoding = []string{"identity"}
+	}
+
 	client := &http.Client{}
 
 	res, err := client.Do(req)


### PR DESCRIPTION
## Description

Stream uploaded file to s3 bucket instead of loading it all upfront into memory

Related to #2327 

### Checklist

* [x] Test your changes as thoroughly as possible before you commit them. Preferably, automate your test by unit/integration tests.
* [x] Make sure that all your commits are signed-off and that you are added to the [Contributors](https://github.com/secureCodeBox/secureCodeBox/blob/main/CONTRIBUTORS.md) file.
* [ ] Make sure that all CI finish successfully.
* [ ] Optional (but appreciated): Make sure that all commits are [Verified](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits).
