### PR TITLE
Fix Invalid ARM Image for DefectDojo hook

### DIFF
--- a/hooks/persistence-defectdojo/hook/Dockerfile
+++ b/hooks/persistence-defectdojo/hook/Dockerfile
@@ -7,7 +7,7 @@ COPY . /home/gradle/src
 WORKDIR /home/gradle/src
 RUN ./gradlew build -x test
 
-FROM gcr.io/distroless/java17:nonroot
+FROM gcr.io/distroless/java17-debian12:nonroot
 COPY --from=build --chown=nonroot:nonroot /home/gradle/src/build/libs/defectdojo-persistenceprovider-*.jar /app/defectdojo-persistenceprovider.jar
 WORKDIR /app
 # TLS Config works around an issue in OpenJDK... See: https://github.com/kubernetes-client/java/issues/854


### PR DESCRIPTION
## Description

Somehow the distroless upstream image without the pinned debian version only has a amd64 variant

the debian 12 one has multi platform support

Not sure if this was always the case or was broken at some point

### Checklist

* [x] Test your changes as thoroughly as possible before you commit them. Preferably, automate your test by unit/integration tests.
* [x] Make sure that all your commits are signed-off and that you are added to the [Contributors](https://github.com/secureCodeBox/secureCodeBox/blob/main/CONTRIBUTORS.md) file.
* [ ] Make sure that all CI finish successfully.
* [ ] Optional (but appreciated): Make sure that all commits are [Verified](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits).
