### PR TITLE
Fix Defectdojo Hook

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -59,6 +59,7 @@ updates:
     ignore:
       - dependency-name: "io.kubernetes:client-java:*-legacy"
       - dependency-name: "io.securecodebox:defectdojo-client:3.0.0"
+      - dependency-name: "org.springframework:spring-web"
     groups:
       gradle-security-updates:
         applies-to: security-updates

--- a/hooks/persistence-defectdojo/hook/build.gradle
+++ b/hooks/persistence-defectdojo/hook/build.gradle
@@ -24,7 +24,9 @@ repositories {
 dependencies {
   implementation group: "io.securecodebox", name: "defectdojo-client", version: "2.0.1"
   implementation group: "io.kubernetes", name: "client-java", version: "20.0.1"
-  implementation group: "org.springframework", name: "spring-web", version: "7.0.1"
+   // will not be updated to 7.0.0 because it no longer implements a class
+   // so it causes issues with the version in the defectdojo client
+  implementation group: "org.springframework", name: "spring-web", version: "6.2.12"
   // https://github.com/FasterXML/jackson-bom
   implementation platform("com.fasterxml.jackson:jackson-bom:2.20.1")
   implementation "com.fasterxml.jackson.core:jackson-core"


### PR DESCRIPTION
## Description
fixes the issues caused by https://github.com/secureCodeBox/secureCodeBox/pull/3390 
Spring-web v7 causes issues because it removed the MultiValueMap in [since 7.0](https://docs.spring.io/spring-framework/docs/current/javadoc-api/org/springframework/http/HttpHeaders.html).
The dependency is set back to the previous version and ignored by the dependabot.

Fixes #3414 

### Checklist

* [ ] Test your changes as thoroughly as possible before you commit them. Preferably, automate your test by unit/integration tests.
* [ ] Make sure that all your commits are signed-off and that you are added to the [Contributors](https://github.com/secureCodeBox/secureCodeBox/blob/main/CONTRIBUTORS.md) file.
* [ ] Make sure that all CI finish successfully.
* [ ] Optional (but appreciated): Make sure that all commits are [Verified](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits).
