### PR TITLE
Fixed Operator (Closes Issue #2895)

### DIFF
--- a/operator/values.yaml
+++ b/operator/values.yaml
@@ -87,6 +87,9 @@ minio:
   auth:
     rootUser: "admin" # placeholder user
     rootPassword: "password" # placeholder password
+  image:
+    repository: "bitnami/minio"
+    tag: "RELEASE.2024-02-15T00-21-19Z"  # Set the correct image version
 
 # Config for external s3 systems
 s3:


### PR DESCRIPTION
fix(operator): Set MinIO image to a fixed stable version. 
This PR closes issue #2895
The issue was caused by SecureCodeBox using the latest MinIO image tag, leading to unstable deployments due to uncontrolled updates. This PR ensures stability by locking MinIO to a fixed version (RELEASE.2024-02-15T00-21-19Z) in values.yaml.
🛠️ How We Solved It
✅ Updated values.yaml to explicitly define the MinIO image.

✅ Verified with Helm Debugging:
Used helm template --debug . to confirm MinIO now pulls the fixed version.
Ran helm lint to check for configuration errors (none found).
