### PR TITLE
Add ARM support for SSH-Audit and SSLyze

### DIFF
--- a/scanners/semgrep/Chart.yaml
+++ b/scanners/semgrep/Chart.yaml
@@ -25,7 +25,7 @@ version: "v3.1.0-alpha1"
 appVersion: "1.106.0"
 annotations:
   versionApi: https://api.github.com/repos/semgrep/semgrep/releases/latest
-  supported-platforms: linux/amd64
+  supported-platforms: linux/amd64,linux/arm64
 kubeVersion: ">=v1.11.0-0"
 home: https://www.securecodebox.io/docs/scanners/semgrep
 icon: https://www.securecodebox.io/img/integrationIcons/semgrep.svg # TODO: Add this

--- a/scanners/ssh-audit/Chart.yaml
+++ b/scanners/ssh-audit/Chart.yaml
@@ -12,7 +12,7 @@ kubeVersion: ">=v1.11.0-0"
 annotations:
   versionApi: https://api.github.com/repos/jtesta/ssh-audit/releases/latest
   # supported cpu architectures for which docker images for the scanner should be build
-  supported-platforms: linux/amd64
+  supported-platforms: linux/amd64,linux/arm64
 keywords:
   - security
   - ssh

--- a/scanners/sslyze/Chart.yaml
+++ b/scanners/sslyze/Chart.yaml
@@ -12,7 +12,7 @@ appVersion: "6.1.0"
 kubeVersion: ">=v1.11.0-0"
 annotations:
   versionApi: https://api.github.com/repos/nabla-c0d3/sslyze/releases/latest
-  supported-platforms: linux/amd64
+  supported-platforms: linux/amd64,linux/arm64
 keywords:
   - security
   - ssl

--- a/scanners/sslyze/scanner/Dockerfile
+++ b/scanners/sslyze/scanner/Dockerfile
@@ -3,15 +3,9 @@
 # SPDX-License-Identifier: Apache-2.0
 
 ARG scannerVersion
-
 FROM nablac0d3/sslyze:$scannerVersion
-
 COPY wrapper.sh /wrapper.sh
-
 USER root
-
 RUN mkdir /home/securecodebox/
-
 USER sslyze
-
 ENTRYPOINT [ "sh", "/wrapper.sh" ]


### PR DESCRIPTION
## Description

- SSH-Audit and SSLyze we maintain custom scanner docker containers for, their upstream images we pull have support for ARM cpus, but we had ours only build for amd64 so far.
- Semgrep we don't have a custom image, so this already works, the docs are just outdated / wrong.

### Checklist

* [x] Test your changes as thoroughly as possible before you commit them. Preferably, automate your test by unit/integration tests.
* [x] Make sure that all your commits are signed-off and that you are added to the [Contributors](https://github.com/secureCodeBox/secureCodeBox/blob/main/CONTRIBUTORS.md) file.
* [ ] Make sure that all CI finish successfully.
* [ ] Optional (but appreciated): Make sure that all commits are [Verified](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits).
