### PR TITLE
Move copy right stuff to sidecar file

### DIFF
--- a/.python-version
+++ b/.python-version
@@ -1,5 +1,1 @@
-# SPDX-FileCopyrightText: the secureCodeBox authors
-#
-# SPDX-License-Identifier: Apache-2.0
-
 3.9.10

--- a/.python-version.license
+++ b/.python-version.license
@@ -1,0 +1,3 @@
+SPDX-FileCopyrightText: the secureCodeBox authors
+
+SPDX-License-Identifier: Apache-2.0


### PR DESCRIPTION
Netlify was failuing with this error.

```
8:48:40 AM: Attempting Python version '3.8', read from environment
8:48:40 AM: mise ERROR error parsing config file: /opt/build/repo/.python-version
8:48:40 AM: mise ERROR invalid tool version request: SPDX-FileCopyrightText:
8:48:40 AM: mise ERROR Run with --verbose or MISE_VERBOSE=1 for more information
```