### PR TITLE
Add script to group scanner version upgrades together

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -70,3 +70,4 @@ documentation/src/integrations.js
 ## Copied over during the build
 documentation/static/findings
 
+**/node_modules/

--- a/bin/.gitignore
+++ b/bin/.gitignore
@@ -1,0 +1,1 @@
+ndoe_modules/

--- a/bin/.gitignore
+++ b/bin/.gitignore
@@ -1,1 +1,0 @@
-ndoe_modules/

--- a/bin/package-lock.json
+++ b/bin/package-lock.json
@@ -1,0 +1,24 @@
+{
+  "name": "bin",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "dependencies": {
+        "semver": "^7.6.3"
+      }
+    },
+    "node_modules/semver": {
+      "version": "7.6.3",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.6.3.tgz",
+      "integrity": "sha512-oVekP1cKtI+CTDvHWYFUcMtsK/00wmAEfyqKfNdARm8u1wNVhSgaX7A8d4UuIlUI5e84iEwOhs7ZPYRmzU9U6A==",
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    }
+  }
+}

--- a/bin/package.json
+++ b/bin/package.json
@@ -1,0 +1,5 @@
+{
+  "dependencies": {
+    "semver": "^7.6.3"
+  }
+}

--- a/bin/release-note-grouper.js
+++ b/bin/release-note-grouper.js
@@ -1,5 +1,9 @@
 #!/usr/bin/env node
 
+// SPDX-FileCopyrightText: the secureCodeBox authors
+//
+// SPDX-License-Identifier: Apache-2.0
+
 /**
 Groups release notes from our SCB Bot into one group/line each per scanner
 To use this script you first have to install the node.js dependencies of the bin/package.json using npm install

--- a/bin/release-note-grouper.js
+++ b/bin/release-note-grouper.js
@@ -1,0 +1,80 @@
+#!/usr/bin/env node
+
+/**
+Groups release notes from our SCB Bot into one group/line each per scanner
+To use this script you first have to install the node.js dependencies of the bin/package.json using npm install
+
+Example Usage: `cat release-context.txt | release-version-grouper.js`
+Example Usage: `pbpaste | release-version-grouper.js`
+
+E.g. turn this:
+```md
+    [SCB-Bot] Upgraded kubeaudit from 0.22.0 to 0.22.1 @secureCodeBoxBot (#2111)
+    [SCB-Bot] Upgraded semgrep from 1.50.0 to 1.51.0 @secureCodeBoxBot (#2112)
+    [SCB-Bot] Upgraded nuclei from v3.0.4 to v3.1.0 @secureCodeBoxBot (#2114)
+    [SCB-Bot] Upgraded gitleaks from v8.18.0 to v8.18.1 @secureCodeBoxBot (#2103)
+    [SCB-Bot] Upgraded nuclei from v3.0.3 to v3.0.4 @secureCodeBoxBot (#2104)
+    [SCB-Bot] Upgraded semgrep from 1.48.0 to 1.50.0 @secureCodeBoxBot (#2101)
+```
+into this:
+```md
+ - Upgraded gitleaks from v8.18.0 to v8.18.1 @secureCodeBoxBot (#2103)
+ - Upgraded kubeaudit from 0.22.0 to 0.22.1 @secureCodeBoxBot (#2111)
+ - Upgraded nuclei from v3.0.3 to v3.1.0 @secureCodeBoxBot (#2114, #2104)
+ - Upgraded semgrep from 1.48.0 to 1.51.0 @secureCodeBoxBot (#2112, #2101)
+```
+ */
+
+const semver = require("semver");
+const readline = require("node:readline");
+const stream = require("node:stream");
+
+// Create readline interface
+const rl = readline.createInterface({
+  input: process.stdin,
+  output: new stream.Writable(),
+  terminal: false,
+});
+
+let upgrades = {};
+
+rl.on("line", (line) => {
+  // Extract information from each line
+  const match = line.match(
+    /\[SCB-Bot\] Upgraded (\w+) from ([\w\.]+) to ([\w\.]+) @secureCodeBoxBot \((#\d+)\)/,
+  );
+  if (match) {
+    const [, dependency, oldVersion, newVersion, pr] = match;
+
+    // Initialize or update the record for each dependency
+    if (!upgrades[dependency]) {
+      upgrades[dependency] = {
+        minVersion: oldVersion,
+        maxVersion: newVersion,
+        prs: [pr],
+      };
+    } else {
+      // Compare and update version numbers using semver
+      if (semver.lt(oldVersion, upgrades[dependency].minVersion)) {
+        upgrades[dependency].minVersion = oldVersion;
+      }
+      if (semver.gt(newVersion, upgrades[dependency].maxVersion)) {
+        upgrades[dependency].maxVersion = newVersion;
+      }
+      upgrades[dependency].prs.push(pr);
+    }
+  }
+});
+
+rl.on("close", () => {
+  // Sort the dependencies alphabetically and output the grouped information
+  Object.keys(upgrades)
+    .sort()
+    .forEach((dep) => {
+      console.log(
+        ` - Upgraded ${dep} from ${upgrades[dep].minVersion} to ${
+          upgrades[dep].maxVersion
+        } @secureCodeBoxBot (${upgrades[dep].prs.join(", ")})`,
+      );
+    });
+});


### PR DESCRIPTION
## Description

Adds a node.js script I've been using for a while to group together our scanner release notes.
See usage / example in the script

### Checklist

* [x] Test your changes as thoroughly as possible before you commit them. Preferably, automate your test by unit/integration tests.
* [x] Make sure that all your commits are signed-off and that you are added to the [Contributors](https://github.com/secureCodeBox/secureCodeBox/blob/main/CONTRIBUTORS.md) file.
* [ ] Make sure that all CI finish successfully.
* [ ] Optional (but appreciated): Make sure that all commits are [Verified](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits).
