### PR TITLE
Optimize Go Docker builds with native cross-compilation

### DIFF
--- a/auto-discovery/cloud-aws/Dockerfile
+++ b/auto-discovery/cloud-aws/Dockerfile
@@ -19,7 +19,7 @@ COPY pkg/ pkg/
 
 # Build
 ARG TARGETOS TARGETARCH
-RUN GOOS=$TARGETOS GOARCH=$TARGETARCH CGO_ENABLED=0 go build -a -o service cmd/service/main.go
+RUN GOOS="$TARGETOS" GOARCH="$TARGETARCH" CGO_ENABLED=0 go build -a -o service cmd/service/main.go
 
 # Use distroless as minimal base image to package the service binary
 # Refer to https://github.com/GoogleContainerTools/distroless for more details

--- a/auto-discovery/cloud-aws/Dockerfile
+++ b/auto-discovery/cloud-aws/Dockerfile
@@ -3,7 +3,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 # Build the service binary
-FROM golang:1.24.6 AS builder
+FROM --platform=$BUILDPLATFORM golang:1.24.6 AS builder
 
 WORKDIR /workspace
 # Copy the Go Modules manifests
@@ -18,7 +18,8 @@ COPY cmd/ cmd/
 COPY pkg/ pkg/
 
 # Build
-RUN CGO_ENABLED=0 go build -a -o service cmd/service/main.go
+ARG TARGETOS TARGETARCH
+RUN GOOS=$TARGETOS GOARCH=$TARGETARCH CGO_ENABLED=0 go build -a -o service cmd/service/main.go
 
 # Use distroless as minimal base image to package the service binary
 # Refer to https://github.com/GoogleContainerTools/distroless for more details

--- a/auto-discovery/kubernetes/Dockerfile
+++ b/auto-discovery/kubernetes/Dockerfile
@@ -3,7 +3,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 # Build the manager binary
-FROM golang:1.24.6 AS builder
+FROM --platform=$BUILDPLATFORM golang:1.24.6 AS builder
 
 WORKDIR /workspace
 # Copy the Go Modules manifests
@@ -19,7 +19,8 @@ COPY controllers/ controllers/
 COPY pkg/ pkg/
 
 # Build
-RUN CGO_ENABLED=0 go build -a -o manager main.go
+ARG TARGETOS TARGETARCH
+RUN GOOS=$TARGETOS GOARCH=$TARGETARCH CGO_ENABLED=0 go build -a -o manager main.go
 
 # Use distroless as minimal base image to package the manager binary
 # Refer to https://github.com/GoogleContainerTools/distroless for more details

--- a/auto-discovery/kubernetes/Dockerfile
+++ b/auto-discovery/kubernetes/Dockerfile
@@ -20,7 +20,7 @@ COPY pkg/ pkg/
 
 # Build
 ARG TARGETOS TARGETARCH
-RUN GOOS=$TARGETOS GOARCH=$TARGETARCH CGO_ENABLED=0 go build -a -o manager main.go
+RUN GOOS="$TARGETOS" GOARCH="$TARGETARCH" CGO_ENABLED=0 go build -a -o manager main.go
 
 # Use distroless as minimal base image to package the manager binary
 # Refer to https://github.com/GoogleContainerTools/distroless for more details

--- a/lurker/Dockerfile
+++ b/lurker/Dockerfile
@@ -18,7 +18,7 @@ COPY main.go main.go
 
 # Build
 ARG TARGETOS TARGETARCH
-RUN GOOS=$TARGETOS GOARCH=$TARGETARCH CGO_ENABLED=0 go build -a -o lurker main.go
+RUN GOOS="$TARGETOS" GOARCH="$TARGETARCH" CGO_ENABLED=0 go build -a -o lurker main.go
 
 # Use distroless as minimal base image to package the manager binary
 # Refer to https://github.com/GoogleContainerTools/distroless for more details

--- a/lurker/Dockerfile
+++ b/lurker/Dockerfile
@@ -3,7 +3,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 # Build the manager binary
-FROM golang:1.24.6 AS builder
+FROM --platform=$BUILDPLATFORM golang:1.24.6 AS builder
 
 WORKDIR /workspace
 # Copy the Go Modules manifests
@@ -17,7 +17,8 @@ RUN go mod download
 COPY main.go main.go
 
 # Build
-RUN CGO_ENABLED=0 go build -a -o lurker main.go
+ARG TARGETOS TARGETARCH
+RUN GOOS=$TARGETOS GOARCH=$TARGETARCH CGO_ENABLED=0 go build -a -o lurker main.go
 
 # Use distroless as minimal base image to package the manager binary
 # Refer to https://github.com/GoogleContainerTools/distroless for more details

--- a/operator/Dockerfile
+++ b/operator/Dockerfile
@@ -22,7 +22,7 @@ COPY utils/ utils/
 
 # Build
 ARG TARGETOS TARGETARCH
-RUN GOOS=$TARGETOS GOARCH=$TARGETARCH CGO_ENABLED=0 go build -a -o manager main.go
+RUN GOOS="$TARGETOS" GOARCH="$TARGETARCH" CGO_ENABLED=0 go build -a -o manager main.go
 
 # Use distroless as minimal base image to package the manager binary
 # Refer to https://github.com/GoogleContainerTools/distroless for more details

--- a/operator/Dockerfile
+++ b/operator/Dockerfile
@@ -3,7 +3,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 # Build the manager binary
-FROM golang:1.24.6 AS builder
+FROM --platform=$BUILDPLATFORM golang:1.24.6 AS builder
 
 WORKDIR /workspace
 # Copy the Go Modules manifests
@@ -21,7 +21,8 @@ COPY internal/ internal/
 COPY utils/ utils/
 
 # Build
-RUN CGO_ENABLED=0 go build -a -o manager main.go
+ARG TARGETOS TARGETARCH
+RUN GOOS=$TARGETOS GOARCH=$TARGETARCH CGO_ENABLED=0 go build -a -o manager main.go
 
 # Use distroless as minimal base image to package the manager binary
 # Refer to https://github.com/GoogleContainerTools/distroless for more details

--- a/scanners/ffuf/scanner/Dockerfile
+++ b/scanners/ffuf/scanner/Dockerfile
@@ -4,7 +4,7 @@
 
 FROM --platform=$BUILDPLATFORM golang:1.24-alpine AS builder
 ARG scannerVersion
-RUN GOOS=$TARGETOS GOARCH=$TARGETARCH CGO_ENABLED=0 go install github.com/ffuf/ffuf/v2@$scannerVersion
+RUN GOOS="$TARGETOS" GOARCH="$TARGETARCH" CGO_ENABLED=0 go install github.com/ffuf/ffuf/v2@$scannerVersion
 
 RUN mkdir -p /home/ffuf/.config/ffuf
 RUN mkdir -p /home/ffuf/.config/ffuf/scraper


### PR DESCRIPTION
## Description

Replace multi-arch emulation with native Go cross-compilation for faster builds:
- Add --platform=$BUILDPLATFORM to builder stage
- Use TARGETOS/TARGETARCH build args for Go cross-compilation
- Apply GOOS/GOARCH environment variables in build command

Affected components:
- operator: Updated manager build process
- lurker: Updated lurker build process
- auto-discovery/kubernetes: Updated manager build process
- auto-discovery/cloud-aws: Updated service build process

This eliminates slow emulation overhead while maintaining multi-arch support.

Done becuase the prod builds are really slow, like 15-20min, this should safe a bit of CPU time and overhead :)

### Checklist

* [x] Test your changes as thoroughly as possible before you commit them. Preferably, automate your test by unit/integration tests.
* [x] Make sure that all your commits are signed-off and that you are added to the [Contributors](https://github.com/secureCodeBox/secureCodeBox/blob/main/CONTRIBUTORS.md) file.
* [ ] Make sure that all CI finish successfully.
* [x] Optional (but appreciated): Make sure that all commits are [Verified](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits).
