### PR TITLE
Fix Health/Readyness Check Issues with Kubernetes AutoDiscovery

### DIFF
--- a/auto-discovery/kubernetes/auto-discovery-config.yaml
+++ b/auto-discovery/kubernetes/auto-discovery-config.yaml
@@ -9,10 +9,11 @@ kind: AutoDiscoveryConfig
 
 # kubebuilder config
 
+health:
+  healthProbeBindAddress: 127.0.0.1:8081
 metrics:
-  bindAddress: 127.0.0.1:8081
-# webhook:
-#   port: 9443
+  bindAddress: 127.0.0.1:8080
+
 leaderElection:
   leaderElect: false
   resourceName: 80807133.tutorial.kubebuilder.io

--- a/auto-discovery/kubernetes/main.go
+++ b/auto-discovery/kubernetes/main.go
@@ -72,8 +72,9 @@ func main() {
 		Metrics: server.Options{
 			BindAddress: ctrlConfig.Metrics.BindAddress,
 		},
-		LeaderElection:   ctrlConfig.LeaderElection.LeaderElect,
-		LeaderElectionID: ctrlConfig.LeaderElection.ResourceName,
+		HealthProbeBindAddress: ctrlConfig.Health.HealthProbeBindAddress,
+		LeaderElection:         ctrlConfig.LeaderElection.LeaderElect,
+		LeaderElectionID:       ctrlConfig.LeaderElection.ResourceName,
 	})
 	if err != nil {
 		setupLog.Error(err, "unable to start manager")

--- a/auto-discovery/kubernetes/pkg/config/autodiscovery_config.go
+++ b/auto-discovery/kubernetes/pkg/config/autodiscovery_config.go
@@ -15,6 +15,7 @@ type AutoDiscoveryConfig struct {
 	metav1.TypeMeta `json:",inline"`
 
 	Metrics        MetricsConfig        `json:"metrics"`
+	Health         HealthConfig         `json:"health"`
 	LeaderElection LeaderElectionConfig `json:"leaderElection"`
 
 	Cluster                ClusterConfig                `json:"cluster"`
@@ -25,6 +26,10 @@ type AutoDiscoveryConfig struct {
 
 type MetricsConfig struct {
 	BindAddress string `json:"bindAddress"`
+}
+
+type HealthConfig struct {
+	HealthProbeBindAddress string `json:"healthProbeBindAddress"`
 }
 
 type LeaderElectionConfig struct {


### PR DESCRIPTION
## Description

Health Check config was previously directly provided by kubebuilder but got lost in the latest upgrade as kubebuilder doesn't handle the config itself anymore

Closes #2575

### Checklist

* [x] Test your changes as thoroughly as possible before you commit them. Preferably, automate your test by unit/integration tests.
* [x] Make sure that all your commits are signed-off and that you are added to the [Contributors](https://github.com/secureCodeBox/secureCodeBox/blob/main/CONTRIBUTORS.md) file.
* [x] Make sure that all CI finish successfully.
* [ ] Optional (but appreciated): Make sure that all commits are [Verified](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits).
