### PR TITLE
Update semgrep scanner

### DIFF
--- a/documentation/docs/architecture/09_architecture_decisions/adr_0009.md
+++ b/documentation/docs/architecture/09_architecture_decisions/adr_0009.md
@@ -240,4 +240,4 @@ The possibility of using init containers adds a large number of new possible fea
 [initc]:        https://kubernetes.io/docs/concepts/workloads/pods/init-containers/
 [initcvolumes]: https://kubernetes.io/docs/tasks/configure-pod-container/configure-pod-initialization/#create-a-pod-that-has-an-init-container
 [gitleaks]:     https://www.securecodebox.io/docs/scanners/gitleaks/
-[semgrep]:      https://github.com/returntocorp/semgrep
+[semgrep]:      https://github.com/semgrep/semgrep

--- a/scanners/semgrep/.helm-docs.gotmpl
+++ b/scanners/semgrep/.helm-docs.gotmpl
@@ -14,7 +14,7 @@ appVersion: "{{ template "chart.appVersion" . }}"
 usecase: "Static Code Analysis"
 ---
 
-![Semgrep logo](https://raw.githubusercontent.com/returntocorp/semgrep-docs/main/static/img/semgrep-icon-text-horizontal.svg)
+![Semgrep logo](https://raw.githubusercontent.com/semgrep/semgrep-docs/main/static/img/semgrep-icon-text-horizontal.svg)
 
 {{- end }}
 

--- a/scanners/semgrep/Chart.yaml
+++ b/scanners/semgrep/Chart.yaml
@@ -22,7 +22,7 @@ version: "v3.1.0-alpha1"
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "1.95.0"
+appVersion: "1.101.0"
 annotations:
   versionApi: https://api.github.com/repos/returntocorp/semgrep/releases/latest
   supported-platforms: linux/amd64

--- a/scanners/semgrep/Chart.yaml
+++ b/scanners/semgrep/Chart.yaml
@@ -24,7 +24,7 @@ version: "v3.1.0-alpha1"
 # It is recommended to use it with quotes.
 appVersion: "1.101.0"
 annotations:
-  versionApi: https://api.github.com/repos/returntocorp/semgrep/releases/latest
+  versionApi: https://api.github.com/repos/semgrep/semgrep/releases/latest
   supported-platforms: linux/amd64
 kubeVersion: ">=v1.11.0-0"
 home: https://www.securecodebox.io/docs/scanners/semgrep

--- a/scanners/semgrep/README.md
+++ b/scanners/semgrep/README.md
@@ -7,7 +7,7 @@ appVersion: "1.95.0"
 usecase: "Static Code Analysis"
 ---
 
-![Semgrep logo](https://raw.githubusercontent.com/returntocorp/semgrep-docs/main/static/img/semgrep-icon-text-horizontal.svg)
+![Semgrep logo](https://raw.githubusercontent.com/semgrep/semgrep-docs/main/static/img/semgrep-icon-text-horizontal.svg)
 
 <!--
 SPDX-FileCopyrightText: the secureCodeBox authors
@@ -192,7 +192,7 @@ Kubernetes: `>=v1.11.0-0`
 | scanner.extraVolumeMounts | list | `[]` | Optional VolumeMounts mapped into each scanJob (see: https://kubernetes.io/docs/concepts/storage/volumes/) |
 | scanner.extraVolumes | list | `[]` | Optional Volumes mapped into each scanJob (see: https://kubernetes.io/docs/concepts/storage/volumes/) |
 | scanner.image.pullPolicy | string | `"IfNotPresent"` | Image pull policy. One of Always, Never, IfNotPresent. Defaults to Always if :latest tag is specified, or IfNotPresent otherwise. More info: https://kubernetes.io/docs/concepts/containers/images#updating-images |
-| scanner.image.repository | string | `"docker.io/returntocorp/semgrep"` | Container Image to run the scan |
+| scanner.image.repository | string | `"docker.io/semgrep/semgrep"` | Container Image to run the scan |
 | scanner.image.tag | string | `nil` | defaults to the charts appVersion |
 | scanner.nodeSelector | object | `{}` | Optional nodeSelector settings that control how the scanner job is scheduled (see: https://kubernetes.io/docs/tasks/configure-pod-container/assign-pods-nodes/) |
 | scanner.podSecurityContext | object | `{}` | Optional securityContext set on scanner pod (see: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/) |

--- a/scanners/semgrep/docs/README.ArtifactHub.md
+++ b/scanners/semgrep/docs/README.ArtifactHub.md
@@ -197,7 +197,7 @@ Kubernetes: `>=v1.11.0-0`
 | scanner.extraVolumeMounts | list | `[]` | Optional VolumeMounts mapped into each scanJob (see: https://kubernetes.io/docs/concepts/storage/volumes/) |
 | scanner.extraVolumes | list | `[]` | Optional Volumes mapped into each scanJob (see: https://kubernetes.io/docs/concepts/storage/volumes/) |
 | scanner.image.pullPolicy | string | `"IfNotPresent"` | Image pull policy. One of Always, Never, IfNotPresent. Defaults to Always if :latest tag is specified, or IfNotPresent otherwise. More info: https://kubernetes.io/docs/concepts/containers/images#updating-images |
-| scanner.image.repository | string | `"docker.io/returntocorp/semgrep"` | Container Image to run the scan |
+| scanner.image.repository | string | `"docker.io/semgrep/semgrep"` | Container Image to run the scan |
 | scanner.image.tag | string | `nil` | defaults to the charts appVersion |
 | scanner.nodeSelector | object | `{}` | Optional nodeSelector settings that control how the scanner job is scheduled (see: https://kubernetes.io/docs/tasks/configure-pod-container/assign-pods-nodes/) |
 | scanner.podSecurityContext | object | `{}` | Optional securityContext set on scanner pod (see: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/) |

--- a/scanners/semgrep/integration-tests/semgrep.test.js
+++ b/scanners/semgrep/integration-tests/semgrep.test.js
@@ -15,19 +15,23 @@ test(
       [
         "-c",
         "r/python.django.security.injection.command.command-injection-os-system.command-injection-os-system",
-        "/test/",
+        "/test-semgrep/",
       ],
       90,
       // volumes
-      [{
-          "name": "test-dir",
-          "configMap": {"name": "semgrep-test-file"}
-      }],
+      [
+        {
+          name: "test-dir",
+          configMap: { name: "semgrep-test-file" },
+        },
+      ],
       // volumeMounts
-      [{
-          "mountPath": "/test/",
-          "name": "test-dir"
-      }],
+      [
+        {
+          mountPath: "/test-semgrep/",
+          name: "test-dir",
+        },
+      ],
     );
 
     expect(count).toBe(3);

--- a/scanners/semgrep/tests/__snapshot__/scanner_test.yaml.snap
+++ b/scanners/semgrep/tests/__snapshot__/scanner_test.yaml.snap
@@ -47,7 +47,7 @@ matches the snapshot:
                   env:
                     - name: foo
                       value: bar
-                  image: docker.io/returntocorp/semgrep:0.0.0
+                  image: docker.io/semgrep/semgrep:0.0.0
                   imagePullPolicy: IfNotPresent
                   name: semgrep
                   resources:

--- a/scanners/semgrep/values.yaml
+++ b/scanners/semgrep/values.yaml
@@ -37,7 +37,7 @@ parser:
 scanner:
   image:
     # scanner.image.repository -- Container Image to run the scan
-    repository: docker.io/returntocorp/semgrep
+    repository: docker.io/semgrep/semgrep
     # scanner.image.tag -- defaults to the charts appVersion
     tag: null
     # -- Image pull policy. One of Always, Never, IfNotPresent. Defaults to Always if :latest tag is specified, or IfNotPresent otherwise. More info: https://kubernetes.io/docs/concepts/containers/images#updating-images


### PR DESCRIPTION

## Description
Updates the semgrep scanner and adjusts integration test. Since version v1.96.0 the directory name test/ is ignored by the scanner. Changing the directory name in the integration test resolves this issue. 
Semgrep changed its repository name from returntocorp/semgrep to semgrep/semgrep, therefore the references to the old repository are updated as well. 

### Checklist

* [x] Test your changes as thoroughly as possible before you commit them. Preferably, automate your test by unit/integration tests.
* [x] Make sure that all your commits are signed-off and that you are added to the [Contributors](https://github.com/secureCodeBox/secureCodeBox/blob/main/CONTRIBUTORS.md) file.
* [x] Make sure that all CI finish successfully.
* [x] Optional (but appreciated): Make sure that all commits are [Verified](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits).
