### PR TITLE
#2680 Grant delete permissions for scheduled scans in auto-discovery

### DIFF
--- a/auto-discovery/kubernetes/.helmignore
+++ b/auto-discovery/kubernetes/.helmignore
@@ -16,3 +16,6 @@ Makefile
 PROJECT
 auto-discovery-config.yaml
 ./tests/
+docs/
+auto-discovery-kubernetes.tar
+pull-secret-extractor/

--- a/auto-discovery/kubernetes/controllers/container_scan_controller.go
+++ b/auto-discovery/kubernetes/controllers/container_scan_controller.go
@@ -47,7 +47,7 @@ type ContainerAutoDiscoveryTemplateArgs struct {
 }
 
 // +kubebuilder:rbac:groups="execution.securecodebox.io",resources=scantypes,verbs=get;list;watch
-// +kubebuilder:rbac:groups="execution.securecodebox.io",resources=scheduledscans,verbs=get;list;watch;create;update;patch
+// +kubebuilder:rbac:groups="execution.securecodebox.io",resources=scheduledscans,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups="execution.securecodebox.io/status",resources=scheduledscans,verbs=get;update;patch
 // +kubebuilder:rbac:groups="",resources=services,verbs=get;list;watch
 // +kubebuilder:rbac:groups="",resources=services/status,verbs=get

--- a/auto-discovery/kubernetes/controllers/container_scan_controller.go
+++ b/auto-discovery/kubernetes/controllers/container_scan_controller.go
@@ -427,7 +427,11 @@ func (r *ContainerScanReconciler) getOrphanedScanImageIDs(ctx context.Context, p
 			var scan executionv1.ScheduledScan
 			err := r.Client.Get(ctx, types.NamespacedName{Name: scanName, Namespace: pod.Namespace}, &scan)
 			if err != nil {
-				r.Log.Error(err, "Unable to fetch scan", "name", scanName)
+				if k8sErrors.IsNotFound(err) {
+					r.Log.Info("Scan was already deleted, nothing to do", "name", scanName)
+				} else {
+					r.Log.Error(err, "Unable to fetch scan", "name", scanName)
+				}
 			} else if !r.containerIDInUse(ctx, pod, imageID) {
 				result[cleanedImageID] = append(result[cleanedImageID], scanConfig)
 			}

--- a/auto-discovery/kubernetes/controllers/service_scan_controller.go
+++ b/auto-discovery/kubernetes/controllers/service_scan_controller.go
@@ -48,7 +48,7 @@ type ServiceAutoDiscoveryTemplateArgs struct {
 const requeueInterval = 5 * time.Second
 
 // +kubebuilder:rbac:groups="execution.securecodebox.io",resources=scantypes,verbs=get;list;watch
-// +kubebuilder:rbac:groups="execution.securecodebox.io",resources=scheduledscans,verbs=get;list;watch;create;update;patch
+// +kubebuilder:rbac:groups="execution.securecodebox.io",resources=scheduledscans,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups="execution.securecodebox.io/status",resources=scheduledscans,verbs=get;update;patch
 // +kubebuilder:rbac:groups="",resources=services,verbs=get;list;watch
 // +kubebuilder:rbac:groups="",resources=services/status,verbs=get

--- a/auto-discovery/kubernetes/templates/rbac/role.yaml
+++ b/auto-discovery/kubernetes/templates/rbac/role.yaml
@@ -64,6 +64,7 @@ rules:
   - scheduledscans
   verbs:
   - create
+  - delete
   - get
   - list
   - patch

--- a/auto-discovery/kubernetes/tests/__snapshot__/auto-discovery_test.yaml.snap
+++ b/auto-discovery/kubernetes/tests/__snapshot__/auto-discovery_test.yaml.snap
@@ -263,6 +263,7 @@ matches the snapshot:
           - scheduledscans
         verbs:
           - create
+          - delete
           - get
           - list
           - patch


### PR DESCRIPTION
Add missing delete permissions for ScheduledScans in auto-discovery. Update `.helmignore` to exclude unused files, reducing Helm container size for local deployments.

<!-- 
Thank you for your contribution to our Project 🙌 

Before submitting your Pull Request, please take the time to check the points below and provide some descriptive information.
* [ ] If this PR comes from a fork, please [Allow edits from maintainers](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork)
* [ ] Set a meaningful title. Format: {task_name} (closes #{issue_number}). For example: Use logger (closes #41)
* [ ] [Link your Pull Request to an issue](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) (if applicable)
* [ ] Create Draft pull requests if you need clarification or an explicit review before you can continue your work item.
* [ ] Make sure that your PR is not introducing _unnecessary_ reformatting (e.g., introduced by on-save hooks in your IDE)
* [ ] Make sure each new source file you add has a correct license header.

For more information on content related and formal acceptance criteria for PRs, please have a look at our 
[docs](https://www.securecodebox.io/docs/contributing/contribution-criteria). 
-->

## Description
<!-- Please describe briefly which issue is solved by your PR or which enhancement it brings -->


### Checklist

* [x] Test your changes as thoroughly as possible before you commit them. Preferably, automate your test by unit/integration tests.
* [x] Make sure that all your commits are signed-off and that you are added to the [Contributors](https://github.com/secureCodeBox/secureCodeBox/blob/main/CONTRIBUTORS.md) file.
* [ ] Make sure that all CI finish successfully.
* [x] Optional (but appreciated): Make sure that all commits are [Verified](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits).
