### PR TITLE
Fix Github Release Trigger

### DIFF
--- a/.github/workflows/release-build.yaml
+++ b/.github/workflows/release-build.yaml
@@ -8,7 +8,7 @@
 name: "Release Build"
 on:
   release:
-    types: [released, prereleased]
+    types: [published]
 
 env:
   # ---- Docker Namespace ----


### PR DESCRIPTION
v5.0.0-rc.1 didn't propery trigger the release build pipeline.
Created it froma. draft release created beforehand.

Docs say:

>  The prereleased type will not trigger for pre-releases published from draft releases, but the published type will trigger. If you want a workflow to run when stable and pre-releases publish, subscribe to published instead of released and prereleased.

I don't think this was always a problem, we've used to always release from draft releases when we were still using the release drafter app for changelog generation.

I've now switched it to the same trigger as the helm chart release actions were using which were triggered successfully.

### Checklist

* [x] Test your changes as thoroughly as possible before you commit them. Preferably, automate your test by unit/integration tests.
* [x] Make sure that all your commits are signed-off and that you are added to the [Contributors](https://github.com/secureCodeBox/secureCodeBox/blob/main/CONTRIBUTORS.md) file.
* [ ] Make sure that all CI finish successfully.
* [x] Optional (but appreciated): Make sure that all commits are [Verified](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits).
