### PR TITLE
Correct duplicated hostname reference in CascadingHook docs

### DIFF
--- a/documentation/docs/api/crds/cascading-rule.md
+++ b/documentation/docs/api/crds/cascading-rule.md
@@ -44,7 +44,7 @@ For convenience a helper object has been added to the mustache call under the `$
 
 This helper object has the following attributes:
 
-- `$.hostOrIP` returns either the hostname (if available) or the hostname of the current finding.
+- `$.hostOrIP` returns either the hostname (if available) or the ip address of the current finding.
 
 ## Example
 


### PR DESCRIPTION
## Description

Minior docs fix.


### Checklist

* [x] Test your changes as thoroughly as possible before you commit them. Preferably, automate your test by unit/integration tests.
* [x] Make sure that all your commits are signed-off and that you are added to the [Contributors](https://github.com/secureCodeBox/secureCodeBox/blob/main/CONTRIBUTORS.md) file.
* [ ] Make sure that all CI finish successfully.
* [x] Optional (but appreciated): Make sure that all commits are [Verified](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits).
