### PR TITLE
Exclude demo targets in renovate-bot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -107,8 +107,8 @@ updates:
     directories: 
       - "/auto-discovery/kubernetes"
       - "/auto-discovery/cloud-aws"
-      - "/operator/go.mod"
-      - "/lurker/go.mod"
+      - "/operator"
+      - "/lurker"
     schedule:
       interval: "weekly"
     groups:

--- a/renovate.json
+++ b/renovate.json
@@ -5,5 +5,19 @@
     "group:recommended",
     ":disableDependencyDashboard"
   ],
-  "enabledManagers": ["dockerfile"]
+  "enabledManagers": ["dockerfile", "docker-compose"],
+
+  "ignorePaths": [
+    "demo-targets/bodgeit/**",
+    "demo-targets/dummy-ssh/**",
+    "demo-targets/http-webhook/**",
+    "demo-targets/old-typo3/**",
+    "demo-targets/old-joomla/**",
+    "demo-targets/old-wordpress/**",
+    "demo-targets/swagger-petstore/**",
+    "demo-targets/unsafe-https/**",
+    "demo-targets/vulnerable-log4j/**"
+  ]
 }
+
+


### PR DESCRIPTION
## Description
Since we want to intentionally keep the demo-target at older versions, they are to be excluded from the renovate config. We have decided to keep the juice-shop in renovate as it is a vulnerable app. 

### Checklist

* [ ] Test your changes as thoroughly as possible before you commit them. Preferably, automate your test by unit/integration tests.
* [ ] Make sure that all your commits are signed-off and that you are added to the [Contributors](https://github.com/secureCodeBox/secureCodeBox/blob/main/CONTRIBUTORS.md) file.
* [ ] Make sure that all CI finish successfully.
* [ ] Optional (but appreciated): Make sure that all commits are [Verified](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits).
