### PR TITLE
Migrate scan kubernetes finalizers to avoid warnings about non-recommended finalizer url structure

### DIFF
--- a/operator/controllers/execution/scans/scan_reconciler.go
+++ b/operator/controllers/execution/scans/scan_reconciler.go
@@ -41,9 +41,25 @@ func (r *ScanReconciler) startScan(scan *executionv1.Scan) error {
 		return nil
 	}
 
-	// Add s3 storage finalizer to scan
+	// Add s3 storage finalizer to scan (and migrate legacy finalizer if needed)
+	updated := false
+	
+	// Migrate legacy finalizer for active scans
+	if containsString(scan.ObjectMeta.Finalizers, s3StorageFinalizerLegacy) && !containsString(scan.ObjectMeta.Finalizers, s3StorageFinalizer) {
+		log.Info("Migrating legacy finalizer for active scan", "legacy", s3StorageFinalizerLegacy, "current", s3StorageFinalizer)
+		scan.ObjectMeta.Finalizers = removeString(scan.ObjectMeta.Finalizers, s3StorageFinalizerLegacy)
+		scan.ObjectMeta.Finalizers = append(scan.ObjectMeta.Finalizers, s3StorageFinalizer)
+		updated = true
+	}
+	
+	// Add s3 storage finalizer if it doesn't exist
 	if !containsString(scan.ObjectMeta.Finalizers, s3StorageFinalizer) {
 		scan.ObjectMeta.Finalizers = append(scan.ObjectMeta.Finalizers, s3StorageFinalizer)
+		updated = true
+	}
+	
+	// Update scan if finalizers were modified
+	if updated {
 		if err := r.Update(context.Background(), scan); err != nil {
 			return err
 		}

--- a/operator/controllers/execution/scans/scan_reconciler_test.go
+++ b/operator/controllers/execution/scans/scan_reconciler_test.go
@@ -19,6 +19,162 @@ import (
 var namespace = "test-namespace"
 var reconciler = &ScanReconciler{}
 var _ = Describe("ScanControllers", func() {
+	Context("Finalizer Migration", func() {
+		var scan *executionv1.Scan
+		
+		BeforeEach(func() {
+			scan = &executionv1.Scan{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: namespace,
+					Name:      "test-scan",
+					Finalizers: []string{},
+				},
+				Spec: executionv1.ScanSpec{
+					ScanType:   "nmap",
+					Parameters: []string{"example.com"},
+				},
+				Status: executionv1.ScanStatus{
+					RawResultFile: "raw-results.json",
+				},
+			}
+		})
+
+		It("should handle legacy finalizer migration logic", func() {
+			// Set up scan with legacy finalizer
+			scan.ObjectMeta.Finalizers = []string{s3StorageFinalizerLegacy, "other-finalizer"}
+			
+			// Test that legacy finalizer is present initially
+			Expect(containsString(scan.ObjectMeta.Finalizers, s3StorageFinalizerLegacy)).To(BeTrue())
+			
+			// Test that it would be detected for migration (without actually running migration
+			// which requires MinioClient setup)
+			hasLegacy := containsString(scan.ObjectMeta.Finalizers, s3StorageFinalizerLegacy)
+			Expect(hasLegacy).To(BeTrue())
+			
+			// Simulate the migration logic manually (what migrateFinalizer would do)
+			if hasLegacy {
+				scan.ObjectMeta.Finalizers = removeString(scan.ObjectMeta.Finalizers, s3StorageFinalizerLegacy)
+			}
+			
+			// After migration, legacy finalizer should be removed
+			Expect(containsString(scan.ObjectMeta.Finalizers, s3StorageFinalizerLegacy)).To(BeFalse())
+			// Other finalizers should remain
+			Expect(containsString(scan.ObjectMeta.Finalizers, "other-finalizer")).To(BeTrue())
+		})
+
+		It("should not migrate when legacy finalizer is not present", func() {
+			// Set up scan without legacy finalizer
+			scan.ObjectMeta.Finalizers = []string{s3StorageFinalizer}
+			
+			mockReconciler := &ScanReconciler{}
+			err := mockReconciler.migrateFinalizer(scan)
+			
+			// Should return nil (no migration needed)
+			Expect(err).To(BeNil())
+			// Should still have the new finalizer
+			Expect(containsString(scan.ObjectMeta.Finalizers, s3StorageFinalizer)).To(BeTrue())
+		})
+
+		It("should not migrate when no finalizers are present", func() {
+			// Set up scan without any finalizers
+			scan.ObjectMeta.Finalizers = []string{}
+			
+			// Test detection logic (no migration needed)
+			hasLegacy := containsString(scan.ObjectMeta.Finalizers, s3StorageFinalizerLegacy)
+			Expect(hasLegacy).To(BeFalse())
+			
+			// Should have no finalizers
+			Expect(len(scan.ObjectMeta.Finalizers)).To(Equal(0))
+		})
+		
+		It("should handle active scan migration from legacy finalizer", func() {
+			// Set up scan with legacy finalizer (simulating existing scan)
+			scan.ObjectMeta.Finalizers = []string{s3StorageFinalizerLegacy}
+			
+			// Simulate the active scan migration logic from startScan function
+			updated := false
+			
+			// Check if migration is needed
+			if containsString(scan.ObjectMeta.Finalizers, s3StorageFinalizerLegacy) && !containsString(scan.ObjectMeta.Finalizers, s3StorageFinalizer) {
+				scan.ObjectMeta.Finalizers = removeString(scan.ObjectMeta.Finalizers, s3StorageFinalizerLegacy)
+				scan.ObjectMeta.Finalizers = append(scan.ObjectMeta.Finalizers, s3StorageFinalizer)
+				updated = true
+			}
+			
+			// Verify migration occurred
+			Expect(updated).To(BeTrue())
+			Expect(containsString(scan.ObjectMeta.Finalizers, s3StorageFinalizerLegacy)).To(BeFalse())
+			Expect(containsString(scan.ObjectMeta.Finalizers, s3StorageFinalizer)).To(BeTrue())
+		})
+		
+		It("should not migrate active scan when current finalizer already exists", func() {
+			// Set up scan with both finalizers (edge case)
+			scan.ObjectMeta.Finalizers = []string{s3StorageFinalizerLegacy, s3StorageFinalizer}
+			
+			// Simulate the active scan migration logic
+			updated := false
+			
+			// Check migration condition (should not migrate if current finalizer exists)
+			if containsString(scan.ObjectMeta.Finalizers, s3StorageFinalizerLegacy) && !containsString(scan.ObjectMeta.Finalizers, s3StorageFinalizer) {
+				// This block should not execute
+				updated = true
+			}
+			
+			// Verify no migration occurred
+			Expect(updated).To(BeFalse())
+			Expect(containsString(scan.ObjectMeta.Finalizers, s3StorageFinalizerLegacy)).To(BeTrue())
+			Expect(containsString(scan.ObjectMeta.Finalizers, s3StorageFinalizer)).To(BeTrue())
+		})
+		
+		It("should add s3 storage finalizer to scan without any finalizers", func() {
+			// Set up scan without finalizers
+			scan.ObjectMeta.Finalizers = []string{}
+			
+			// Simulate adding s3 storage finalizer
+			updated := false
+			
+			if !containsString(scan.ObjectMeta.Finalizers, s3StorageFinalizer) {
+				scan.ObjectMeta.Finalizers = append(scan.ObjectMeta.Finalizers, s3StorageFinalizer)
+				updated = true
+			}
+			
+			// Verify finalizer was added
+			Expect(updated).To(BeTrue())
+			Expect(containsString(scan.ObjectMeta.Finalizers, s3StorageFinalizer)).To(BeTrue())
+			Expect(len(scan.ObjectMeta.Finalizers)).To(Equal(1))
+		})
+	})
+
+	Context("Helper Functions", func() {
+		It("should correctly identify when string contains finalizer", func() {
+			finalizers := []string{"other-finalizer", s3StorageFinalizer, "another-finalizer"}
+			Expect(containsString(finalizers, s3StorageFinalizer)).To(BeTrue())
+			Expect(containsString(finalizers, s3StorageFinalizerLegacy)).To(BeFalse())
+			Expect(containsString(finalizers, "non-existent")).To(BeFalse())
+		})
+
+		It("should correctly remove string from slice", func() {
+			originalSlice := []string{"first", s3StorageFinalizerLegacy, "last"}
+			result := removeString(originalSlice, s3StorageFinalizerLegacy)
+			
+			Expect(len(result)).To(Equal(2))
+			Expect(result).To(Equal([]string{"first", "last"}))
+			Expect(containsString(result, s3StorageFinalizerLegacy)).To(BeFalse())
+		})
+
+		It("should handle removing non-existent string", func() {
+			originalSlice := []string{"first", "second", "third"}
+			result := removeString(originalSlice, "non-existent")
+			
+			Expect(len(result)).To(Equal(3))
+			Expect(result).To(Equal(originalSlice))
+		})
+
+		It("should handle empty slice", func() {
+			result := removeString([]string{}, "any-string")
+			Expect(len(result)).To(Equal(0))
+		})
+	})
 	Context("checkIfTTLSecondsAfterFinishedIsCompleted", func() {
 		It("should return true if TTLSecondsAfterFinished is set", func() {
 			finishTime := time.Date(


### PR DESCRIPTION
## Description


We've been getting this warning logged in the operator for a while now:

```txt
{"level":"info","ts":"2025-08-20T19:00:44Z","msg":"metadata.finalizers:
\"s3.storage.securecodebox.io\": prefer a domain-qualified finalizer
name including a path (/) to avoid accidental conflicts with other
finalizer writers"}
```

This should resolve this.

Related migration code removal ticket #3225

### Checklist

* [x] Test your changes as thoroughly as possible before you commit them. Preferably, automate your test by unit/integration tests.
* [x] Make sure that all your commits are signed-off and that you are added to the [Contributors](https://github.com/secureCodeBox/secureCodeBox/blob/main/CONTRIBUTORS.md) file.
* [ ] Make sure that all CI finish successfully.
* [x] Optional (but appreciated): Make sure that all commits are [Verified](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits).
