### PR TITLE
Fix golang renovate dependency updates

### DIFF
--- a/auto-discovery/kubernetes/go.mod
+++ b/auto-discovery/kubernetes/go.mod
@@ -16,7 +16,6 @@ require (
 	k8s.io/apimachinery v0.37.0
 	k8s.io/client-go v0.37.0
 	k8s.io/klog/v2 v2.140.0
-	k8s.io/utils v0.0.0-20260626114624-be93311217bd
 	sigs.k8s.io/controller-runtime v0.25.0
 	sigs.k8s.io/yaml v1.6.0
 )
@@ -84,6 +83,7 @@ require (
 	gopkg.in/tomb.v1 v1.0.0-20141024135613-dd632973f1e7 // indirect
 	k8s.io/apiextensions-apiserver v0.37.0 // indirect
 	k8s.io/kube-openapi v0.0.0-20260721132016-d427ff9ee9ad // indirect
+	k8s.io/utils v0.0.0-20260626114624-be93311217bd // indirect
 	sigs.k8s.io/json v0.0.0-20250730193827-2d320260d730 // indirect
 	sigs.k8s.io/randfill v1.0.0 // indirect
 	sigs.k8s.io/structured-merge-diff/v6 v6.4.2 // indirect

--- a/auto-discovery/kubernetes/pkg/util/checkScanConfig.go
+++ b/auto-discovery/kubernetes/pkg/util/checkScanConfig.go
@@ -7,14 +7,15 @@ package util
 import (
 	"errors"
 	"fmt"
+	"slices"
 
 	config "github.com/secureCodeBox/secureCodeBox/auto-discovery/kubernetes/pkg/config"
-	"k8s.io/utils/strings/slices"
 )
 
 func CheckUniquenessOfScanNames(scanConfigs []config.ScanConfig) error {
 	var namesSeen []string
 	for _, config := range scanConfigs {
+
 		if slices.Contains(namesSeen, config.Name) {
 			return errors.New(fmt.Sprintf("Scan names %s are not unique!", config.Name))
 		}

--- a/renovate.json
+++ b/renovate.json
@@ -11,10 +11,16 @@
 
   "packageRules": [
     {
+      "description": "Only update Go version directives, not module dependencies",
+      "matchManagers": ["gomod"],
+      "enabled": false
+    },
+    {
       "description": "Keep minimum Go versions in go.mod current",
       "matchManagers": ["gomod"],
       "matchDepNames": ["go"],
       "matchDepTypes": ["golang"],
+      "enabled": true,
       "rangeStrategy": "bump"
     }
   ],


### PR DESCRIPTION
## Description

I've configured renovate to bump the golang version in the go.mod files.
The config wasn't properly working and was also bumping other golang deps (we intentionally kept this with dependabot for now) If we keep it enabled we'll get conflicting versions bumps from booth tools.

So this PR should disable the golang package update via renovate for us to stick with dependabot

While looking at the renovate PRs i've noticed that we still pull in a kubernetes utils packages thats only used for a slice contains call, quickly removed it & switched to the std lib.

### Checklist

* [x] Test your changes as thoroughly as possible before you commit them. Preferably, automate your test by unit/integration tests.
* [x] Make sure that all your commits are signed-off and that you are added to the [Contributors](https://github.com/secureCodeBox/secureCodeBox/blob/main/CONTRIBUTORS.md) file.
* [ ] Make sure that all CI finish successfully.
* [x] Optional (but appreciated): Make sure that all commits are [Verified](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits).
