### PR TITLE
Bugfix Corrected branches keyword trigger workflow correctly

### DIFF
--- a/.github/workflows/move-bot-pr-to-review.yaml
+++ b/.github/workflows/move-bot-pr-to-review.yaml
@@ -7,13 +7,13 @@ on:
   pull_request:
     types: [opened]
     branches:
-      - 'dependabot/**'
-      - 'dependencies/upgrading**'
-
+      - main
 
 jobs:
   move-bot-pr-to-review:   
     runs-on: ubuntu-22.04
+    # only run if the branch starts with 'dependabot/' or 'dependencies/upgrading' 
+    if: startsWith(github.head_ref, 'dependabot/') || startsWith(github.head_ref, 'dependencies/upgrading')
     steps:
       - uses: actions/checkout@v4
 


### PR DESCRIPTION
## Description
Reconfigured the trigger specifications of the workflow. The head-ref of the PRs were incorrectly added to the _branches_ keyword which specifies the target branch. 


### Checklist

* [ ] Test your changes as thoroughly as possible before you commit them. Preferably, automate your test by unit/integration tests.
* [ ] Make sure that all your commits are signed-off and that you are added to the [Contributors](https://github.com/secureCodeBox/secureCodeBox/blob/main/CONTRIBUTORS.md) file.
* [ ] Make sure that all CI finish successfully.
* [ ] Optional (but appreciated): Make sure that all commits are [Verified](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits).
