### PR TITLE
Backport "Add YT Presentation of scbctl From Thibaut Batale" to 4.x

### DIFF
--- a/documentation/docs/12-mentions.md
+++ b/documentation/docs/12-mentions.md
@@ -26,8 +26,9 @@ Here we collect blog posts, articles, talks about etc. _secureCodeBox_. They are
 
 ## Random Stuff
 
-- [Interview with RadioTux on YouTube][radiotux-youtube] 🇩🇪 ([Podcast Episode][radiotux-podcast])
+- [Interview with RadioTux on YouTube][radiotux-youtube] 🇩🇪 ([Podcast Episode][radiotux-podcast]).
 - [35 DevSecOps Tools to Add Sec to Your DevOps][thechief.io] 🇬🇧.
+- [Enhanced secureCodeBox CLI Tool](https://www.youtube.com/watch?v=OTkYM9UYcJc) 🇬🇧 by our GDoC student 2024 [Thibaut Batale](https://www.linkedin.com/in/magnim-thibaut-batale-905843208/).
 
 [theowni-post]:     https://itnext.io/exploring-securecodebox-an-open-source-continuous-security-testing-solution-for-devsecops-b233fc5341e1
 [theowni-author]:   https://medium.com/@theowni


### PR DESCRIPTION
Since we've pinned documentation on 4.x branch, I backported this commit.