### PR TITLE
Added affinity and tolerations fields to ssh-audit-scan-type.yaml

### DIFF
--- a/scanners/ssh-audit/templates/ssh-audit-scan-type.yaml
+++ b/scanners/ssh-audit/templates/ssh-audit-scan-type.yaml
@@ -19,7 +19,17 @@ spec:
       backoffLimit: {{ .Values.scanner.backoffLimit }}
       template:
         spec:
-          restartPolicy: Never
+          restartPolicy: OnFailure
+          affinity:
+            {{- toYaml .Values.scanner.affinity | nindent 12 }}
+          tolerations: 
+            {{- toYaml .Values.scanner.tolerations | nindent 12 }}
+          {{- with .Values.imagePullSecrets }}
+          imagePullSecrets:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          securityContext:
+            {{- toYaml .Values.scanner.podSecurityContext | nindent 12 }}
           containers:
             - name: ssh-audit
               image: "{{ .Values.scanner.image.repository }}:{{ .Values.scanner.image.tag | default .Chart.AppVersion }}"


### PR DESCRIPTION
## Description
#3295 This fix adds fields for affinity rules and tolerations to the template ssh-audit-scan-type.yaml.

