### PR TITLE
Fix cascading-hooks labels

### DIFF
--- a/hooks/cascading-scans/templates/cascading-scans-hook.yaml
+++ b/hooks/cascading-scans/templates/cascading-scans-hook.yaml
@@ -10,7 +10,7 @@ metadata:
     {{- include "cascading-scans.labels" . | nindent 4 }}
     securecodebox.io/internal: "true"
     {{- with .Values.hook.labels }}
-    {{ toYaml . }}
+    {{ toYaml . | nindent 4 }}
     {{- end }}
 spec:
   priority: {{ .Values.hook.priority }}


### PR DESCRIPTION
When supplying multiple labels for the cascading scans hook, we end up with an indention error.

Values:

```yaml
hook:
  labels:
    app: securecodebox
    hooks: cascading
```

Result:

```yaml
apiVersion: "execution.securecodebox.io/v1"
kind: ScanCompletionHook
metadata:
  name: release-name-cascading-scans
  labels:
    helm.sh/chart: cascading-scans-5.6.0
    app.kubernetes.io/name: cascading-scans
    app.kubernetes.io/instance: release-name
    app.kubernetes.io/managed-by: Helm
    securecodebox.io/internal: "true"
    app: securecodebox
hooks: cascading
spec:
  priority: 100
  type: ReadOnly
  ```
  
  As you can see, the `hooks: cascading` label is not indented.
  
This PR fixes labels indentation