### PR TITLE
Avoid run fail for dependabot PRs

### DIFF
--- a/.github/workflows/move-bot-pr-to-review.yaml
+++ b/.github/workflows/move-bot-pr-to-review.yaml
@@ -37,6 +37,8 @@ jobs:
           PR_ID: ${{ github.event.pull_request.node_id }}
 
       - name: Move PR to column To Review
+        # only move SCB-Bot, since dependabot is not part of core team and therefore has no access to secrets
+        if: startsWith(github.head_ref, 'dependencies/upgrading')
         run: |
           # Get the ID for the field Status 
           # gh project field-list 6 --owner secureCodeBox

--- a/.github/workflows/move-bot-pr-to-review.yaml
+++ b/.github/workflows/move-bot-pr-to-review.yaml
@@ -14,6 +14,10 @@ jobs:
     runs-on: ubuntu-22.04
     # only run if the branch starts with 'dependabot/' or 'dependencies/upgrading' 
     if: startsWith(github.head_ref, 'dependabot/') || startsWith(github.head_ref, 'dependencies/upgrading')
+    permissions:
+      pull-requests: write
+      repository-projects: write
+    
     steps:
       - uses: actions/checkout@v4
 
@@ -33,7 +37,7 @@ jobs:
               }
             }" | jq -r '.data.addProjectV2ItemById.item.id') >> $GITHUB_ENV
         env: 
-          GH_TOKEN: ${{ secrets.SCB_BOT_USER_TOKEN }} 
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }} 
           PR_ID: ${{ github.event.pull_request.node_id }}
 
       - name: Move PR to column To Review


### PR DESCRIPTION

## Description
Since the dependabot PR cannot access the secrets, the workflow fails when trying to move the PR to the 'To Review' column. Therefore the step for editing the column will be skipped to avoid failed runs. 

### Checklist

* [ ] Test your changes as thoroughly as possible before you commit them. Preferably, automate your test by unit/integration tests.
* [ ] Make sure that all your commits are signed-off and that you are added to the [Contributors](https://github.com/secureCodeBox/secureCodeBox/blob/main/CONTRIBUTORS.md) file.
* [ ] Make sure that all CI finish successfully.
* [ ] Optional (but appreciated): Make sure that all commits are [Verified](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits).
