### PR TITLE
Deprecation Notice for deprecated Scanners

### DIFF
--- a/scanners/kubeaudit/.helm-docs.gotmpl
+++ b/scanners/kubeaudit/.helm-docs.gotmpl
@@ -23,6 +23,11 @@ usecase: "Kubernetes Configuration Scanner"
 
 {{- define "extra.chartAboutSection" -}}
 ## What is Kubeaudit?
+
+:::caution Deprecation Notice
+The `kubeaudit ` ScanType is being deprecated in the secureCodeBox since it will no longer be maintained as described in the [GitHub repository](kubeaudit GitHub). The scanner will be removed in the  upcoming v5 release.
+:::
+
 Kubeaudit finds security misconfigurations in you Kubernetes Resources and gives tips on how to resolve these.
 
 Kubeaudit comes with a large lists of "auditors" which test various aspects, like the SecurityContext of pods.

--- a/scanners/kubeaudit/README.md
+++ b/scanners/kubeaudit/README.md
@@ -34,6 +34,11 @@ Otherwise your changes will be reverted/overwritten automatically due to the bui
 </p>
 
 ## What is Kubeaudit?
+
+:::caution Deprecation Notice
+The `kubeaudit ` ScanType is being deprecated in the secureCodeBox since it will no longer be maintained as described in the [GitHub repository](kubeaudit GitHub). The scanner will be removed in the  upcoming v5 release.
+:::
+
 Kubeaudit finds security misconfigurations in you Kubernetes Resources and gives tips on how to resolve these.
 
 Kubeaudit comes with a large lists of "auditors" which test various aspects, like the SecurityContext of pods.

--- a/scanners/kubeaudit/docs/README.ArtifactHub.md
+++ b/scanners/kubeaudit/docs/README.ArtifactHub.md
@@ -41,6 +41,11 @@ The secureCodeBox project is running on [Kubernetes](https://kubernetes.io/). To
 You can find resources to help you get started on our [documentation website](https://www.securecodebox.io) including instruction on how to [install the secureCodeBox project](https://www.securecodebox.io/docs/getting-started/installation) and guides to help you [run your first scans](https://www.securecodebox.io/docs/getting-started/first-scans) with it.
 
 ## What is Kubeaudit?
+
+:::caution Deprecation Notice
+The `kubeaudit ` ScanType is being deprecated in the secureCodeBox since it will no longer be maintained as described in the [GitHub repository](kubeaudit GitHub). The scanner will be removed in the  upcoming v5 release.
+:::
+
 Kubeaudit finds security misconfigurations in you Kubernetes Resources and gives tips on how to resolve these.
 
 Kubeaudit comes with a large lists of "auditors" which test various aspects, like the SecurityContext of pods.

--- a/scanners/kubeaudit/docs/README.DockerHub-Parser.md
+++ b/scanners/kubeaudit/docs/README.DockerHub-Parser.md
@@ -52,6 +52,11 @@ docker pull securecodebox/parser-kubeaudit
 ```
 
 ## What is Kubeaudit?
+
+:::caution Deprecation Notice
+The `kubeaudit ` ScanType is being deprecated in the secureCodeBox since it will no longer be maintained as described in the [GitHub repository](kubeaudit GitHub). The scanner will be removed in the  upcoming v5 release.
+:::
+
 Kubeaudit finds security misconfigurations in you Kubernetes Resources and gives tips on how to resolve these.
 
 Kubeaudit comes with a large lists of "auditors" which test various aspects, like the SecurityContext of pods.

--- a/scanners/kubeaudit/docs/README.DockerHub-Scanner.md
+++ b/scanners/kubeaudit/docs/README.DockerHub-Scanner.md
@@ -52,6 +52,11 @@ docker pull securecodebox/scanner-kubeaudit
 ```
 
 ## What is Kubeaudit?
+
+:::caution Deprecation Notice
+The `kubeaudit ` ScanType is being deprecated in the secureCodeBox since it will no longer be maintained as described in the [GitHub repository](kubeaudit GitHub). The scanner will be removed in the  upcoming v5 release.
+:::
+
 Kubeaudit finds security misconfigurations in you Kubernetes Resources and gives tips on how to resolve these.
 
 Kubeaudit comes with a large lists of "auditors" which test various aspects, like the SecurityContext of pods.

--- a/scanners/ssh-scan/.helm-docs.gotmpl
+++ b/scanners/ssh-scan/.helm-docs.gotmpl
@@ -24,6 +24,10 @@ usecase: "SSH Configuration and Policy Scanner"
 {{- define "extra.chartAboutSection" -}}
 ## What is SSH_scan?
 
+:::caution Deprecation Notice
+The `ssh-scan` ScanType is being deprecated in the secureCodeBox since it will no longer be maintained as described in the [GitHub repository](ssh_scan GitHub). The 'ssh-audit' has been integrated as an alternative to the ssh-scan. The scanner will be removed in the  upcoming v5 release.
+:::
+
 SSH_scan is an easy-to-use prototype SSH configuration and policy scanner, inspired by Mozilla OpenSSH Security Guide, which provides a reasonable baseline policy recommendation for SSH configuration parameters such as Ciphers, MACs, and KexAlgos and much more.
 
 To learn more about the ssh_scan scanner itself visit [ssh_scan GitHub].

--- a/scanners/ssh-scan/README.md
+++ b/scanners/ssh-scan/README.md
@@ -35,6 +35,10 @@ Otherwise your changes will be reverted/overwritten automatically due to the bui
 
 ## What is SSH_scan?
 
+:::caution Deprecation Notice
+The `ssh-scan` ScanType is being deprecated in the secureCodeBox since it will no longer be maintained as described in the [GitHub repository](ssh_scan GitHub). The 'ssh-audit' has been integrated as an alternative to the ssh-scan. The scanner will be removed in the  upcoming v5 release.
+:::
+
 SSH_scan is an easy-to-use prototype SSH configuration and policy scanner, inspired by Mozilla OpenSSH Security Guide, which provides a reasonable baseline policy recommendation for SSH configuration parameters such as Ciphers, MACs, and KexAlgos and much more.
 
 To learn more about the ssh_scan scanner itself visit [ssh_scan GitHub].

--- a/scanners/ssh-scan/docs/README.ArtifactHub.md
+++ b/scanners/ssh-scan/docs/README.ArtifactHub.md
@@ -42,6 +42,10 @@ You can find resources to help you get started on our [documentation website](ht
 
 ## What is SSH_scan?
 
+:::caution Deprecation Notice
+The `ssh-scan` ScanType is being deprecated in the secureCodeBox since it will no longer be maintained as described in the [GitHub repository](ssh_scan GitHub). The 'ssh-audit' has been integrated as an alternative to the ssh-scan. The scanner will be removed in the  upcoming v5 release.
+:::
+
 SSH_scan is an easy-to-use prototype SSH configuration and policy scanner, inspired by Mozilla OpenSSH Security Guide, which provides a reasonable baseline policy recommendation for SSH configuration parameters such as Ciphers, MACs, and KexAlgos and much more.
 
 To learn more about the ssh_scan scanner itself visit [ssh_scan GitHub].

--- a/scanners/ssh-scan/docs/README.DockerHub-Parser.md
+++ b/scanners/ssh-scan/docs/README.DockerHub-Parser.md
@@ -53,6 +53,10 @@ docker pull securecodebox/parser-ssh-scan
 
 ## What is SSH_scan?
 
+:::caution Deprecation Notice
+The `ssh-scan` ScanType is being deprecated in the secureCodeBox since it will no longer be maintained as described in the [GitHub repository](ssh_scan GitHub). The 'ssh-audit' has been integrated as an alternative to the ssh-scan. The scanner will be removed in the  upcoming v5 release.
+:::
+
 SSH_scan is an easy-to-use prototype SSH configuration and policy scanner, inspired by Mozilla OpenSSH Security Guide, which provides a reasonable baseline policy recommendation for SSH configuration parameters such as Ciphers, MACs, and KexAlgos and much more.
 
 To learn more about the ssh_scan scanner itself visit [ssh_scan GitHub].

--- a/scanners/typo3scan/.helm-docs.gotmpl
+++ b/scanners/typo3scan/.helm-docs.gotmpl
@@ -23,6 +23,11 @@ usecase: "Automation of the process of detecting the Typo3 CMS and its installed
 
 {{- define "extra.chartAboutSection" -}}
 ## What is Typo3Scan?
+
+:::caution Deprecation Notice
+The `typo3scan` ScanType is being deprecated in the secureCodeBox since it will no longer be maintained as described in the [GitHub repository](https://github.com/whoot/Typo3Scan). The scanner will be removed in the  upcoming v5 release.
+:::
+
 Typo3Scan is an open source penetration testing tool, that automates the process of detecting the Typo3 CMS version and its installed extensions. It also has a database with known vulnerabilities for core and extensions.
 The vulnerabilities corresponding to the version detected are presented as findings.
 To learn more about the Typo3Scan scanner itself, visit the Typo3Scan GitHub repository [here](https://github.com/whoot/Typo3Scan).

--- a/scanners/typo3scan/README.md
+++ b/scanners/typo3scan/README.md
@@ -34,6 +34,11 @@ Otherwise your changes will be reverted/overwritten automatically due to the bui
 </p>
 
 ## What is Typo3Scan?
+
+:::caution Deprecation Notice
+The `typo3scan` ScanType is being deprecated in the secureCodeBox since it will no longer be maintained as described in the [GitHub repository](https://github.com/whoot/Typo3Scan). The scanner will be removed in the  upcoming v5 release.
+:::
+
 Typo3Scan is an open source penetration testing tool, that automates the process of detecting the Typo3 CMS version and its installed extensions. It also has a database with known vulnerabilities for core and extensions.
 The vulnerabilities corresponding to the version detected are presented as findings.
 To learn more about the Typo3Scan scanner itself, visit the Typo3Scan GitHub repository [here](https://github.com/whoot/Typo3Scan).

--- a/scanners/typo3scan/docs/README.ArtifactHub.md
+++ b/scanners/typo3scan/docs/README.ArtifactHub.md
@@ -41,6 +41,11 @@ The secureCodeBox project is running on [Kubernetes](https://kubernetes.io/). To
 You can find resources to help you get started on our [documentation website](https://www.securecodebox.io) including instruction on how to [install the secureCodeBox project](https://www.securecodebox.io/docs/getting-started/installation) and guides to help you [run your first scans](https://www.securecodebox.io/docs/getting-started/first-scans) with it.
 
 ## What is Typo3Scan?
+
+:::caution Deprecation Notice
+The `typo3scan` ScanType is being deprecated in the secureCodeBox since it will no longer be maintained as described in the [GitHub repository](https://github.com/whoot/Typo3Scan). The scanner will be removed in the  upcoming v5 release.
+:::
+
 Typo3Scan is an open source penetration testing tool, that automates the process of detecting the Typo3 CMS version and its installed extensions. It also has a database with known vulnerabilities for core and extensions.
 The vulnerabilities corresponding to the version detected are presented as findings.
 To learn more about the Typo3Scan scanner itself, visit the Typo3Scan GitHub repository [here](https://github.com/whoot/Typo3Scan).

--- a/scanners/typo3scan/docs/README.DockerHub-Parser.md
+++ b/scanners/typo3scan/docs/README.DockerHub-Parser.md
@@ -52,6 +52,11 @@ docker pull securecodebox/parser-typo3scan
 ```
 
 ## What is Typo3Scan?
+
+:::caution Deprecation Notice
+The `typo3scan` ScanType is being deprecated in the secureCodeBox since it will no longer be maintained as described in the [GitHub repository](https://github.com/whoot/Typo3Scan). The scanner will be removed in the  upcoming v5 release.
+:::
+
 Typo3Scan is an open source penetration testing tool, that automates the process of detecting the Typo3 CMS version and its installed extensions. It also has a database with known vulnerabilities for core and extensions.
 The vulnerabilities corresponding to the version detected are presented as findings.
 To learn more about the Typo3Scan scanner itself, visit the Typo3Scan GitHub repository [here](https://github.com/whoot/Typo3Scan).

--- a/scanners/typo3scan/docs/README.DockerHub-Scanner.md
+++ b/scanners/typo3scan/docs/README.DockerHub-Scanner.md
@@ -52,6 +52,11 @@ docker pull securecodebox/scanner-typo3scan
 ```
 
 ## What is Typo3Scan?
+
+:::caution Deprecation Notice
+The `typo3scan` ScanType is being deprecated in the secureCodeBox since it will no longer be maintained as described in the [GitHub repository](https://github.com/whoot/Typo3Scan). The scanner will be removed in the  upcoming v5 release.
+:::
+
 Typo3Scan is an open source penetration testing tool, that automates the process of detecting the Typo3 CMS version and its installed extensions. It also has a database with known vulnerabilities for core and extensions.
 The vulnerabilities corresponding to the version detected are presented as findings.
 To learn more about the Typo3Scan scanner itself, visit the Typo3Scan GitHub repository [here](https://github.com/whoot/Typo3Scan).


### PR DESCRIPTION
## Description
The scanners Typo3Scan, SSH_scan and kubeaudit are deprecated as describes in their respective repositories. Therefore, deprecation notices for each scanner have  been added to the documentation.
This closes #2676

### Checklist

* [x] Test your changes as thoroughly as possible before you commit them. Preferably, automate your test by unit/integration tests.
* [x] Make sure that all your commits are signed-off and that you are added to the [Contributors](https://github.com/secureCodeBox/secureCodeBox/blob/main/CONTRIBUTORS.md) file.
* [ ] Make sure that all CI finish successfully.
* [ ] Optional (but appreciated): Make sure that all commits are [Verified](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits).
