### PR TITLE
Update supported k8s versions to include new Kubernetes 1.34 release.

### DIFF
--- a/documentation/docs/getting-started/installation.md
+++ b/documentation/docs/getting-started/installation.md
@@ -24,7 +24,7 @@ You're now ready to install your [first scan types and start your first scans](/
 
 ## Supported Kubernetes Version
 
-The secureCodeBox supports the 4 latest Kubernetes releases (`v1.33`, `v1.32`, `v1.31` & `v1.30`). Older versions might also work but are not officially supported or tested.
+The secureCodeBox supports the 4 latest Kubernetes releases (`v1.34`, `v1.33`, `v1.32` & `v1.31`). Older versions might also work but are not officially supported or tested.
 
 ## Accessing the included MinIO Instance
 


### PR DESCRIPTION
## Description

K8s 1.34 is out. Updating supported version matrix.
CI is already running with k8s 1.34.

### Checklist

* [x] Test your changes as thoroughly as possible before you commit them. Preferably, automate your test by unit/integration tests.
* [x] Make sure that all your commits are signed-off and that you are added to the [Contributors](https://github.com/secureCodeBox/secureCodeBox/blob/main/CONTRIBUTORS.md) file.
* [ ] Make sure that all CI finish successfully.
* [x] Optional (but appreciated): Make sure that all commits are [Verified](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits).
