### PR TITLE
Add retries for the raw result upload from the lurker sidecar

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -210,7 +210,7 @@ jobs:
           go vet ./...
 
       - name: Test
-        working-directory: ./operator
+        working-directory: ./${{ matrix.component }}
         run: task test
 
       - name: Build Container Image

--- a/lurker/.gitignore
+++ b/lurker/.gitignore
@@ -3,3 +3,8 @@
 # SPDX-License-Identifier: Apache-2.0
 
 main
+lurker
+bin
+
+# Output of the go coverage tool
+*.out

--- a/lurker/Taskfile.yaml
+++ b/lurker/Taskfile.yaml
@@ -1,0 +1,38 @@
+# SPDX-FileCopyrightText: the secureCodeBox authors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+version: "3.48.0"
+
+tasks:
+  fmt:
+    desc: "Run go fmt against code"
+    dir: '{{ .TASKFILE_DIR }}'
+    cmds:
+      - go fmt ./...
+
+  vet:
+    desc: "Run go vet against code"
+    dir: '{{ .TASKFILE_DIR }}'
+    cmds:
+      - go vet ./...
+
+  test:
+    desc: "Run all tests"
+    deps: [fmt, vet]
+    dir: '{{ .TASKFILE_DIR }}'
+    cmds:
+      - go test ./... -coverprofile cover.out
+
+  view-coverage:
+    desc: "View test coverage in browser"
+    dir: '{{ .TASKFILE_DIR }}'
+    cmds:
+      - go tool cover -html=cover.out
+
+  build:
+    desc: "Build the lurker binary"
+    deps: [fmt, vet]
+    dir: '{{ .TASKFILE_DIR }}'
+    cmds:
+      - go build -o bin/lurker main.go

--- a/lurker/main.go
+++ b/lurker/main.go
@@ -8,6 +8,7 @@ import (
 	"context"
 	"flag"
 	"fmt"
+	"io"
 	"log"
 	"net/http"
 	"net/http/httputil"
@@ -55,11 +56,42 @@ func main() {
 
 	log.Printf("Uploading result files.")
 	log.Printf("Uploading %s", filePath)
-	err = uploadFile(filePath, uploadURL)
+	err = uploadFileWithRetries(filePath, uploadURL)
 	if err != nil {
 		log.Fatal(err)
 	}
 	log.Printf("Uploaded file successfully")
+}
+
+// delays waited before each retry of a failed upload. The number of entries
+// defines how often the upload is retried after the initial attempt.
+var uploadBackoffs = []time.Duration{1 * time.Second, 3 * time.Second, 5 * time.Second, 10 * time.Second, 30 * time.Second}
+
+// indirection to allow tests to run without actually waiting
+var sleep = time.Sleep
+
+// uploadFileWithRetries uploads the file and retries every failure (transport
+// errors as well as non 2xx responses) using the uploadBackoffs schedule.
+func uploadFileWithRetries(path, url string) error {
+	attempts := len(uploadBackoffs) + 1
+
+	var err error
+	for attempt := 1; attempt <= attempts; attempt++ {
+		err = uploadFile(path, url)
+		if err == nil {
+			return nil
+		}
+
+		if attempt == attempts {
+			break
+		}
+
+		backoff := uploadBackoffs[attempt-1]
+		log.Printf("Upload attempt %d of %d failed: %v. Retrying in %s", attempt, attempts, err, backoff)
+		sleep(backoff)
+	}
+
+	return fmt.Errorf("lurker failed to upload scan result file after %d attempts: %w", attempts, err)
 }
 
 func uploadFile(path, url string) error {
@@ -81,7 +113,7 @@ func uploadFile(path, url string) error {
 	// Create a new file upload request
 	req, err := http.NewRequest("PUT", url, file)
 	if err != nil {
-		log.Fatalf("Failed to create request: %v", err)
+		log.Printf("Failed to create request: %v", err)
 		return err
 	}
 
@@ -109,13 +141,15 @@ func uploadFile(path, url string) error {
 	log.Printf("File upload returned non 2xx status code (%d)", res.StatusCode)
 
 	// Dump response for debugging purposes
-	resultBytes, err := httputil.DumpResponse(res, true)
-	if err != nil {
-		log.Fatal(fmt.Errorf("failed to dump out failed requests to upload scan report to the s3 bucket: %w", err))
+	resultBytes, dumpErr := httputil.DumpResponse(res, true)
+	if dumpErr != nil {
+		log.Printf("failed to dump out failed requests to upload scan report to the s3 bucket: %v", dumpErr)
+		// drain the body so that the connection can be reused by the next attempt
+		io.Copy(io.Discard, res.Body)
+	} else {
+		log.Println("Response of Failed Request:")
+		log.Println(string(resultBytes))
 	}
-
-	log.Println("Response of Failed Request:")
-	log.Println(string(resultBytes))
 
 	return fmt.Errorf("lurker failed to upload scan result file. File upload returned non 2xx status code (%d)", res.StatusCode)
 }

--- a/lurker/main.go
+++ b/lurker/main.go
@@ -6,10 +6,12 @@ package main
 
 import (
 	"context"
+	"errors"
 	"flag"
 	"fmt"
 	"io"
 	"log"
+	"net"
 	"net/http"
 	"net/http/httputil"
 	"net/url"
@@ -17,7 +19,7 @@ import (
 	"time"
 
 	corev1 "k8s.io/api/core/v1"
-	errors "k8s.io/apimachinery/pkg/api/errors"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/rest"
@@ -70,19 +72,20 @@ var uploadBackoffs = []time.Duration{1 * time.Second, 3 * time.Second, 5 * time.
 // indirection to allow tests to run without actually waiting
 var sleep = time.Sleep
 
-// uploadFileWithRetries uploads the file and retries every failure (transport
-// errors as well as non 2xx responses) using the uploadBackoffs schedule.
+// uploadFileWithRetries uploads the file and retries network failures using the
+// uploadBackoffs schedule.
 func uploadFileWithRetries(path, url string) error {
 	attempts := len(uploadBackoffs) + 1
 
 	var err error
 	for attempt := 1; attempt <= attempts; attempt++ {
-		err = uploadFile(path, url)
+		var retryable bool
+		err, retryable = uploadFile(path, url)
 		if err == nil {
 			return nil
 		}
 
-		if attempt == attempts {
+		if !retryable || attempt == attempts {
 			break
 		}
 
@@ -94,18 +97,18 @@ func uploadFileWithRetries(path, url string) error {
 	return fmt.Errorf("lurker failed to upload scan result file after %d attempts: %w", attempts, err)
 }
 
-func uploadFile(path, url string) error {
+func uploadFile(path, url string) (error, bool) {
 	file, err := os.Open(path)
 	if err != nil {
 		log.Printf("Failed to open file: %v", err)
-		return err
+		return err, false
 	}
 	defer file.Close()
 
 	fileInfo, err := file.Stat()
 	if err != nil {
 		log.Printf("Failed to get file stats: %v", err)
-		return err
+		return err, false
 	}
 	size := fileInfo.Size()
 	log.Printf("Scan result file has a size of %d bytes", size)
@@ -114,7 +117,7 @@ func uploadFile(path, url string) error {
 	req, err := http.NewRequest("PUT", url, file)
 	if err != nil {
 		log.Printf("Failed to create request: %v", err)
-		return err
+		return err, false
 	}
 
 	req.ContentLength = size
@@ -128,14 +131,15 @@ func uploadFile(path, url string) error {
 
 	res, err := client.Do(req)
 	if err != nil {
-		return err
+		var networkErr net.Error
+		return err, errors.As(err, &networkErr)
 	}
 	defer res.Body.Close()
 
 	// Check the response status code
 	if res.StatusCode >= 200 && res.StatusCode < 300 {
 		// all good
-		return nil
+		return nil, false
 	}
 
 	log.Printf("File upload returned non 2xx status code (%d)", res.StatusCode)
@@ -151,7 +155,7 @@ func uploadFile(path, url string) error {
 		log.Println(string(resultBytes))
 	}
 
-	return fmt.Errorf("lurker failed to upload scan result file. File upload returned non 2xx status code (%d)", res.StatusCode)
+	return fmt.Errorf("lurker failed to upload scan result file. File upload returned non 2xx status code (%d)", res.StatusCode), false
 }
 
 func waitForMainContainerToEnd(container, pod, namespace string) {
@@ -174,9 +178,9 @@ func waitForMainContainerToEnd(container, pod, namespace string) {
 
 func keepWaitingForMainContainerToExit(context context.Context, container string, podName string, namespace string, clientset *kubernetes.Clientset) bool {
 	pod, err := clientset.CoreV1().Pods(namespace).Get(context, podName, metav1.GetOptions{})
-	if errors.IsNotFound(err) {
+	if apierrors.IsNotFound(err) {
 		log.Printf("Pod %s not found in namespace %s", pod, namespace)
-	} else if statusError, isStatus := err.(*errors.StatusError); isStatus {
+	} else if statusError, isStatus := err.(*apierrors.StatusError); isStatus {
 		log.Printf("Error getting pod %v", statusError.ErrStatus.Message)
 	} else if err != nil {
 		panic(err.Error())

--- a/lurker/main.go
+++ b/lurker/main.go
@@ -13,7 +13,6 @@ import (
 	"log"
 	"net"
 	"net/http"
-	"net/http/httputil"
 	"net/url"
 	"os"
 	"time"
@@ -142,17 +141,11 @@ func uploadFile(path, url string) (error, bool) {
 		return nil, false
 	}
 
-	log.Printf("File upload returned non 2xx status code (%d)", res.StatusCode)
-
-	// Dump response for debugging purposes
-	resultBytes, dumpErr := httputil.DumpResponse(res, true)
-	if dumpErr != nil {
-		log.Printf("failed to dump out failed requests to upload scan report to the s3 bucket: %v", dumpErr)
-		// drain the body so that the connection can be reused by the next attempt
-		io.Copy(io.Discard, res.Body)
+	resultBytes, readErr := io.ReadAll(res.Body)
+	if readErr != nil {
+		log.Printf("File upload returned status code %d; failed to read response body: %v", res.StatusCode, readErr)
 	} else {
-		log.Println("Response of Failed Request:")
-		log.Println(string(resultBytes))
+		log.Printf("File upload returned status code %d with response body: %s", res.StatusCode, resultBytes)
 	}
 
 	return fmt.Errorf("lurker failed to upload scan result file. File upload returned non 2xx status code (%d)", res.StatusCode), false

--- a/lurker/main_test.go
+++ b/lurker/main_test.go
@@ -1,0 +1,162 @@
+// SPDX-FileCopyrightText: the secureCodeBox authors
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package main
+
+import (
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+const testFileContents = `{"findings": []}`
+
+// writeResultFile creates a temporary scan result file and returns its path.
+func writeResultFile(t *testing.T) string {
+	t.Helper()
+
+	path := filepath.Join(t.TempDir(), "findings.json")
+	if err := os.WriteFile(path, []byte(testFileContents), 0o600); err != nil {
+		t.Fatalf("failed to write test file: %v", err)
+	}
+	return path
+}
+
+// stubSleep replaces the backoff sleep with a recorder, so that tests don't
+// have to actually wait. Returns a pointer to the recorded delays.
+func stubSleep(t *testing.T) *[]time.Duration {
+	t.Helper()
+
+	original := sleep
+	delays := []time.Duration{}
+	sleep = func(d time.Duration) {
+		delays = append(delays, d)
+	}
+	t.Cleanup(func() { sleep = original })
+
+	return &delays
+}
+
+func TestUploadFileWithRetriesSucceedsOnFirstAttempt(t *testing.T) {
+	delays := stubSleep(t)
+
+	requests := 0
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requests++
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer server.Close()
+
+	if err := uploadFileWithRetries(writeResultFile(t), server.URL); err != nil {
+		t.Fatalf("expected upload to succeed, got: %v", err)
+	}
+	if requests != 1 {
+		t.Errorf("expected 1 request, got %d", requests)
+	}
+	if len(*delays) != 0 {
+		t.Errorf("expected no backoff, got %v", *delays)
+	}
+}
+
+func TestUploadFileWithRetriesRetriesUntilSuccess(t *testing.T) {
+	delays := stubSleep(t)
+
+	requests := 0
+	receivedBodies := []string{}
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requests++
+		body, err := io.ReadAll(r.Body)
+		if err != nil {
+			t.Errorf("failed to read request body: %v", err)
+		}
+		receivedBodies = append(receivedBodies, string(body))
+
+		if requests < 3 {
+			w.WriteHeader(http.StatusInternalServerError)
+			return
+		}
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer server.Close()
+
+	if err := uploadFileWithRetries(writeResultFile(t), server.URL); err != nil {
+		t.Fatalf("expected upload to succeed after retries, got: %v", err)
+	}
+	if requests != 3 {
+		t.Errorf("expected 3 requests, got %d", requests)
+	}
+
+	// every attempt, especially the last one, has to send the complete file
+	for attempt, body := range receivedBodies {
+		if body != testFileContents {
+			t.Errorf("attempt %d uploaded %q, expected %q", attempt+1, body, testFileContents)
+		}
+	}
+
+	expectedDelays := uploadBackoffs[:2]
+	if len(*delays) != len(expectedDelays) {
+		t.Fatalf("expected %d backoffs, got %v", len(expectedDelays), *delays)
+	}
+	for i, delay := range *delays {
+		if delay != expectedDelays[i] {
+			t.Errorf("backoff %d was %s, expected %s", i+1, delay, expectedDelays[i])
+		}
+	}
+}
+
+func TestUploadFileWithRetriesGivesUpAfterAllAttempts(t *testing.T) {
+	delays := stubSleep(t)
+
+	requests := 0
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requests++
+		w.WriteHeader(http.StatusInternalServerError)
+	}))
+	defer server.Close()
+
+	if err := uploadFileWithRetries(writeResultFile(t), server.URL); err == nil {
+		t.Fatal("expected upload to fail")
+	}
+
+	expectedRequests := len(uploadBackoffs) + 1
+	if requests != expectedRequests {
+		t.Errorf("expected %d requests, got %d", expectedRequests, requests)
+	}
+	if len(*delays) != len(uploadBackoffs) {
+		t.Errorf("expected %d backoffs, got %v", len(uploadBackoffs), *delays)
+	}
+	for i, delay := range *delays {
+		if delay != uploadBackoffs[i] {
+			t.Errorf("backoff %d was %s, expected %s", i+1, delay, uploadBackoffs[i])
+		}
+	}
+}
+
+func TestUploadFileWithRetriesRetriesTransportErrors(t *testing.T) {
+	delays := stubSleep(t)
+
+	// closing the server up front makes every attempt fail on the transport level
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {}))
+	url := server.URL
+	server.Close()
+
+	if err := uploadFileWithRetries(writeResultFile(t), url); err == nil {
+		t.Fatal("expected upload to fail")
+	}
+	if len(*delays) != len(uploadBackoffs) {
+		t.Errorf("expected %d backoffs, got %v", len(uploadBackoffs), *delays)
+	}
+}
+
+func TestUploadFileWithRetriesFailsForMissingFile(t *testing.T) {
+	stubSleep(t)
+
+	if err := uploadFileWithRetries(filepath.Join(t.TempDir(), "does-not-exist.json"), "http://127.0.0.1:1"); err == nil {
+		t.Fatal("expected upload of a missing file to fail")
+	}
+}

--- a/lurker/main_test.go
+++ b/lurker/main_test.go
@@ -63,7 +63,7 @@ func TestUploadFileWithRetriesSucceedsOnFirstAttempt(t *testing.T) {
 	}
 }
 
-func TestUploadFileWithRetriesRetriesUntilSuccess(t *testing.T) {
+func TestUploadFileWithRetriesDoesNotRetryHTTPFailures(t *testing.T) {
 	delays := stubSleep(t)
 
 	requests := 0
@@ -76,19 +76,15 @@ func TestUploadFileWithRetriesRetriesUntilSuccess(t *testing.T) {
 		}
 		receivedBodies = append(receivedBodies, string(body))
 
-		if requests < 3 {
-			w.WriteHeader(http.StatusInternalServerError)
-			return
-		}
-		w.WriteHeader(http.StatusOK)
+		w.WriteHeader(http.StatusInternalServerError)
 	}))
 	defer server.Close()
 
-	if err := uploadFileWithRetries(writeResultFile(t), server.URL); err != nil {
-		t.Fatalf("expected upload to succeed after retries, got: %v", err)
+	if err := uploadFileWithRetries(writeResultFile(t), server.URL); err == nil {
+		t.Fatal("expected upload to fail")
 	}
-	if requests != 3 {
-		t.Errorf("expected 3 requests, got %d", requests)
+	if requests != 1 {
+		t.Errorf("expected 1 request, got %d", requests)
 	}
 
 	// every attempt, especially the last one, has to send the complete file
@@ -98,42 +94,8 @@ func TestUploadFileWithRetriesRetriesUntilSuccess(t *testing.T) {
 		}
 	}
 
-	expectedDelays := uploadBackoffs[:2]
-	if len(*delays) != len(expectedDelays) {
-		t.Fatalf("expected %d backoffs, got %v", len(expectedDelays), *delays)
-	}
-	for i, delay := range *delays {
-		if delay != expectedDelays[i] {
-			t.Errorf("backoff %d was %s, expected %s", i+1, delay, expectedDelays[i])
-		}
-	}
-}
-
-func TestUploadFileWithRetriesGivesUpAfterAllAttempts(t *testing.T) {
-	delays := stubSleep(t)
-
-	requests := 0
-	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		requests++
-		w.WriteHeader(http.StatusInternalServerError)
-	}))
-	defer server.Close()
-
-	if err := uploadFileWithRetries(writeResultFile(t), server.URL); err == nil {
-		t.Fatal("expected upload to fail")
-	}
-
-	expectedRequests := len(uploadBackoffs) + 1
-	if requests != expectedRequests {
-		t.Errorf("expected %d requests, got %d", expectedRequests, requests)
-	}
-	if len(*delays) != len(uploadBackoffs) {
-		t.Errorf("expected %d backoffs, got %v", len(uploadBackoffs), *delays)
-	}
-	for i, delay := range *delays {
-		if delay != uploadBackoffs[i] {
-			t.Errorf("backoff %d was %s, expected %s", i+1, delay, uploadBackoffs[i])
-		}
+	if len(*delays) != 0 {
+		t.Errorf("expected no backoff, got %v", *delays)
 	}
 }
 
@@ -154,9 +116,12 @@ func TestUploadFileWithRetriesRetriesTransportErrors(t *testing.T) {
 }
 
 func TestUploadFileWithRetriesFailsForMissingFile(t *testing.T) {
-	stubSleep(t)
+	delays := stubSleep(t)
 
 	if err := uploadFileWithRetries(filepath.Join(t.TempDir(), "does-not-exist.json"), "http://127.0.0.1:1"); err == nil {
 		t.Fatal("expected upload of a missing file to fail")
+	}
+	if len(*delays) != 0 {
+		t.Errorf("expected no backoff, got %v", *delays)
 	}
 }


### PR DESCRIPTION
## Description

When upload fails it can be painful to retry the entire scan just rerun the file upload.

### Checklist

* [x] Test your changes as thoroughly as possible before you commit them. Preferably, automate your test by unit/integration tests.
* [x] Make sure that all your commits are signed-off and that you are added to the [Contributors](https://github.com/secureCodeBox/secureCodeBox/blob/main/CONTRIBUTORS.md) file.
* [ ] Make sure that all CI finish successfully.
* [x] Optional (but appreciated): Make sure that all commits are [Verified](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits).
