### PR TITLE
Slight refactor of scbctl

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -57,3 +57,4 @@ Committing with `git commit -s` will add the sign-off at the end of the commit m
 - Tobias Stenby Brixen <kind.job1347@fastmail.com>
 - Eline Henriksen <mains.moon.0x@icloud.com>
 - Michael Kruggel <michael.kruggel@defenseunicorns.com>
+- Ochi Daiki <lbfdeatq@gmail.com>

--- a/scbctl/cmd/cascading.go
+++ b/scbctl/cmd/cascading.go
@@ -57,9 +57,6 @@ func buildTree(scans []v1.Scan) *gtree.Node {
 	root := gtree.NewRoot("Scans")
 
 	scanMap := make(map[string]*v1.Scan)
-	for i := range scans {
-		scanMap[scans[i].Name] = &scans[i]
-	}
 	for _, scan := range scans {
 		scanMap[scan.Name] = &scan
 	}


### PR DESCRIPTION
<!-- 
Thank you for your contribution to our Project 🙌 

Before submitting your Pull Request, please take the time to check the points below and provide some descriptive information.
* [ ] If this PR comes from a fork, please [Allow edits from maintainers](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork)
* [ ] Set a meaningful title. Format: {task_name} (closes #{issue_number}). For example: Use logger (closes #41)
* [ ] [Link your Pull Request to an issue](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) (if applicable)
* [ ] Create Draft pull requests if you need clarification or an explicit review before you can continue your work item.
* [ ] Make sure that your PR is not introducing _unnecessary_ reformatting (e.g., introduced by on-save hooks in your IDE)
* [ ] Make sure each new source file you add has a correct license header.

For more information on content related and formal acceptance criteria for PRs, please have a look at our 
[docs](https://www.securecodebox.io/docs/contributing/contribution-criteria). 
-->

## Description
<!-- Please describe briefly which issue is solved by your PR or which enhancement it brings -->

Refactor scbctl👍!
- Remove extra processing in scbctl cmd's buildTree function ( https://github.com/secureCodeBox/secureCodeBox/pull/2682/commits/80f408b86186e72d2c279542d012f01c15d12f2e )
- Replace Map to Slice ( https://github.com/secureCodeBox/secureCodeBox/pull/2682/commits/1e1ac14476f29d3b3757d27c9a1c097c320a7ae8 )
  - Golang's map does not guarantee ordering, so I changed it from a map to a slice so that the result of each execution is the same each time.
  - I think it will solve the [problem](https://github.com/secureCodeBox/secureCodeBox/pull/2665#issuecomment-2359292320).
  - The following is a log of multiple runs of go test before and after the change at local.

    Before
    ```console
    ddddddo@debian:~/github.com/ddddddO/secureCodeBox/scbctl/cmd$ go test ./... -count=1
    ok      github.com/secureCodeBox/secureCodeBox/scbctl/cmd       0.027s
    ddddddo@debian:~/github.com/ddddddO/secureCodeBox/scbctl/cmd$ go test ./... -count=1
    ok      github.com/secureCodeBox/secureCodeBox/scbctl/cmd       0.021s
    ddddddo@debian:~/github.com/ddddddO/secureCodeBox/scbctl/cmd$ go test ./... -count=1
    ok      github.com/secureCodeBox/secureCodeBox/scbctl/cmd       0.019s
    ddddddo@debian:~/github.com/ddddddO/secureCodeBox/scbctl/cmd$ go test ./... -count=1
    ok      github.com/secureCodeBox/secureCodeBox/scbctl/cmd       0.020s
    ddddddo@debian:~/github.com/ddddddO/secureCodeBox/scbctl/cmd$ go test ./... -count=1
    --- FAIL: TestBuildTree (0.00s)
        --- FAIL: TestBuildTree/Complex_cascade (0.00s)
            cascading_test.go:125: 
                    Error Trace:    /home/ddddddo/github.com/ddddddO/secureCodeBox/scbctl/cmd/cascading_test.go:125
                    Error:          Not equal: 
                                    expected: "Scans\n└── root\n    ├── child1\n    │   └── grandchild\n    └── child2\n"
                                    actual  : "Scans\n└── root\n    ├── child2\n    └── child1\n        └── grandchild\n"
                                
                                    Diff:
                                    --- Expected
                                    +++ Actual
                                    @@ -2,5 +2,5 @@
                                     └── root
                                    -    ├── child1
                                    -    │   └── grandchild
                                    -    └── child2
                                    +    ├── child2
                                    +    └── child1
                                    +        └── grandchild
                                     
                    Test:           TestBuildTree/Complex_cascade
    🆕 Creating a new scan with name 'nmap' and parameters 'scanme.nmap.org'
    🚀 Successfully created a new Scan 'nmap'
    🆕 Creating a new scan with name 'nmap' and parameters 'scanme.nmap.org -p 90'
    🚀 Successfully created a new Scan 'nmap'
    🆕 Creating a new scan with name 'scanme-nmap-org' and parameters 'scanme.nmap.org'
    🚀 Successfully created a new Scan 'scanme-nmap-org'
    🆕 Creating a new scan with name 'nmap' and parameters 'scanme.nmap.org'
    🚀 Successfully created a new Scan 'nmap'
    🆕 Creating a new scan with name 'kubeaudit' and parameters '--namespace some-other-namespace'
    🚀 Successfully created a new Scan 'kubeaudit'
    Error: you must use '--' to separate scan parameters
    Error: you must use '--' to separate scan parameters
    triggered new Scan for ScheduledScan 'nmap'
    Error: could not find ScheduledScan 'nonexistent-scan' in namespace 'foobar'
    Error: accepts 1 arg(s), received 0
    triggered new Scan for ScheduledScan 'nmap'
    FAIL
    FAIL    github.com/secureCodeBox/secureCodeBox/scbctl/cmd       0.025s
    FAIL
    ddddddo@debian:~/github.com/ddddddO/secureCodeBox/scbctl/cmd$
    ```
    
    ↓
    
    After
    ```console
    ddddddo@debian:~/github.com/ddddddO/secureCodeBox/scbctl/cmd$ go test ./... -count=1
    ok      github.com/secureCodeBox/secureCodeBox/scbctl/cmd       0.019s
    ddddddo@debian:~/github.com/ddddddO/secureCodeBox/scbctl/cmd$ go test ./... -count=1
    ok      github.com/secureCodeBox/secureCodeBox/scbctl/cmd       0.019s
    ddddddo@debian:~/github.com/ddddddO/secureCodeBox/scbctl/cmd$ go test ./... -count=1
    ok      github.com/secureCodeBox/secureCodeBox/scbctl/cmd       0.025s
    ddddddo@debian:~/github.com/ddddddO/secureCodeBox/scbctl/cmd$ go test ./... -count=1
    ok      github.com/secureCodeBox/secureCodeBox/scbctl/cmd       0.023s
    ddddddo@debian:~/github.com/ddddddO/secureCodeBox/scbctl/cmd$ go test ./... -count=1
    ok      github.com/secureCodeBox/secureCodeBox/scbctl/cmd       0.017s
    ddddddo@debian:~/github.com/ddddddO/secureCodeBox/scbctl/cmd$ go test ./... -count=1
    ok      github.com/secureCodeBox/secureCodeBox/scbctl/cmd       0.025s
    ddddddo@debian:~/github.com/ddddddO/secureCodeBox/scbctl/cmd$ go test ./... -count=1
    ok      github.com/secureCodeBox/secureCodeBox/scbctl/cmd       0.019s
    ddddddo@debian:~/github.com/ddddddO/secureCodeBox/scbctl/cmd$ go test ./... -count=1
    ok      github.com/secureCodeBox/secureCodeBox/scbctl/cmd       0.034s
    ddddddo@debian:~/github.com/ddddddO/secureCodeBox/scbctl/cmd$ go test ./... -count=1
    ok      github.com/secureCodeBox/secureCodeBox/scbctl/cmd       0.019s
    ddddddo@debian:~/github.com/ddddddO/secureCodeBox/scbctl/cmd$ go test ./... -count=1
    ok      github.com/secureCodeBox/secureCodeBox/scbctl/cmd       0.021s
    ddddddo@debian:~/github.com/ddddddO/secureCodeBox/scbctl/cmd$ go test ./... -count=1
    ok      github.com/secureCodeBox/secureCodeBox/scbctl/cmd       0.023s
    ddddddo@debian:~/github.com/ddddddO/secureCodeBox/scbctl/cmd$ go test ./... -count=1
    ok      github.com/secureCodeBox/secureCodeBox/scbctl/cmd       0.022s
    ddddddo@debian:~/github.com/ddddddO/secureCodeBox/scbctl/cmd$ go test ./... -count=1
    ok      github.com/secureCodeBox/secureCodeBox/scbctl/cmd       0.024s
    ddddddo@debian:~/github.com/ddddddO/secureCodeBox/scbctl/cmd$ go test ./... -count=1
    ok      github.com/secureCodeBox/secureCodeBox/scbctl/cmd       0.020s
    ddddddo@debian:~/github.com/ddddddO/secureCodeBox/scbctl/cmd$ go test ./... -count=1
    ok      github.com/secureCodeBox/secureCodeBox/scbctl/cmd       0.018s
    ddddddo@debian:~/github.com/ddddddO/secureCodeBox/scbctl/cmd$ go test ./... -count=1
    ok      github.com/secureCodeBox/secureCodeBox/scbctl/cmd       0.026s
    ddddddo@debian:~/github.com/ddddddO/secureCodeBox/scbctl/cmd$ go test ./... -count=1
    ok      github.com/secureCodeBox/secureCodeBox/scbctl/cmd       0.021s
    ddddddo@debian:~/github.com/ddddddO/secureCodeBox/scbctl/cmd$
    ```


### Checklist

* [x] Test your changes as thoroughly as possible before you commit them. Preferably, automate your test by unit/integration tests.

  ```console
  ddddddo@debian:~/github.com/ddddddO/secureCodeBox/scbctl/cmd$ go test ./...
  ok      github.com/secureCodeBox/secureCodeBox/scbctl/cmd       (cached)
  ddddddo@debian:~/github.com/ddddddO/secureCodeBox/scbctl/cmd$
  ```

* [x] Make sure that all your commits are signed-off and that you are added to the [Contributors](https://github.com/secureCodeBox/secureCodeBox/blob/main/CONTRIBUTORS.md) file.
* [ ] Make sure that all CI finish successfully.
* [x] Optional (but appreciated): Make sure that all commits are [Verified](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits).
