### PR TITLE
fix: Prevent parser startup before scanner job is visible

### DIFF
--- a/operator/controllers/execution/scans/job.go
+++ b/operator/controllers/execution/scans/job.go
@@ -26,6 +26,10 @@ const (
 
 // checkIfAllJobsCompleted returns `completed` if all jobs of the given jobList are in a successful state, incompleted otherwise.
 func checkIfAllJobsCompleted(jobs *batch.JobList) jobCompletionType {
+	if len(jobs.Items) == 0 {
+		return incomplete
+	}
+
 	hasCompleted := true
 
 	for _, job := range jobs.Items {

--- a/operator/controllers/execution/scans/job_test.go
+++ b/operator/controllers/execution/scans/job_test.go
@@ -22,6 +22,12 @@ func TestScanControllers(t *testing.T) {
 
 var _ = Describe("ScanControllers", func() {
 	Context("checkIfAllJobsCompleted", func() {
+		It("should return incomplete if no jobs were found", func() {
+			jobs := &batch.JobList{}
+
+			Expect(checkIfAllJobsCompleted(jobs)).To(Equal(incomplete))
+		})
+
 		It("should return completed if all jobs succeeded", func() {
 			jobs := &batch.JobList{
 				Items: []batch.Job{
@@ -61,6 +67,11 @@ var _ = Describe("ScanControllers", func() {
 		It("should return failed if any job exceeded backoff limit", func() {
 			jobs := &batch.JobList{
 				Items: []batch.Job{
+					{
+						Status: batch.JobStatus{
+							Succeeded: 1,
+						},
+					},
 					{
 						Status: batch.JobStatus{
 							Failed: 1,


### PR DESCRIPTION
## Description

Change `checkIfAllJobsCompleted` so that a list containing no Jobs is explicitly incomplete; completion must require at least one observed Job and successful status for every observed Job. Keep the existing precedence in which any `BackoffLimitExceeded` Job reports failure and any non-succeeded Job reports incomplete, so all three production callers—the scanner, parser, and hook reconciliation paths—remain conservative during cache-observation gaps. Extend the existing table of focused helper tests with the empty-list case, while retaining coverage for all-succeeded, mixed/incomplete, and failed lists.

The scan reconciler decides whether scanner, parser, and hook Jobs have finished through `checkIfAllJobsCompleted`. That helper initializes its aggregate result as completed, so an empty Job list is interpreted as successful even though no Job has reported success. During the short interval in which the controller cache has not yet observed a newly created scanner Job, this can advance the Scan to `ScanCompleted` and start the parser before the scanner uploads its raw result, producing an intermittent MinIO `NoSuchKey` error. The maintainer reproduced the rare behavior and identified this helper as the relevant decision point.

Closes #3139

### Checklist

* [ ] Test your changes as thoroughly as possible before you commit them. Preferably, automate your test by unit/integration tests.
* [ ] Make sure that all your commits are signed-off and that you are added to the [Contributors](https://github.com/secureCodeBox/secureCodeBox/blob/main/CONTRIBUTORS.md) file.
* [ ] Make sure that all CI finish successfully.
* [ ] Optional (but appreciated): Make sure that all commits are [Verified](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits).
