### PR TITLE
Dependabot/gradle/hooks/persistence defectdojo/hook/gradle version updates 27032e4d85

### DIFF
--- a/hooks/persistence-defectdojo/hook/build.gradle
+++ b/hooks/persistence-defectdojo/hook/build.gradle
@@ -25,10 +25,12 @@ dependencies {
   implementation group: "io.securecodebox", name: "defectdojo-client", version: "2.0.1"
   implementation group: "io.kubernetes", name: "client-java", version: "20.0.1"
   implementation group: "org.springframework", name: "spring-web", version: "6.2.11"
-  implementation group: "com.fasterxml.jackson.core", name: "jackson-core", version: "2.20.0"
-  implementation group: "com.fasterxml.jackson.core", name: "jackson-annotations", version: "2.20.0"
-  implementation group: "com.fasterxml.jackson.core", name: "jackson-databind", version: "2.20.0"
-  implementation group: "com.fasterxml.jackson.datatype", name: "jackson-datatype-jsr310", version: "2.20.0"
+  // https://github.com/FasterXML/jackson-bom
+  implementation platform("com.fasterxml.jackson:jackson-bom:2.20.0")
+  implementation "com.fasterxml.jackson.core:jackson-core"
+  implementation "com.fasterxml.jackson.core:jackson-annotations"
+  implementation "com.fasterxml.jackson.core:jackson-databind"
+  implementation "com.fasterxml.jackson.datatype:jackson-datatype-jsr310"
   implementation group: "org.slf4j", name: "slf4j-api", version: "2.0.17"
   implementation group: "org.slf4j", name: "slf4j-log4j12", version: "2.0.17"
   // If I try to notate this like the others (with separate strings) I got errors. No idea why sh... Gradle

--- a/hooks/persistence-defectdojo/hook/build.gradle
+++ b/hooks/persistence-defectdojo/hook/build.gradle
@@ -24,11 +24,11 @@ repositories {
 dependencies {
   implementation group: "io.securecodebox", name: "defectdojo-client", version: "2.0.1"
   implementation group: "io.kubernetes", name: "client-java", version: "20.0.1"
-  implementation group: "org.springframework", name: "spring-web", version: "6.2.10"
-  implementation group: "com.fasterxml.jackson.core", name: "jackson-core", version: "2.19.2"
-  implementation group: "com.fasterxml.jackson.core", name: "jackson-annotations", version: "2.19.2"
-  implementation group: "com.fasterxml.jackson.core", name: "jackson-databind", version: "2.19.2"
-  implementation group: "com.fasterxml.jackson.datatype", name: "jackson-datatype-jsr310", version: "2.19.2"
+  implementation group: "org.springframework", name: "spring-web", version: "6.2.11"
+  implementation group: "com.fasterxml.jackson.core", name: "jackson-core", version: "2.20.0"
+  implementation group: "com.fasterxml.jackson.core", name: "jackson-annotations", version: "2.20.0"
+  implementation group: "com.fasterxml.jackson.core", name: "jackson-databind", version: "2.20.0"
+  implementation group: "com.fasterxml.jackson.datatype", name: "jackson-datatype-jsr310", version: "2.20.0"
   implementation group: "org.slf4j", name: "slf4j-api", version: "2.0.17"
   implementation group: "org.slf4j", name: "slf4j-log4j12", version: "2.0.17"
   // If I try to notate this like the others (with separate strings) I got errors. No idea why sh... Gradle


### PR DESCRIPTION
For unknown reason the dependency `jackson-annotations` could not be found. Anyway, since Jackson provides a BOM dependency, this is preferable because this ensures consistent versions over all Jackson modules.