### PR TITLE
Fix http-webhook chart

### DIFF
--- a/demo-targets/http-webhook/templates/deployment.yaml
+++ b/demo-targets/http-webhook/templates/deployment.yaml
@@ -47,7 +47,7 @@ spec:
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           ports:
             - name: http
-              containerPort: 80
+              containerPort: 8080
               protocol: TCP
           resources:
             {{- toYaml .Values.resources | nindent 12 }}

--- a/demo-targets/http-webhook/templates/ingress.yaml
+++ b/demo-targets/http-webhook/templates/ingress.yaml
@@ -2,7 +2,7 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-{{- if .Values.ingress.enabled -}}
+{{ if .Values.ingress.enabled -}}
 {{- $fullName := include "http-webhook.fullname" . -}}
 {{- $svcPort := .Values.service.port -}}
 apiVersion: networking.k8s.io/v1

--- a/demo-targets/http-webhook/templates/ingress.yaml
+++ b/demo-targets/http-webhook/templates/ingress.yaml
@@ -5,11 +5,7 @@
 {{- if .Values.ingress.enabled -}}
 {{- $fullName := include "http-webhook.fullname" . -}}
 {{- $svcPort := .Values.service.port -}}
-{{- if semverCompare ">=1.14-0" .Capabilities.KubeVersion.GitVersion -}}
-apiVersion: networking.k8s.io/v1beta1
-{{- else -}}
-apiVersion: extensions/v1beta1
-{{- end }}
+apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   name: {{ $fullName }}
@@ -37,9 +33,12 @@ spec:
         paths:
           {{- range .paths }}
           - path: {{ . }}
+            pathType: Prefix
             backend:
-              serviceName: {{ $fullName }}
-              servicePort: {{ $svcPort }}
+              service:
+                name: {{ $fullName }}
+                port:
+                  name: http
           {{- end }}
     {{- end }}
   {{- end }}

--- a/demo-targets/http-webhook/tests/__snapshot__/http-webhook_test.yaml.snap
+++ b/demo-targets/http-webhook/tests/__snapshot__/http-webhook_test.yaml.snap
@@ -44,7 +44,7 @@ matches the snapshot:
               imagePullPolicy: IfNotPresent
               name: http-webhook
               ports:
-                - containerPort: 80
+                - containerPort: 8080
                   name: http
                   protocol: TCP
               resources:
@@ -93,6 +93,7 @@ matches the snapshot:
         kind: Deployment
         name: bar
   4: |
+    apiVersion: networking.k8s.io/v1
     kind: Ingress
     metadata:
       annotations:


### PR DESCRIPTION
## Description
Fixes the helm chart for "http-webhook". It's removing support for older Kubernetes versions (pre 1.22) ruthlessly but supporting those would bloat the template and feels unnecessary.


### Checklist

* [x] Test your changes as thoroughly as possible before you commit them. Preferably, automate your test by unit/integration tests.
* [x] Make sure that all your commits are signed-off and that you are added to the [Contributors](https://github.com/secureCodeBox/secureCodeBox/blob/main/CONTRIBUTORS.md) file.
* [ ] Make sure that all CI finish successfully.
* [ ] Optional (but appreciated): Make sure that all commits are [Verified](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits).
