### PR TITLE
operator: make minio endpoint cluster domain configurable

### DIFF
--- a/operator/README.md
+++ b/operator/README.md
@@ -70,6 +70,7 @@ helm install securecodebox-operator oci://ghcr.io/securecodebox/helm/operator
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
 | allowIstioSidecarInjectionInJobs | bool | `false` | Sets the value of the istio sidecar annotation ("sidecar.istio.io/inject") for jobs started by the operator (scans, parser and hooks). defaults to false to prevent jobs hanging indefinitely due to the sidecar never terminating. If you aren't using istio this setting/annotation has no effect. |
+| clusterDomain | string | `"cluster.local"` | The cluster domain to use when building the in-cluster Minio endpoint (`<release>-minio.<namespace>.svc.<clusterDomain>`). Override this if your cluster uses a custom domain instead of the Kubernetes default `cluster.local`. |
 | customCACertificate | object | `{"certificate":"public.crt","existingCertificate":null}` | Setup for Custom CA certificates. These are automatically mounted into every secureCodeBox component (lurker, parser & hooks). Requires that every namespace has a configmap with the CA certificate(s) |
 | customCACertificate.certificate | string | `"public.crt"` | key in the configmap holding the certificate(s) |
 | customCACertificate.existingCertificate | string | `nil` | name of the configMap holding the ca certificate(s), needs to be the same across all namespaces |

--- a/operator/templates/manager/manager.yaml
+++ b/operator/templates/manager/manager.yaml
@@ -75,7 +75,7 @@ spec:
             - name: S3_USE_SSL
               value: "{{ .Values.minio.tls.enabled }}"
             - name: S3_ENDPOINT
-              value: "{{ .Release.Name }}-minio.{{ .Release.Namespace }}.svc.cluster.local"
+              value: "{{ .Release.Name }}-minio.{{ .Release.Namespace }}.svc.{{ .Values.clusterDomain }}"
             - name: S3_PORT
               value: '9000'
             - name:  MINIO_ACCESS_KEY

--- a/operator/tests/operator_test.yaml
+++ b/operator/tests/operator_test.yaml
@@ -91,6 +91,20 @@ tests:
       - equal:
           path: spec.template.spec.containers[0].env[?(@.name=="S3_ENDPOINT")].value
           value: "RELEASE-NAME-minio.NAMESPACE.svc.cluster.local"
+  - it: allows overriding the cluster domain used for the minio endpoint
+    templates:
+      - manager/manager.yaml
+    chart:
+      version: 0.0.0
+      appVersion: 0.0.0
+    set:
+      minio:
+        enabled: true
+      clusterDomain: custom.local
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].env[?(@.name=="S3_ENDPOINT")].value
+          value: "RELEASE-NAME-minio.NAMESPACE.svc.custom.local"
   - it: configures manager deployment for external s3
     templates:
       - manager/manager.yaml

--- a/operator/values.yaml
+++ b/operator/values.yaml
@@ -9,6 +9,9 @@
 # telemetryEnabled -- The Operator sends anonymous telemetry data, to give the team an overview how much the secureCodeBox is used. Find out more at https://www.securecodebox.io/telemetry
 telemetryEnabled: true
 
+# -- The cluster domain to use when building the in-cluster Minio endpoint (`<release>-minio.<namespace>.svc.<clusterDomain>`). Override this if your cluster uses a custom domain instead of the Kubernetes default `cluster.local`.
+clusterDomain: cluster.local
+
 # -- Define imagePullSecrets when a private registry is used (see: https://kubernetes.io/docs/tasks/configure-pod-container/pull-image-private-registry/)
 imagePullSecrets: []
 


### PR DESCRIPTION
Fixes #2895

## Problem

The operator's Helm chart hardcodes `.svc.cluster.local` when building the in-cluster Minio endpoint:

```
operator/templates/manager/manager.yaml:78
value: "{{ .Release.Name }}-minio.{{ .Release.Namespace }}.svc.cluster.local"
```

On clusters configured with a non-default cluster domain (e.g. kubelet started with `--cluster-domain=mycorp.internal`), this hostname doesn't resolve, and the operator can't reach its own bundled Minio.

## Fix

Adds a `clusterDomain` value to `operator/values.yaml`, defaulting to `cluster.local` (no change to existing behavior), and uses it in the endpoint template instead of the hardcoded literal.

## Note on prior attempt

I saw that #2921 previously tried to address this issue and was closed — that PR referenced a nonexistent image and changed the Minio image tag/version instead of actually touching the hardcoded endpoint, so it didn't fix the reported problem. This PR only touches the `clusterDomain` value and the one template line that builds the endpoint string; it doesn't change the Minio image, tag, or any chart dependency.

## Testing

- Added a `helm-unittest` case (`allows overriding the cluster domain used for the minio endpoint`) asserting `S3_ENDPOINT` reflects a custom `clusterDomain`.
- Confirmed the existing `configures manager deployment for minio` test still passes with the default value (`cluster.local`), preserving backward compatibility — and verified it actually catches a regression by temporarily breaking the default and re-running.
- Rendered the chart directly with `helm template` both with and without `--set clusterDomain=...` to confirm the output is correct in both cases:
  ```
  $ helm template operator --set clusterDomain=mycorp.internal --show-only templates/manager/manager.yaml | grep S3_ENDPOINT
  value: "release-name-minio.default.svc.mycorp.internal"

  $ helm template operator --show-only templates/manager/manager.yaml | grep S3_ENDPOINT
  value: "release-name-minio.default.svc.cluster.local"
  ```
- Updated `operator/README.md`'s generated values table with the new `clusterDomain` entry.

I wasn't able to verify this against a live cluster with a custom cluster domain, but the chart-level behavior (default preserved, override applied) is covered by the test above.