### PR TITLE
Fix Issue MS Teams Notification Hook Not Being Able To Deliver Messages

### DIFF
--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -12,3 +12,5 @@
 
 # Applied megalinter automatic fixes
 992174c1fb24a0808ee2894dfff22e568af2b589
+# prettier reformatting of the notification hook
+3f033b5c73a087f474f1f22c5091dc5b096bfadd

--- a/.prettierrc.yaml
+++ b/.prettierrc.yaml
@@ -2,4 +2,10 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-bracketSpacing: false
+overrides:
+  - files: "*.yaml"
+    options:
+      bracketSpacing: false
+  - files: "*.yml"
+    options:
+      bracketSpacing: false

--- a/hooks/notification/hook/Notifier.ts
+++ b/hooks/notification/hook/Notifier.ts
@@ -2,11 +2,11 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-import { Finding } from "./model/Finding"
+import { Finding } from "./model/Finding";
 
 export interface Notifier {
   /**
-   * Sends a Notification Message to the desired End-Point (e.g. Slack or MS Teams) 
+   * Sends a Notification Message to the desired End-Point (e.g. Slack or MS Teams)
    */
-  sendMessage(): Promise<void>
+  sendMessage(): Promise<void>;
 }

--- a/hooks/notification/hook/NotifierFactory.test.ts
+++ b/hooks/notification/hook/NotifierFactory.test.ts
@@ -5,7 +5,7 @@
 import { Finding } from "./model/Finding";
 import { NotificationChannel } from "./model/NotificationChannel";
 import { Scan } from "./model/Scan";
-import { NotifierFactory } from "./NotifierFactory"
+import { NotifierFactory } from "./NotifierFactory";
 import { SlackNotifier } from "./Notifiers/SlackNotifier";
 import { MSTeamsNotifier } from "./Notifiers/MSTeamsNotifier";
 import { TrelloNotifier } from "./Notifiers/TrelloNotifier";
@@ -68,14 +68,14 @@ test("Should Create Slack Notifier", async () => {
     type: NotifierType.SLACK,
     template: "template",
     rules: [],
-    endPoint: "some.endpoint"
-  }
-  const findings: Finding[] = []
-  findings.push(finding)
+    endPoint: "some.endpoint",
+  };
+  const findings: Finding[] = [];
+  findings.push(finding);
   const s = NotifierFactory.create(chan, scan, findings, []);
 
   expect(s instanceof SlackNotifier).toBe(true);
-})
+});
 
 test("Should Create MS Teams Notifier", async () => {
   const chan: NotificationChannel = {
@@ -83,15 +83,15 @@ test("Should Create MS Teams Notifier", async () => {
     type: NotifierType.MS_TEAMS,
     template: "template",
     rules: [],
-    endPoint: "some.endpoint"
-  }
-  const findings: Finding[] = []
-  findings.push(finding)
+    endPoint: "some.endpoint",
+  };
+  const findings: Finding[] = [];
+  findings.push(finding);
 
   const s = NotifierFactory.create(chan, scan, findings, []);
 
   expect(s instanceof MSTeamsNotifier).toBe(true);
-})
+});
 
 test("Should Create Trello Notifier", async () => {
   const chan: NotificationChannel = {
@@ -99,12 +99,12 @@ test("Should Create Trello Notifier", async () => {
     type: NotifierType.TRELLO,
     template: "template",
     rules: [],
-    endPoint: "some.endpoint"
-  }
-  const findings: Finding[] = []
-  findings.push(finding)
+    endPoint: "some.endpoint",
+  };
+  const findings: Finding[] = [];
+  findings.push(finding);
 
   const s = NotifierFactory.create(chan, scan, findings, []);
 
   expect(s instanceof TrelloNotifier).toBe(true);
-})
+});

--- a/hooks/notification/hook/NotifierFactory.test.ts
+++ b/hooks/notification/hook/NotifierFactory.test.ts
@@ -38,7 +38,7 @@ const scan: Scan = {
   },
   status: {
     findingDownloadLink:
-      "https://my-secureCodeBox-instance.com/scan-b9as-sdweref--sadf-asdfsdf-dasdgf-asdffdsfa7/findings.json",
+      "https://s3.securecodebox.example.com/scan-b9as-sdweref--sadf-asdfsdf-dasdgf-asdffdsfa7/findings.json",
     findings: {
       categories: {
         "A Client Error response code was returned by the server": 1,
@@ -55,7 +55,7 @@ const scan: Scan = {
     },
     finishedAt: new Date("2020-05-25T02:38:13Z"),
     rawResultDownloadLink:
-      "https://my-secureCodeBox-instance.com/scan-blkfsdg-sdgfsfgd-sfg-sdfg-dfsg-gfs98-e8af2172caa7/zap-results.json?Expires=1601691232",
+      "https://s3.securecodebox.example.com/scan-blkfsdg-sdgfsfgd-sfg-sdfg-dfsg-gfs98-e8af2172caa7/zap-results.json?Expires=1601691232",
     rawResultFile: "zap-results.json",
     rawResultType: "zap-json",
     state: "Done",

--- a/hooks/notification/hook/NotifierFactory.ts
+++ b/hooks/notification/hook/NotifierFactory.ts
@@ -19,7 +19,7 @@ export class NotifierFactory {
     channel: NotificationChannel,
     scan: Scan,
     findings: Finding[],
-    args: any
+    args: any,
   ): Notifier {
     switch (channel.type) {
       case NotifierType.SLACK:
@@ -35,7 +35,9 @@ export class NotifierFactory {
       case NotifierType.ROCKET_CHAT:
         return new RocketChatNotifier(channel, scan, findings, args);
       default:
-        throw new Error(`Notifier of Type: "${channel.type}"  is not implemented :( Check with the notification hooks documentation for a list of available notifiers.`);
+        throw new Error(
+          `Notifier of Type: "${channel.type}"  is not implemented :( Check with the notification hooks documentation for a list of available notifiers.`,
+        );
     }
   }
 }

--- a/hooks/notification/hook/Notifiers/AbstractNotifier.ts
+++ b/hooks/notification/hook/Notifiers/AbstractNotifier.ts
@@ -14,7 +14,7 @@ import * as nunjucks from "nunjucks";
 export abstract class AbstractNotifier implements Notifier {
   private static readonly TEMPLATE_DIR: string = path.join(
     __dirname,
-    "../notification-templates"
+    "../notification-templates",
   );
   private static readonly TEMPLATE_FILE_TYPE = "njk";
   protected channel: NotificationChannel;
@@ -28,7 +28,7 @@ export abstract class AbstractNotifier implements Notifier {
     channel: NotificationChannel,
     scan: Scan,
     findings: Finding[],
-    args: Object
+    args: Object,
   ) {
     this.channel = channel;
     this.scan = scan;
@@ -42,11 +42,10 @@ export abstract class AbstractNotifier implements Notifier {
     return JSON.stringify(this.renderYamlTemplate());
   }
 
-
   /**
    * By default the value of the endpoint channel config is mapped to a environment variable to be able to store these values securely
    * This behavior can be overwritten for hooks where it doesn't make sense as the endpoint is not considered sensitive.
-   * 
+   *
    * @param envName value of the channels endpoint
    * @returns string actual EndPoint value
    */
@@ -63,7 +62,7 @@ export abstract class AbstractNotifier implements Notifier {
         scan: this.scan,
         args: this.args,
         renderString: nunjucks.renderString,
-      }
+      },
     );
     try {
       const templateObject = jsyaml.load(renderedTemplate);

--- a/hooks/notification/hook/Notifiers/AbstractWebHookNotifier.ts
+++ b/hooks/notification/hook/Notifiers/AbstractWebHookNotifier.ts
@@ -1,19 +1,23 @@
 // SPDX-FileCopyrightText: the secureCodeBox authors
 //
 // SPDX-License-Identifier: Apache-2.0
-import axios from 'axios';
+import axios from "axios";
 import { Scan } from "../model/Scan";
-import { Finding } from "../model/Finding"
-import { NotifierType } from "../NotifierType"
-import type { AxiosRequestConfig } from 'axios';
-import { AbstractNotifier } from "./AbstractNotifier"
+import { Finding } from "../model/Finding";
+import { NotifierType } from "../NotifierType";
+import type { AxiosRequestConfig } from "axios";
+import { AbstractNotifier } from "./AbstractNotifier";
 import { NotificationChannel } from "../model/NotificationChannel";
 
 export abstract class AbstractWebHookNotifier extends AbstractNotifier {
-
   protected abstract type: NotifierType;
 
-  constructor(channel: NotificationChannel, scan: Scan, findings: Finding[], args: Object) {
+  constructor(
+    channel: NotificationChannel,
+    scan: Scan,
+    findings: Finding[],
+    args: Object,
+  ) {
     super(channel, scan, findings, args);
   }
 
@@ -21,12 +25,23 @@ export abstract class AbstractWebHookNotifier extends AbstractNotifier {
     await this.sendPostRequest(this.renderMessage());
   }
 
-  protected async sendPostRequest(message: string, options?: AxiosRequestConfig) {
+  protected async sendPostRequest(
+    message: string,
+    options?: AxiosRequestConfig,
+  ) {
     try {
-      const response = await axios.post(this.resolveEndPoint(), message, options)
-      console.log(`Notifier sent out request for notification, got response code: ${response.status}`)
+      const response = await axios.post(
+        this.resolveEndPoint(),
+        message,
+        options,
+      );
+      console.log(
+        `Notifier sent out request for notification, got response code: ${response.status}`,
+      );
     } catch (e) {
-      console.log(`There was an error sending the message for notifier  "${this.channel.name}" of type "${this.type}":`);
+      console.log(
+        `There was an error sending the message for notifier  "${this.channel.name}" of type "${this.type}":`,
+      );
       console.log(e);
     }
   }

--- a/hooks/notification/hook/Notifiers/EMailNotifier.test.ts
+++ b/hooks/notification/hook/Notifiers/EMailNotifier.test.ts
@@ -41,7 +41,7 @@ function createExampleScan(): Scan {
     },
     status: {
       findingDownloadLink:
-        "https://my-secureCodeBox-instance.com/scan-b9as-sdweref--sadf-asdfsdf-dasdgf-asdffdsfa7/findings.json",
+        "https://s3.securecodebox.example.com/scan-b9as-sdweref--sadf-asdfsdf-dasdgf-asdffdsfa7/findings.json",
       findings: {
         categories: {
           "A Client Error response code was returned by the server": 1,
@@ -58,7 +58,7 @@ function createExampleScan(): Scan {
       },
       finishedAt: new Date("2020-05-25T02:38:13Z"),
       rawResultDownloadLink:
-        "https://my-secureCodeBox-instance.com/scan-blkfsdg-sdgfsfgd-sfg-sdfg-dfsg-gfs98-e8af2172caa7/zap-results.json?Expires=1601691232",
+        "https://s3.securecodebox.example.com/scan-blkfsdg-sdgfsfgd-sfg-sdfg-dfsg-gfs98-e8af2172caa7/zap-results.json?Expires=1601691232",
       rawResultFile: "zap-results.json",
       rawResultType: "zap-json",
       state: "Done",

--- a/hooks/notification/hook/Notifiers/EMailNotifier.test.ts
+++ b/hooks/notification/hook/Notifiers/EMailNotifier.test.ts
@@ -86,7 +86,7 @@ test("Should Send Mail", async () => {
 
   await notifier.sendMessage();
 
-  expect(sendMail).toBeCalledWith({
+  expect(sendMail).toHaveBeenCalledWith({
     from: "secureCodeBox",
     html: `<strong>Scan demo-scan-1601086432</strong><br>
 Created at ${creationTimestamp.toString()}
@@ -121,7 +121,7 @@ Strict-Transport-Security Header Not Set: 1
 `,
     to: "mail@example.com",
   });
-  expect(close).toBeCalled();
+  expect(close).toHaveBeenCalled();
 });
 
 test("should send mail to recipient overwritten in scan annotation", async () => {
@@ -147,7 +147,7 @@ test("should send mail to recipient overwritten in scan annotation", async () =>
 
   await notifier.sendMessage();
 
-  expect(sendMail).toBeCalledWith({
+  expect(sendMail).toHaveBeenCalledWith({
     from: "secureCodeBox",
     html: `<strong>Scan demo-scan-1601086432</strong><br>
 Created at ${creationTimestamp.toString()}
@@ -182,5 +182,5 @@ Strict-Transport-Security Header Not Set: 1
 `,
     to: "foo@example.com",
   });
-  expect(close).toBeCalled();
+  expect(close).toHaveBeenCalled();
 });

--- a/hooks/notification/hook/Notifiers/EMailNotifier.ts
+++ b/hooks/notification/hook/Notifiers/EMailNotifier.ts
@@ -4,11 +4,11 @@
 
 import { NotifierType } from "../NotifierType";
 import { AbstractNotifier } from "./AbstractNotifier";
-import { createTransport } from "nodemailer"
+import { createTransport } from "nodemailer";
 
 export class EMailNotifier extends AbstractNotifier {
-  public static readonly SMTP_CONFIG = 'SMTP_CONFIG';
-  public static readonly EMAIL_FROM = 'EMAIL_FROM';
+  public static readonly SMTP_CONFIG = "SMTP_CONFIG";
+  public static readonly EMAIL_FROM = "EMAIL_FROM";
   protected type: NotifierType.EMAIL;
 
   /**
@@ -34,7 +34,7 @@ export class EMailNotifier extends AbstractNotifier {
       const info = await transporter.sendMail(message);
       console.log(info);
     } catch (e) {
-      console.log(`There was an error sending the email: ${e}`)
+      console.log(`There was an error sending the email: ${e}`);
     } finally {
       transporter.close();
     }
@@ -42,7 +42,7 @@ export class EMailNotifier extends AbstractNotifier {
 
   private prepareMessage(): any {
     const message = JSON.parse(this.renderMessage());
-    if(!message.to) {
+    if (!message.to) {
       // only use fixed endpoint / mail address if it isn't already defined by the template
       message.to = this.resolveEndPoint();
     }

--- a/hooks/notification/hook/Notifiers/MSTeamsNotifier.test.ts
+++ b/hooks/notification/hook/Notifiers/MSTeamsNotifier.test.ts
@@ -43,7 +43,7 @@ test("Should Send Message With Findings And Severities", async () => {
     },
     status: {
       findingDownloadLink:
-        "https://my-secureCodeBox-instance.com/scan-b9as-sdweref--sadf-asdfsdf-dasdgf-asdffdsfa7/findings.json",
+        "https://s3.securecodebox.example.com/scan-b9as-sdweref--sadf-asdfsdf-dasdgf-asdffdsfa7/findings.json",
       findings: {
         categories: {
           "A Client Error response code was returned by the server": 1,
@@ -60,7 +60,7 @@ test("Should Send Message With Findings And Severities", async () => {
       },
       finishedAt: new Date("2020-05-25T02:38:13Z"),
       rawResultDownloadLink:
-        "https://my-secureCodeBox-instance.com/scan-blkfsdg-sdgfsfgd-sfg-sdfg-dfsg-gfs98-e8af2172caa7/zap-results.json?Expires=1601691232",
+        "https://s3.securecodebox.example.com/scan-blkfsdg-sdgfsfgd-sfg-sdfg-dfsg-gfs98-e8af2172caa7/zap-results.json?Expires=1601691232",
       rawResultFile: "zap-results.json",
       rawResultType: "zap-json",
       state: "Done",
@@ -92,11 +92,11 @@ test("Should Send Minimal Template For Empty Findings", async () => {
     },
     status: {
       findingDownloadLink:
-        "https://my-secureCodeBox-instance.com/scan-b9as-sdweref--sadf-asdfsdf-dasdgf-asdffdsfa7/findings.json",
+        "https://s3.securecodebox.example.com/scan-b9as-sdweref--sadf-asdfsdf-dasdgf-asdffdsfa7/findings.json",
       findings: {},
       finishedAt: new Date("2020-05-25T02:38:13Z"),
       rawResultDownloadLink:
-        "https://my-secureCodeBox-instance.com/scan-blkfsdg-sdgfsfgd-sfg-sdfg-dfsg-gfs98-e8af2172caa7/zap-results.json?Expires=1601691232",
+        "https://s3.securecodebox.example.com/scan-blkfsdg-sdgfsfgd-sfg-sdfg-dfsg-gfs98-e8af2172caa7/zap-results.json?Expires=1601691232",
       rawResultFile: "zap-results.json",
       rawResultType: "zap-json",
       state: "Done",

--- a/hooks/notification/hook/Notifiers/MSTeamsNotifier.test.ts
+++ b/hooks/notification/hook/Notifiers/MSTeamsNotifier.test.ts
@@ -14,14 +14,16 @@ beforeEach(() => {
   jest.clearAllMocks();
 });
 
+const TEAMS_ENDPOINT =
+  "https://teams.example.com/webhookb2/<uuid>@<uuid>>/IncomingWebhook/<something>/<uuid>";
 const channel: NotificationChannel = {
   name: "Channel Name",
   type: NotifierType.MS_TEAMS,
   template: "msteams-messageCard",
   rules: [],
-  endPoint:
-    "https://teams.example.com/webhookb2/<uuid>@<uuid>>/IncomingWebhook/<something>/<uuid>",
+  endPoint: "TEAMS_ENDPOINT",
 };
+process.env["TEAMS_ENDPOINT"] = TEAMS_ENDPOINT;
 
 test("Should Send Message With Findings And Severities", async () => {
   const scan: Scan = {
@@ -67,7 +69,9 @@ test("Should Send Message With Findings And Severities", async () => {
 
   const teamsNotifier = new MSTeamsNotifier(channel, scan, [], []);
   teamsNotifier.sendMessage();
-  expect(axios.post).toHaveBeenCalled();
+  expect(axios.post).toHaveBeenCalledWith(TEAMS_ENDPOINT, expect.any(String), {
+    headers: { "Content-Type": "application/json" },
+  });
 });
 
 test("Should Send Minimal Template For Empty Findings", async () => {
@@ -101,5 +105,7 @@ test("Should Send Minimal Template For Empty Findings", async () => {
 
   const n = new MSTeamsNotifier(channel, scan, [], []);
   n.sendMessage();
-  expect(axios.post).toHaveBeenCalled();
+  expect(axios.post).toHaveBeenCalledWith(TEAMS_ENDPOINT, expect.any(String), {
+    headers: { "Content-Type": "application/json" },
+  });
 });

--- a/hooks/notification/hook/Notifiers/MSTeamsNotifier.test.ts
+++ b/hooks/notification/hook/Notifiers/MSTeamsNotifier.test.ts
@@ -67,7 +67,7 @@ test("Should Send Message With Findings And Severities", async () => {
 
   const teamsNotifier = new MSTeamsNotifier(channel, scan, [], []);
   teamsNotifier.sendMessage();
-  expect(axios.post).toBeCalled();
+  expect(axios.post).toHaveBeenCalled();
 });
 
 test("Should Send Minimal Template For Empty Findings", async () => {
@@ -101,5 +101,5 @@ test("Should Send Minimal Template For Empty Findings", async () => {
 
   const n = new MSTeamsNotifier(channel, scan, [], []);
   n.sendMessage();
-  expect(axios.post).toBeCalled();
+  expect(axios.post).toHaveBeenCalled();
 });

--- a/hooks/notification/hook/Notifiers/MSTeamsNotifier.test.ts
+++ b/hooks/notification/hook/Notifiers/MSTeamsNotifier.test.ts
@@ -3,27 +3,27 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import { MSTeamsNotifier } from "./MSTeamsNotifier";
-import axios from 'axios'
+import axios from "axios";
 import { NotificationChannel } from "../model/NotificationChannel";
 import { NotifierType } from "../NotifierType";
 import { Scan } from "../model/Scan";
 
-jest.mock('axios');
+jest.mock("axios");
 
 beforeEach(() => {
   jest.clearAllMocks();
-})
+});
 
 const channel: NotificationChannel = {
   name: "Channel Name",
   type: NotifierType.MS_TEAMS,
   template: "msteams-messageCard",
   rules: [],
-  endPoint: "https://teams.example.com/webhookb2/<uuid>@<uuid>>/IncomingWebhook/<something>/<uuid>"
+  endPoint:
+    "https://teams.example.com/webhookb2/<uuid>@<uuid>>/IncomingWebhook/<something>/<uuid>",
 };
 
 test("Should Send Message With Findings And Severities", async () => {
-
   const scan: Scan = {
     metadata: {
       uid: "09988cdf-1fc7-4f85-95ee-1b1d65dbc7cc",
@@ -102,4 +102,4 @@ test("Should Send Minimal Template For Empty Findings", async () => {
   const n = new MSTeamsNotifier(channel, scan, [], []);
   n.sendMessage();
   expect(axios.post).toBeCalled();
-})
+});

--- a/hooks/notification/hook/Notifiers/MSTeamsNotifier.ts
+++ b/hooks/notification/hook/Notifiers/MSTeamsNotifier.ts
@@ -19,4 +19,10 @@ export class MSTeamsNotifier extends AbstractWebHookNotifier {
   ) {
     super(channel, scan, findings, args);
   }
+
+  public async sendMessage(): Promise<void> {
+    await this.sendPostRequest(this.renderMessage(), {
+      headers: { "Content-Type": "application/json" },
+    });
+  }
 }

--- a/hooks/notification/hook/Notifiers/MSTeamsNotifier.ts
+++ b/hooks/notification/hook/Notifiers/MSTeamsNotifier.ts
@@ -2,17 +2,21 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-import { NotifierType } from "../NotifierType"
-import { AbstractWebHookNotifier } from "./AbstractWebHookNotifier"
-import { Finding } from "../model/Finding"
+import { NotifierType } from "../NotifierType";
+import { AbstractWebHookNotifier } from "./AbstractWebHookNotifier";
+import { Finding } from "../model/Finding";
 import { NotificationChannel } from "../model/NotificationChannel";
 import { Scan } from "../model/Scan";
 
 export class MSTeamsNotifier extends AbstractWebHookNotifier {
+  protected type: NotifierType = NotifierType.MS_TEAMS;
 
-  protected type: NotifierType = NotifierType.MS_TEAMS
-
-  constructor(channel: NotificationChannel, scan: Scan, findings: Finding[], args: Object) {
+  constructor(
+    channel: NotificationChannel,
+    scan: Scan,
+    findings: Finding[],
+    args: Object,
+  ) {
     super(channel, scan, findings, args);
   }
 }

--- a/hooks/notification/hook/Notifiers/MSTeamsNotifier.ts
+++ b/hooks/notification/hook/Notifiers/MSTeamsNotifier.ts
@@ -5,7 +5,6 @@
 import { NotifierType } from "../NotifierType"
 import { AbstractWebHookNotifier } from "./AbstractWebHookNotifier"
 import { Finding } from "../model/Finding"
-import axios from 'axios';
 import { NotificationChannel } from "../model/NotificationChannel";
 import { Scan } from "../model/Scan";
 

--- a/hooks/notification/hook/Notifiers/RocketChat.ts
+++ b/hooks/notification/hook/Notifiers/RocketChat.ts
@@ -15,7 +15,7 @@ export class RocketChatNotifier extends AbstractWebHookNotifier {
     channel: NotificationChannel,
     scan: Scan,
     findings: Finding[],
-    args: Object
+    args: Object,
   ) {
     super(channel, scan, findings, args);
   }

--- a/hooks/notification/hook/Notifiers/RocketChatNotifier.test.ts
+++ b/hooks/notification/hook/Notifiers/RocketChatNotifier.test.ts
@@ -41,7 +41,7 @@ function getTestData() {
     },
     status: {
       findingDownloadLink:
-        "https://my-secureCodeBox-instance.com/scan-b9as-sdweref--sadf-asdfsdf-dasdgf-asdffdsfa7/findings.json",
+        "https://s3.securecodebox.example.com/scan-b9as-sdweref--sadf-asdfsdf-dasdgf-asdffdsfa7/findings.json",
       findings: {
         categories: {
           "A Client Error response code was returned by the server": 1,
@@ -58,7 +58,7 @@ function getTestData() {
       },
       finishedAt: new Date("2020-05-25T02:38:13Z"),
       rawResultDownloadLink:
-        "https://my-secureCodeBox-instance.com/scan-blkfsdg-sdgfsfgd-sfg-sdfg-dfsg-gfs98-e8af2172caa7/zap-results.json?Expires=1601691232",
+        "https://s3.securecodebox.example.com/scan-blkfsdg-sdgfsfgd-sfg-sdfg-dfsg-gfs98-e8af2172caa7/zap-results.json?Expires=1601691232",
       rawResultFile: "zap-results.json",
       rawResultType: "zap-json",
       state: "Done",

--- a/hooks/notification/hook/Notifiers/RocketChatNotifier.test.ts
+++ b/hooks/notification/hook/Notifiers/RocketChatNotifier.test.ts
@@ -90,7 +90,7 @@ test("Should Send Message With Findings And Severities", async () => {
   });
   await rocketChatNotifier.sendMessage();
 
-  expect(axios.post).toBeCalledWith(
+  expect(axios.post).toHaveBeenCalledWith(
     "https://rocketchat.example.com/api/v1/chat.postMessage",
     '{"channel":"#securecodebox","text":"New Scan Results for demo-scan-1601086432","attachments":[{"fields":[{"title":"- foobar","value":"hello world","short":false}]}]}',
     {
@@ -116,7 +116,7 @@ test("Should use channel overwrite from annotation if set", async () => {
   });
   await rocketChatNotifier.sendMessage();
 
-  expect(axios.post).toBeCalledWith(
+  expect(axios.post).toHaveBeenCalledWith(
     "https://rocketchat.example.com/api/v1/chat.postMessage",
     '{"channel":"#team-42-channel","text":"New Scan Results for demo-scan-1601086432","attachments":[{"fields":[{"title":"- foobar","value":"hello world","short":false}]}]}',
     {
@@ -143,7 +143,7 @@ test("Should include link back to defectdojo if set in finding", async () => {
   });
   await rocketChatNotifier.sendMessage();
 
-  expect(axios.post).toBeCalledWith(
+  expect(axios.post).toHaveBeenCalledWith(
     "https://rocketchat.example.com/api/v1/chat.postMessage",
     '{"channel":"#securecodebox","text":"New Scan Results for demo-scan-1601086432","attachments":[{"fields":[{"title":"- foobar","value":"hello world [Open in DefectDojo](https://defectdojo.example.com/finding/42)","short":false}]}]}',
     {

--- a/hooks/notification/hook/Notifiers/RocketChatNotifier.test.ts
+++ b/hooks/notification/hook/Notifiers/RocketChatNotifier.test.ts
@@ -99,7 +99,7 @@ test("Should Send Message With Findings And Severities", async () => {
         "X-Auth-Token": "foobar",
         "X-User-Id": "barfoo",
       },
-    }
+    },
   );
 });
 
@@ -125,7 +125,7 @@ test("Should use channel overwrite from annotation if set", async () => {
         "X-Auth-Token": "foobar",
         "X-User-Id": "barfoo",
       },
-    }
+    },
   );
 });
 
@@ -152,6 +152,6 @@ test("Should include link back to defectdojo if set in finding", async () => {
         "X-Auth-Token": "foobar",
         "X-User-Id": "barfoo",
       },
-    }
+    },
   );
 });

--- a/hooks/notification/hook/Notifiers/SlackAppNotifier.test.ts
+++ b/hooks/notification/hook/Notifiers/SlackAppNotifier.test.ts
@@ -42,7 +42,7 @@ test("Should Send Message With Findings And Severities", async () => {
     },
     status: {
       findingDownloadLink:
-        "https://my-secureCodeBox-instance.com/scan-b9as-sdweref--sadf-asdfsdf-dasdgf-asdffdsfa7/findings.json",
+        "https://s3.securecodebox.example.com/scan-b9as-sdweref--sadf-asdfsdf-dasdgf-asdffdsfa7/findings.json",
       findings: {
         categories: {
           "A Client Error response code was returned by the server": 1,
@@ -59,7 +59,7 @@ test("Should Send Message With Findings And Severities", async () => {
       },
       finishedAt: new Date("2020-05-25T02:38:13Z"),
       rawResultDownloadLink:
-        "https://my-secureCodeBox-instance.com/scan-blkfsdg-sdgfsfgd-sfg-sdfg-dfsg-gfs98-e8af2172caa7/zap-results.json?Expires=1601691232",
+        "https://s3.securecodebox.example.com/scan-blkfsdg-sdgfsfgd-sfg-sdfg-dfsg-gfs98-e8af2172caa7/zap-results.json?Expires=1601691232",
       rawResultFile: "zap-results.json",
       rawResultType: "zap-json",
       state: "Done",

--- a/hooks/notification/hook/Notifiers/SlackAppNotifier.test.ts
+++ b/hooks/notification/hook/Notifiers/SlackAppNotifier.test.ts
@@ -68,5 +68,5 @@ test("Should Send Message With Findings And Severities", async () => {
 
   const slackNotifier = new SlackAppNotifier(channel, scan, [], []);
   slackNotifier.sendMessage();
-  expect(axios.post).toBeCalled();
+  expect(axios.post).toHaveBeenCalled();
 });

--- a/hooks/notification/hook/Notifiers/SlackAppNotifier.ts
+++ b/hooks/notification/hook/Notifiers/SlackAppNotifier.ts
@@ -23,7 +23,7 @@ export class SlackAppNotifier extends AbstractNotifier {
     channel: NotificationChannel,
     scan: Scan,
     findings: Finding[],
-    args: Object
+    args: Object,
   ) {
     super(channel, scan, findings, args);
 
@@ -35,7 +35,7 @@ export class SlackAppNotifier extends AbstractNotifier {
 
     if (this.slackChannel === undefined) {
       throw new Error(
-        "Not Slack channel configured via 'notification.securecodebox.io/slack-channel' scan annotation or via the 'SLACK_DEFAULT_CHANNEL' env variable."
+        "Not Slack channel configured via 'notification.securecodebox.io/slack-channel' scan annotation or via the 'SLACK_DEFAULT_CHANNEL' env variable.",
       );
     }
   }
@@ -47,7 +47,7 @@ export class SlackAppNotifier extends AbstractNotifier {
   protected async sendPostRequest(message: any) {
     try {
       console.log(
-        `Sending notification to Slack Channel: ${this.slackChannel}`
+        `Sending notification to Slack Channel: ${this.slackChannel}`,
       );
 
       const { data: response } = await axios.post<SlackApiResponse>(
@@ -60,7 +60,7 @@ export class SlackAppNotifier extends AbstractNotifier {
           headers: {
             Authorization: `Bearer ${process.env["SLACK_APP_TOKEN"]}`,
           },
-        }
+        },
       );
 
       if (!response.ok) {
@@ -68,7 +68,7 @@ export class SlackAppNotifier extends AbstractNotifier {
       }
     } catch (e) {
       console.log(
-        `There was an Error sending the Message for the Slack App Notifier "${this.channel.name}"`
+        `There was an Error sending the Message for the Slack App Notifier "${this.channel.name}"`,
       );
       console.log(e);
     }

--- a/hooks/notification/hook/Notifiers/SlackNotifier.test.ts
+++ b/hooks/notification/hook/Notifiers/SlackNotifier.test.ts
@@ -40,7 +40,7 @@ test("Should Send Message With Findings And Severities", async () => {
     },
     status: {
       findingDownloadLink:
-        "https://my-secureCodeBox-instance.com/scan-b9as-sdweref--sadf-asdfsdf-dasdgf-asdffdsfa7/findings.json",
+        "https://s3.securecodebox.example.com/scan-b9as-sdweref--sadf-asdfsdf-dasdgf-asdffdsfa7/findings.json",
       findings: {
         categories: {
           "A Client Error response code was returned by the server": 1,
@@ -57,7 +57,7 @@ test("Should Send Message With Findings And Severities", async () => {
       },
       finishedAt: new Date("2020-05-25T02:38:13Z"),
       rawResultDownloadLink:
-        "https://my-secureCodeBox-instance.com/scan-blkfsdg-sdgfsfgd-sfg-sdfg-dfsg-gfs98-e8af2172caa7/zap-results.json?Expires=1601691232",
+        "https://s3.securecodebox.example.com/scan-blkfsdg-sdgfsfgd-sfg-sdfg-dfsg-gfs98-e8af2172caa7/zap-results.json?Expires=1601691232",
       rawResultFile: "zap-results.json",
       rawResultType: "zap-json",
       state: "Done",
@@ -87,11 +87,11 @@ test("Should Send Minimal Template For Empty Findings", async () => {
     },
     status: {
       findingDownloadLink:
-        "https://my-secureCodeBox-instance.com/scan-b9as-sdweref--sadf-asdfsdf-dasdgf-asdffdsfa7/findings.json",
+        "https://s3.securecodebox.example.com/scan-b9as-sdweref--sadf-asdfsdf-dasdgf-asdffdsfa7/findings.json",
       findings: {},
       finishedAt: new Date("2020-05-25T02:38:13Z"),
       rawResultDownloadLink:
-        "https://my-secureCodeBox-instance.com/scan-blkfsdg-sdgfsfgd-sfg-sdfg-dfsg-gfs98-e8af2172caa7/zap-results.json?Expires=1601691232",
+        "https://s3.securecodebox.example.com/scan-blkfsdg-sdgfsfgd-sfg-sdfg-dfsg-gfs98-e8af2172caa7/zap-results.json?Expires=1601691232",
       rawResultFile: "zap-results.json",
       rawResultType: "zap-json",
       state: "Done",

--- a/hooks/notification/hook/Notifiers/SlackNotifier.test.ts
+++ b/hooks/notification/hook/Notifiers/SlackNotifier.test.ts
@@ -3,27 +3,26 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import { SlackNotifier } from "./SlackNotifier";
-import axios from 'axios'
+import axios from "axios";
 import { NotificationChannel } from "../model/NotificationChannel";
 import { NotifierType } from "../NotifierType";
 import { Scan } from "../model/Scan";
 
-jest.mock('axios');
+jest.mock("axios");
 
 beforeEach(() => {
   jest.clearAllMocks();
-})
+});
 
 const channel: NotificationChannel = {
   name: "Channel Name",
   type: NotifierType.SLACK,
   template: "slack-messageCard",
   rules: [],
-  endPoint: "https://hooks.slack.com/services/<YOUR_TOKEN>"
+  endPoint: "https://hooks.slack.com/services/<YOUR_TOKEN>",
 };
 
 test("Should Send Message With Findings And Severities", async () => {
-
   const scan: Scan = {
     metadata: {
       uid: "09988cdf-1fc7-4f85-95ee-1b1d65dbc7cc",
@@ -102,4 +101,4 @@ test("Should Send Minimal Template For Empty Findings", async () => {
   const n = new SlackNotifier(channel, scan, [], []);
   n.sendMessage();
   expect(axios.post).toBeCalled();
-})
+});

--- a/hooks/notification/hook/Notifiers/SlackNotifier.test.ts
+++ b/hooks/notification/hook/Notifiers/SlackNotifier.test.ts
@@ -66,7 +66,7 @@ test("Should Send Message With Findings And Severities", async () => {
 
   const slackNotifier = new SlackNotifier(channel, scan, [], []);
   slackNotifier.sendMessage();
-  expect(axios.post).toBeCalled();
+  expect(axios.post).toHaveBeenCalled();
 });
 
 test("Should Send Minimal Template For Empty Findings", async () => {
@@ -100,5 +100,5 @@ test("Should Send Minimal Template For Empty Findings", async () => {
 
   const n = new SlackNotifier(channel, scan, [], []);
   n.sendMessage();
-  expect(axios.post).toBeCalled();
+  expect(axios.post).toHaveBeenCalled();
 });

--- a/hooks/notification/hook/Notifiers/SlackNotifier.ts
+++ b/hooks/notification/hook/Notifiers/SlackNotifier.ts
@@ -2,18 +2,22 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-import { NotifierType } from "../NotifierType"
-import { AbstractWebHookNotifier } from "./AbstractWebHookNotifier"
-import { Finding } from "../model/Finding"
-import axios from 'axios';
+import { NotifierType } from "../NotifierType";
+import { AbstractWebHookNotifier } from "./AbstractWebHookNotifier";
+import { Finding } from "../model/Finding";
+import axios from "axios";
 import { NotificationChannel } from "../model/NotificationChannel";
 import { Scan } from "../model/Scan";
 
 export class SlackNotifier extends AbstractWebHookNotifier {
+  protected type: NotifierType = NotifierType.SLACK;
 
-  protected type: NotifierType = NotifierType.SLACK
-
-  constructor(channel: NotificationChannel, scan: Scan, findings: Finding[], args: Object) {
+  constructor(
+    channel: NotificationChannel,
+    scan: Scan,
+    findings: Finding[],
+    args: Object,
+  ) {
     super(channel, scan, findings, args);
   }
 }

--- a/hooks/notification/hook/Notifiers/TrelloNotifier.test.ts
+++ b/hooks/notification/hook/Notifiers/TrelloNotifier.test.ts
@@ -3,17 +3,17 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import { TrelloNotifier } from "./TrelloNotifier";
-import axios from 'axios'
+import axios from "axios";
 import { Finding } from "../model/Finding";
 import { NotificationChannel } from "../model/NotificationChannel";
 import { NotifierType } from "../NotifierType";
 import { Scan } from "../model/Scan";
 
-jest.mock('axios');
+jest.mock("axios");
 
 beforeEach(() => {
   jest.clearAllMocks();
-})
+});
 
 const finding: Finding = {
   name: "test finding",
@@ -30,11 +30,10 @@ const channel: NotificationChannel = {
   type: NotifierType.TRELLO,
   template: "",
   rules: [],
-  endPoint: "https://api.trello.com/1/cards"
+  endPoint: "https://api.trello.com/1/cards",
 };
 
 test("Should Create Cards With Findings And Severities", async () => {
-
   const scan: Scan = {
     metadata: {
       uid: "09988cdf-1fc7-4f85-95ee-1b1d65dbc7cc",
@@ -76,8 +75,8 @@ test("Should Create Cards With Findings And Severities", async () => {
     },
   };
 
-  const findings: Finding[] = []
-  findings.push(finding)
+  const findings: Finding[] = [];
+  findings.push(finding);
 
   const trelloNotifier = new TrelloNotifier(channel, scan, findings, []);
   trelloNotifier.sendMessage();
@@ -113,10 +112,10 @@ test("Should Send Minimal Template For Empty Findings", async () => {
     },
   };
 
-  const findings: Finding[] = []
-  findings.push(finding)
+  const findings: Finding[] = [];
+  findings.push(finding);
 
   const trelloNotifier = new TrelloNotifier(channel, scan, findings, []);
   trelloNotifier.sendMessage();
   expect(axios.post).toBeCalled();
-})
+});

--- a/hooks/notification/hook/Notifiers/TrelloNotifier.test.ts
+++ b/hooks/notification/hook/Notifiers/TrelloNotifier.test.ts
@@ -51,7 +51,7 @@ test("Should Create Cards With Findings And Severities", async () => {
     },
     status: {
       findingDownloadLink:
-        "https://my-secureCodeBox-instance.com/scan-b9as-sdweref--sadf-asdfsdf-dasdgf-asdffdsfa7/findings.json",
+        "https://s3.securecodebox.example.com/scan-b9as-sdweref--sadf-asdfsdf-dasdgf-asdffdsfa7/findings.json",
       findings: {
         categories: {
           "A Client Error response code was returned by the server": 1,
@@ -68,7 +68,7 @@ test("Should Create Cards With Findings And Severities", async () => {
       },
       finishedAt: new Date("2020-05-25T02:38:13Z"),
       rawResultDownloadLink:
-        "https://my-secureCodeBox-instance.com/scan-blkfsdg-sdgfsfgd-sfg-sdfg-dfsg-gfs98-e8af2172caa7/zap-results.json?Expires=1601691232",
+        "https://s3.securecodebox.example.com/scan-blkfsdg-sdgfsfgd-sfg-sdfg-dfsg-gfs98-e8af2172caa7/zap-results.json?Expires=1601691232",
       rawResultFile: "zap-results.json",
       rawResultType: "zap-json",
       state: "Done",
@@ -101,11 +101,11 @@ test("Should Send Minimal Template For Empty Findings", async () => {
     },
     status: {
       findingDownloadLink:
-        "https://my-secureCodeBox-instance.com/scan-b9as-sdweref--sadf-asdfsdf-dasdgf-asdffdsfa7/findings.json",
+        "https://s3.securecodebox.example.com/scan-b9as-sdweref--sadf-asdfsdf-dasdgf-asdffdsfa7/findings.json",
       findings: {},
       finishedAt: new Date("2020-05-25T02:38:13Z"),
       rawResultDownloadLink:
-        "https://my-secureCodeBox-instance.com/scan-blkfsdg-sdgfsfgd-sfg-sdfg-dfsg-gfs98-e8af2172caa7/zap-results.json?Expires=1601691232",
+        "https://s3.securecodebox.example.com/scan-blkfsdg-sdgfsfgd-sfg-sdfg-dfsg-gfs98-e8af2172caa7/zap-results.json?Expires=1601691232",
       rawResultFile: "zap-results.json",
       rawResultType: "zap-json",
       state: "Done",

--- a/hooks/notification/hook/Notifiers/TrelloNotifier.test.ts
+++ b/hooks/notification/hook/Notifiers/TrelloNotifier.test.ts
@@ -80,7 +80,7 @@ test("Should Create Cards With Findings And Severities", async () => {
 
   const trelloNotifier = new TrelloNotifier(channel, scan, findings, []);
   trelloNotifier.sendMessage();
-  expect(axios.post).toBeCalled();
+  expect(axios.post).toHaveBeenCalled();
 });
 
 test("Should Send Minimal Template For Empty Findings", async () => {
@@ -117,5 +117,5 @@ test("Should Send Minimal Template For Empty Findings", async () => {
 
   const trelloNotifier = new TrelloNotifier(channel, scan, findings, []);
   trelloNotifier.sendMessage();
-  expect(axios.post).toBeCalled();
+  expect(axios.post).toHaveBeenCalled();
 });

--- a/hooks/notification/hook/Notifiers/TrelloNotifier.ts
+++ b/hooks/notification/hook/Notifiers/TrelloNotifier.ts
@@ -2,27 +2,31 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-import { NotifierType } from "../NotifierType"
-import { AbstractWebHookNotifier } from "./AbstractWebHookNotifier"
-import { Finding } from "../model/Finding"
+import { NotifierType } from "../NotifierType";
+import { AbstractWebHookNotifier } from "./AbstractWebHookNotifier";
+import { Finding } from "../model/Finding";
 import { matches } from "../hook";
-import axios from 'axios';
+import axios from "axios";
 import { NotificationChannel } from "../model/NotificationChannel";
 import { Scan } from "../model/Scan";
 
 export class TrelloNotifier extends AbstractWebHookNotifier {
+  public static readonly TRELLO_CARDS_ENDPOINT = "TRELLO_CARDS_ENDPOINT";
+  public static readonly TRELLO_KEY = "TRELLO_KEY";
+  public static readonly TRELLO_TOKEN = "TRELLO_TOKEN";
+  public static readonly TRELLO_LIST = "TRELLO_LIST";
+  public static readonly TRELLO_LABELS = "TRELLO_LABELS";
+  public static readonly TRELLO_POS = "TRELLO_POS";
+  public static readonly TRELLO_TITLE_PREFIX = "TRELLO_TITLE_PREFIX";
 
-  public static readonly TRELLO_CARDS_ENDPOINT = 'TRELLO_CARDS_ENDPOINT';
-  public static readonly TRELLO_KEY = 'TRELLO_KEY';
-  public static readonly TRELLO_TOKEN = 'TRELLO_TOKEN';
-  public static readonly TRELLO_LIST = 'TRELLO_LIST';
-  public static readonly TRELLO_LABELS = 'TRELLO_LABELS';
-  public static readonly TRELLO_POS = 'TRELLO_POS';
-  public static readonly TRELLO_TITLE_PREFIX = 'TRELLO_TITLE_PREFIX';
+  protected type: NotifierType = NotifierType.TRELLO;
 
-  protected type: NotifierType = NotifierType.TRELLO
-
-  constructor(channel: NotificationChannel, scan: Scan, findings: Finding[], args: Object) {
+  constructor(
+    channel: NotificationChannel,
+    scan: Scan,
+    findings: Finding[],
+    args: Object,
+  ) {
     super(channel, scan, findings, args);
   }
 
@@ -31,37 +35,39 @@ export class TrelloNotifier extends AbstractWebHookNotifier {
    * So if the TRELLO_CARDS_ENDPOINT env is not explicitly defined then default to that URL
    */
   public resolveEndPoint(): string {
-    if(TrelloNotifier.TRELLO_CARDS_ENDPOINT in process.env) { 
-      return super.resolveEndPoint(); 
+    if (TrelloNotifier.TRELLO_CARDS_ENDPOINT in process.env) {
+      return super.resolveEndPoint();
     }
     return "https://api.trello.com/1/cards";
   }
 
   // The Trello hook will create a card for each finding
   public async sendMessage(): Promise<void> {
-    for ( let idx in this.findings ) {
+    for (let idx in this.findings) {
       var jsonData = {
-          "key": this.getTrelloKey(),
-          "token": this.getTrelloToken(),
-          "idList": this.getTrelloList(),
-          "name": this.getCardName(this.findings[idx]),
-          "desc": this.getCardDescription(this.findings[idx]),
-          "pos": this.getTrelloPos()
-      }
+        key: this.getTrelloKey(),
+        token: this.getTrelloToken(),
+        idList: this.getTrelloList(),
+        name: this.getCardName(this.findings[idx]),
+        desc: this.getCardDescription(this.findings[idx]),
+        pos: this.getTrelloPos(),
+      };
 
-      // Add the labels only if defined    
-      if(this.getTrelloLabels().length > 0)
+      // Add the labels only if defined
+      if (this.getTrelloLabels().length > 0)
         jsonData["idLabels"] = this.getTrelloLabels();
 
       await this.sendJSONPostRequest(jsonData);
     }
   }
 
-  protected async sendJSONPostRequest( jsonData ) {
+  protected async sendJSONPostRequest(jsonData) {
     try {
-      await axios.post(this.resolveEndPoint(), jsonData)
+      await axios.post(this.resolveEndPoint(), jsonData);
     } catch (e) {
-      console.log(`There was an Error sending the Message for the "${this.type}": "${this.channel.name}"`);
+      console.log(
+        `There was an Error sending the Message for the "${this.type}": "${this.channel.name}"`,
+      );
       console.log(e);
     }
   }
@@ -80,7 +86,7 @@ export class TrelloNotifier extends AbstractWebHookNotifier {
 
   // If labels env not defined return empty string
   private getTrelloLabels(): string {
-    if(TrelloNotifier.TRELLO_LABELS in process.env) { 
+    if (TrelloNotifier.TRELLO_LABELS in process.env) {
       return process.env[TrelloNotifier.TRELLO_LABELS];
     }
     return "";
@@ -88,7 +94,7 @@ export class TrelloNotifier extends AbstractWebHookNotifier {
 
   // If card pos env not defined return top
   private getTrelloPos(): string {
-    if(TrelloNotifier.TRELLO_POS in process.env) { 
+    if (TrelloNotifier.TRELLO_POS in process.env) {
       return process.env[TrelloNotifier.TRELLO_POS];
     }
     return "top";
@@ -96,7 +102,7 @@ export class TrelloNotifier extends AbstractWebHookNotifier {
 
   // Any user defined prefix to add to the card title
   private getTrelloTitlePrefix(): string {
-    if(TrelloNotifier.TRELLO_TITLE_PREFIX in process.env) { 
+    if (TrelloNotifier.TRELLO_TITLE_PREFIX in process.env) {
       return process.env[TrelloNotifier.TRELLO_TITLE_PREFIX];
     }
     return "";
@@ -104,25 +110,31 @@ export class TrelloNotifier extends AbstractWebHookNotifier {
 
   // Constructs the card name from the finding
   private getCardName(finding: Finding): string {
-    return this.getTrelloTitlePrefix() + finding.name + "(" + finding.severity + ")";
+    return (
+      this.getTrelloTitlePrefix() + finding.name + "(" + finding.severity + ")"
+    );
   }
 
   private getCardDescription(finding: Finding): string {
-
-    let res = "Scan Type: " + this.scan.spec.scanType + "\n" +
-          "Location: " + finding.location + "\n" +
-          "Description: " + finding.description + "\n";
+    let res =
+      "Scan Type: " +
+      this.scan.spec.scanType +
+      "\n" +
+      "Location: " +
+      finding.location +
+      "\n" +
+      "Description: " +
+      finding.description +
+      "\n";
 
     // Add Zap specific information if available
-    if(Object.keys(finding.attributes).length > 0) {
-      if("zap_solution" in finding.attributes)
+    if (Object.keys(finding.attributes).length > 0) {
+      if ("zap_solution" in finding.attributes)
         res += "Solution: " + finding.attributes["zap_solution"] + "\n";
-      if("zap_reference" in finding.attributes)
+      if ("zap_reference" in finding.attributes)
         res += "Reference: " + finding.attributes["zap_reference"] + "\n";
     }
 
     return res;
   }
-
-
 }

--- a/hooks/notification/hook/hook.test.ts
+++ b/hooks/notification/hook/hook.test.ts
@@ -19,17 +19,19 @@ test("Should Match for High Severity Findings", async () => {
     attributes: new Map(),
   };
 
-  const rules = [{
-    matches: {
-      anyOf: [
-        {
-          severity: "high"
-        }
-      ]
+  const rules = [
+    {
+      matches: {
+        anyOf: [
+          {
+            severity: "high",
+          },
+        ],
+      },
     },
-  }]
+  ];
   expect(matches(finding, rules)).toBeTruthy();
-})
+});
 
 test("Should Not Match for High Severity Findings", async () => {
   const finding: Finding = {
@@ -42,18 +44,19 @@ test("Should Not Match for High Severity Findings", async () => {
     attributes: new Map(),
   };
 
-  const rules = [{
-    matches: {
-      anyOf: [
-        {
-          severity: "NOT HIGH"
-        }
-      ]
+  const rules = [
+    {
+      matches: {
+        anyOf: [
+          {
+            severity: "NOT HIGH",
+          },
+        ],
+      },
     },
-  }]
+  ];
   expect(matches(finding, rules)).toBeFalsy();
-
-})
+});
 
 test("Should Match for Multiple 'anyOf' Rules", async () => {
   const finding: Finding = {
@@ -66,20 +69,22 @@ test("Should Match for Multiple 'anyOf' Rules", async () => {
     attributes: new Map(),
   };
 
-  const rules = [{
-    matches: {
-      anyOf: [
-        {
-          severity: "NOT HIGH"
-        },
-        {
-          category: "Open Port",
-        }
-      ]
+  const rules = [
+    {
+      matches: {
+        anyOf: [
+          {
+            severity: "NOT HIGH",
+          },
+          {
+            category: "Open Port",
+          },
+        ],
+      },
     },
-  }]
+  ];
   expect(matches(finding, rules)).toBeTruthy();
-})
+});
 
 test("Should NOT Match Multiple 'anyOf' Rules", async () => {
   const finding: Finding = {
@@ -92,21 +97,23 @@ test("Should NOT Match Multiple 'anyOf' Rules", async () => {
     attributes: new Map(),
   };
 
-  const rules = [{
-    matches: {
-      anyOf: [
-        {
-          severity: "NOT HIGH"
-        },
-        {
-          category: "NOT OPEN PORT"
-        }
-      ]
+  const rules = [
+    {
+      matches: {
+        anyOf: [
+          {
+            severity: "NOT HIGH",
+          },
+          {
+            category: "NOT OPEN PORT",
+          },
+        ],
+      },
     },
-  }]
+  ];
 
   expect(matches(finding, rules)).toBeFalsy();
-})
+});
 
 test("Should Match Multiple 'and' Rules", async () => {
   const finding: Finding = {
@@ -124,24 +131,24 @@ test("Should Match Multiple 'and' Rules", async () => {
       matches: {
         anyOf: [
           {
-            severity: "high"
-          }
-        ]
+            severity: "high",
+          },
+        ],
       },
     },
     {
       matches: {
         anyOf: [
           {
-            category: "Open Port"
-          }
-        ]
+            category: "Open Port",
+          },
+        ],
       },
     },
-  ]
+  ];
 
   expect(matches(finding, rules)).toBeTruthy();
-})
+});
 
 test("Should Not Match Multiple 'and' Rules", async () => {
   const finding: Finding = {
@@ -159,24 +166,24 @@ test("Should Not Match Multiple 'and' Rules", async () => {
       matches: {
         anyOf: [
           {
-            severity: "high"
-          }
-        ]
+            severity: "high",
+          },
+        ],
       },
     },
     {
       matches: {
         anyOf: [
           {
-            severity: "low"
-          }
-        ]
+            severity: "low",
+          },
+        ],
       },
     },
-  ]
+  ];
 
   expect(matches(finding, rules)).toBeFalsy();
-})
+});
 
 test("Should Match If No Rules Provided", async () => {
   const finding: Finding = {
@@ -190,26 +197,28 @@ test("Should Match If No Rules Provided", async () => {
   };
   const rules = [];
 
-  expect(matches(finding, rules)).toBeTruthy()
-})
+  expect(matches(finding, rules)).toBeTruthy();
+});
 
 test("Should Return Channels", async () => {
-  const channelFile = path.join(__dirname, "./__testfiles__/channels.yaml")
-  const channels = getNotificationChannels(channelFile) as NotificationChannel[];
+  const channelFile = path.join(__dirname, "./__testfiles__/channels.yaml");
+  const channels = getNotificationChannels(
+    channelFile,
+  ) as NotificationChannel[];
   const c: NotificationChannel = {
     name: "slack",
     type: NotifierType.SLACK,
     template: "messageCard",
     rules: [],
-    endPoint: "some.url"
-  }
+    endPoint: "some.url",
+  };
   const expected: NotificationChannel[] = [];
-  expected.push(c)
+  expected.push(c);
   expect(channels).toStrictEqual(expected);
-})
+});
 
 test("Should Map Env Name To endPoint", async () => {
-  const expectedEndPoint = 'webhook.site';
+  const expectedEndPoint = "webhook.site";
   process.env["TEST_ENDPOINT"] = expectedEndPoint;
 
   const endpoint = mapToEndPoint("TEST_ENDPOINT");

--- a/hooks/notification/hook/hook.ts
+++ b/hooks/notification/hook/hook.ts
@@ -20,16 +20,16 @@ export async function handle({ getFindings, scan }) {
 
   console.log("Starting notification hook");
   console.log(
-    "Configured notification channels: " + notificationChannels.join(", ")
+    "Configured notification channels: " + notificationChannels.join(", "),
   );
   console.log(notificationChannels);
   for (const channel of notificationChannels) {
     console.log(
-      `Starting notifier "${channel.name}" of type "${channel.type}"`
+      `Starting notifier "${channel.name}" of type "${channel.type}"`,
     );
 
     const findingsToNotify = findings.filter((finding) =>
-      matches(finding, channel.rules)
+      matches(finding, channel.rules),
     );
 
     if (
@@ -37,7 +37,7 @@ export async function handle({ getFindings, scan }) {
       findingsToNotify.length === 0
     ) {
       console.log(
-        `Skipping notifier "${channel.name}" as there are no findings to send the notification out for.`
+        `Skipping notifier "${channel.name}" as there are no findings to send the notification out for.`,
       );
       continue;
     }
@@ -46,7 +46,7 @@ export async function handle({ getFindings, scan }) {
       channel,
       scan,
       findingsToNotify,
-      args
+      args,
     );
     await notifier.sendMessage();
   }
@@ -74,7 +74,7 @@ export function getNotificationChannels(channelFile: string): any[] {
 
 function doesNotMatch(rule: any, finding: Finding): boolean {
   return !rule.matches.anyOf.some((condition: object) =>
-    isMatch(finding, condition)
+    isMatch(finding, condition),
   );
 }
 

--- a/hooks/notification/hook/model/Scan.ts
+++ b/hooks/notification/hook/model/Scan.ts
@@ -2,7 +2,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-import * as k8s from "@kubernetes/client-node"
+import * as k8s from "@kubernetes/client-node";
 
 export interface Scan {
   metadata: k8s.V1ObjectMeta;


### PR DESCRIPTION
## Description

This PR fixes a issue with notifications not beeing properly delivered to MS Teams by setting the content type for the http request send  to MS Teams.

Closes #2664

### Checklist

* [x] Test your changes as thoroughly as possible before you commit them. Preferably, automate your test by unit/integration tests.
* [x] Make sure that all your commits are signed-off and that you are added to the [Contributors](https://github.com/secureCodeBox/secureCodeBox/blob/main/CONTRIBUTORS.md) file.
* [ ] Make sure that all CI finish successfully.
* [ ] Optional (but appreciated): Make sure that all commits are [Verified](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits).
