### PR TITLE
Correct inocorrect image link in cascading hook docs

### DIFF
--- a/hooks/cascading-scans/.helm-docs.gotmpl
+++ b/hooks/cascading-scans/.helm-docs.gotmpl
@@ -26,7 +26,7 @@ usecase: "Cascading Scans based declarative Rules."
 The Cascading Scans Hook can be used to start additional scans based on the results of other scans.
 This allows you to create powerful setups to automatically discover targets, and then trigger more specialized scans for the type of target that was discovered.
 
-![Diagram of CascadingScans showing one amass scans for example.com finding two subdomains. These then trigger a port scan each. An identified ssh port then gets a SSH Scan and a Ncrack scan triggered. A https port gets a sslyze and a nuclei scan triggered.](https://www.securecodebox.io/static/img/cascades.drawio.svg)
+![Diagram of CascadingScans showing one amass scans for example.com finding two subdomains. These then trigger a port scan each. An identified ssh port then gets a SSH Scan and a Ncrack scan triggered. A https port gets a sslyze and a nuclei scan triggered.](https://www.securecodebox.io/img/cascades.drawio.svg)
 
 The so called `CascadingRules` consist of a `matches` section which contains one or multiple rules which are compared against `findings`.
 When a `finding` matches a `rule` the `scanSpec` section will then be used to create a new scan.

--- a/hooks/cascading-scans/README.md
+++ b/hooks/cascading-scans/README.md
@@ -37,7 +37,7 @@ Otherwise your changes will be reverted/overwritten automatically due to the bui
 The Cascading Scans Hook can be used to start additional scans based on the results of other scans.
 This allows you to create powerful setups to automatically discover targets, and then trigger more specialized scans for the type of target that was discovered.
 
-![Diagram of CascadingScans showing one amass scans for example.com finding two subdomains. These then trigger a port scan each. An identified ssh port then gets a SSH Scan and a Ncrack scan triggered. A https port gets a sslyze and a nuclei scan triggered.](https://www.securecodebox.io/static/img/cascades.drawio.svg)
+![Diagram of CascadingScans showing one amass scans for example.com finding two subdomains. These then trigger a port scan each. An identified ssh port then gets a SSH Scan and a Ncrack scan triggered. A https port gets a sslyze and a nuclei scan triggered.](https://www.securecodebox.io/img/cascades.drawio.svg)
 
 The so called `CascadingRules` consist of a `matches` section which contains one or multiple rules which are compared against `findings`.
 When a `finding` matches a `rule` the `scanSpec` section will then be used to create a new scan.

--- a/hooks/cascading-scans/docs/README.ArtifactHub.md
+++ b/hooks/cascading-scans/docs/README.ArtifactHub.md
@@ -45,7 +45,7 @@ You can find resources to help you get started on our [documentation website](ht
 The Cascading Scans Hook can be used to start additional scans based on the results of other scans.
 This allows you to create powerful setups to automatically discover targets, and then trigger more specialized scans for the type of target that was discovered.
 
-![Diagram of CascadingScans showing one amass scans for example.com finding two subdomains. These then trigger a port scan each. An identified ssh port then gets a SSH Scan and a Ncrack scan triggered. A https port gets a sslyze and a nuclei scan triggered.](https://www.securecodebox.io/static/img/cascades.drawio.svg)
+![Diagram of CascadingScans showing one amass scans for example.com finding two subdomains. These then trigger a port scan each. An identified ssh port then gets a SSH Scan and a Ncrack scan triggered. A https port gets a sslyze and a nuclei scan triggered.](https://www.securecodebox.io/img/cascades.drawio.svg)
 
 The so called `CascadingRules` consist of a `matches` section which contains one or multiple rules which are compared against `findings`.
 When a `finding` matches a `rule` the `scanSpec` section will then be used to create a new scan.

--- a/hooks/cascading-scans/docs/README.DockerHub-Hook.md
+++ b/hooks/cascading-scans/docs/README.DockerHub-Hook.md
@@ -56,7 +56,7 @@ docker pull securecodebox/hook-cascading-scans
 The Cascading Scans Hook can be used to start additional scans based on the results of other scans.
 This allows you to create powerful setups to automatically discover targets, and then trigger more specialized scans for the type of target that was discovered.
 
-![Diagram of CascadingScans showing one amass scans for example.com finding two subdomains. These then trigger a port scan each. An identified ssh port then gets a SSH Scan and a Ncrack scan triggered. A https port gets a sslyze and a nuclei scan triggered.](https://www.securecodebox.io/static/img/cascades.drawio.svg)
+![Diagram of CascadingScans showing one amass scans for example.com finding two subdomains. These then trigger a port scan each. An identified ssh port then gets a SSH Scan and a Ncrack scan triggered. A https port gets a sslyze and a nuclei scan triggered.](https://www.securecodebox.io/img/cascades.drawio.svg)
 
 The so called `CascadingRules` consist of a `matches` section which contains one or multiple rules which are compared against `findings`.
 When a `finding` matches a `rule` the `scanSpec` section will then be used to create a new scan.


### PR DESCRIPTION
## Description

Added that image recently, unfortunatly got the path it would be available under wrong.
This should fix it

### Checklist

* [x] Test your changes as thoroughly as possible before you commit them. Preferably, automate your test by unit/integration tests.
* [x] Make sure that all your commits are signed-off and that you are added to the [Contributors](https://github.com/secureCodeBox/secureCodeBox/blob/main/CONTRIBUTORS.md) file.
* [ ] Make sure that all CI finish successfully.
* [ ] Optional (but appreciated): Make sure that all commits are [Verified](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits).
