### PR TITLE
Adjust release note grouper for release notes generated by the native github feature

### DIFF
--- a/bin/release-note-grouper.js
+++ b/bin/release-note-grouper.js
@@ -45,7 +45,7 @@ let upgrades = {};
 rl.on("line", (line) => {
   // Extract information from each line
   const match = line.match(
-    /\[SCB-Bot\] Upgraded (\w+) from ([\w\.]+) to ([\w\.]+) @secureCodeBoxBot \((#\d+)\)/,
+    /.*\[SCB-Bot\] Upgraded (.+) from ([\w\.]+) to ([\w\.]+) by @secureCodeBoxBot in (.*)/,
   );
   if (match) {
     const [, dependency, oldVersion, newVersion, pr] = match;


### PR DESCRIPTION


## Description

Format for the release notes has changed with the github release notes, see https://github.com/secureCodeBox/secureCodeBox/pull/2792) Script needed some adjustments to handle the new format

### Checklist

* [x] Test your changes as thoroughly as possible before you commit them. Preferably, automate your test by unit/integration tests.
* [x] Make sure that all your commits are signed-off and that you are added to the [Contributors](https://github.com/secureCodeBox/secureCodeBox/blob/main/CONTRIBUTORS.md) file.
* [ ] Make sure that all CI finish successfully.
* [ ] Optional (but appreciated): Make sure that all commits are [Verified](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits).
