### PR TITLE
Speed up parser execution time by up to 2x & reduce cpu load by up to 5x by bundling parser-sdk

### DIFF
--- a/parser-sdk/nodejs/.gitignore
+++ b/parser-sdk/nodejs/.gitignore
@@ -3,3 +3,4 @@
 # SPDX-License-Identifier: Apache-2.0
 
 node_modules/
+build/

--- a/parser-sdk/nodejs/Dockerfile
+++ b/parser-sdk/nodejs/Dockerfile
@@ -2,19 +2,19 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-FROM node:22-alpine AS build
-WORKDIR /home/app
+FROM oven/bun:1.2 AS build
+WORKDIR /home/app/
 COPY package.json package-lock.json ./
-RUN npm ci --omit=dev
+RUN bun install
+COPY *.js ./
+RUN bun run build
 
 FROM node:22-alpine
 ARG NODE_ENV
 RUN addgroup --system --gid 1001 app && adduser app --system --uid 1001 --ingroup app
 WORKDIR /home/app/parser-wrapper/
-COPY --from=build --chown=root:root --chmod=755 /home/app/node_modules/ ./node_modules/
-COPY --chown=root:root --chmod=755 ./parser-wrapper.js ./parser-wrapper.js
-COPY --chown=root:root --chmod=755 ./parser-utils.js ./parser-utils.js
+COPY --from=build --chown=root:root --chmod=755 /home/app/build/ ./
 COPY --chown=root:root --chmod=755 ./findings-schema.json ./findings-schema.json
 USER 1001
 ENV NODE_ENV=${NODE_ENV:-production}
-ENTRYPOINT ["node", "/home/app/parser-wrapper/parser-wrapper.js"]
+ENTRYPOINT ["node", "--enable-source-maps", "/home/app/parser-wrapper/parser-wrapper.js"]

--- a/parser-sdk/nodejs/package-lock.json
+++ b/parser-sdk/nodejs/package-lock.json
@@ -14,7 +14,8 @@
         "ajv-draft-04": "^1.0.0",
         "ajv-formats": "^3.0.1",
         "jsonpointer": "^5.0.1"
-      }
+      },
+      "devDependencies": {}
     },
     "node_modules/@jsep-plugin/assignment": {
       "version": "1.3.0",

--- a/parser-sdk/nodejs/package.json
+++ b/parser-sdk/nodejs/package.json
@@ -7,11 +7,15 @@
   "keywords": [],
   "author": "iteratec GmbH",
   "license": "Apache-2.0",
+  "scripts": {
+    "build": "bun build --production --target=node --outdir=build/ --external=./parser/parser.js --sourcemap=external --minify ./parser-wrapper.js"
+  },
   "dependencies": {
     "@kubernetes/client-node": "^1.3.0",
     "ajv": "^8.17.1",
     "ajv-draft-04": "^1.0.0",
     "ajv-formats": "^3.0.1",
     "jsonpointer": "^5.0.1"
-  }
+  },
+  "devDependencies": {}
 }


### PR DESCRIPTION
## Description

Using bun here over esbuild as bun generates correct esm code which works. esbuild right now outputs a weird mixture bundles which fails with cryptic "stream cannot be required dynamically" node error messages.

The performance speedup here is quit substantial:
(tester using hyperfine with a mocked out parser (always returning emtpy results), result files are fetched from a github gist and pushed to some webhook testing site.

e.g.

```sh
hyperfine --runs 25 -i 'SCAN_NAME=nmap NAMESPACE=default node --enable-source-maps parser-wrapper.js https://gist.githubusercontent.com/J12934/6440478a5005dafdf52c1236c859eed0/raw/bc212dffbdaaf03cdf119b60b0c5211533677b36/scanme-nmap-org.xml hyperfine --runs 25 -i 'SCAN_NAME=nmap NAMESPACE=default node --enable-source-maps parser-wrapper.js https://gist.githubusercontent.com/J12934/6440478a5005dafdf52c1236c859eed0/raw/bc212dffbdaaf03cdf119b60b0c5211533677b36/scanme-nmap-org.xml https://webhook.site/...
```

Results:

Regular:
```
  Time (mean ± σ):     467.0 ms ±  47.2 ms    [User: 443.8 ms, System: 97.7 ms]
  Range (min … max):   443.2 ms … 692.0 ms    25 runs
```
Bundled:
```
  Time (mean ± σ):     246.0 ms ±  16.3 ms    [User: 176.6 ms, System: 16.9 ms]
  Range (min … max):   232.7 ms … 319.7 ms    25 runs
```

So total runtime dropped from 467ms to 232ms, but even more significant system time dropped from ~100ms to ~20ms. So it should require a lot less cpu cycles and resources to execute 🥳

### Checklist

* [x] Test your changes as thoroughly as possible before you commit them. Preferably, automate your test by unit/integration tests.
* [x] Make sure that all your commits are signed-off and that you are added to the [Contributors](https://github.com/secureCodeBox/secureCodeBox/blob/main/CONTRIBUTORS.md) file.
* [ ] Make sure that all CI finish successfully.
* [x] Optional (but appreciated): Make sure that all commits are [Verified](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits).
